### PR TITLE
feat: implement single-instance locking, custom album mapping, and UI taskbar actions, user specified album name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ build/
 AI_CONTEXT.md
 convert_icon.py
 filesystem_tree.txt
+project_tree.md

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This application monitors local directories (e.g., `~/Pictures`, `~/Videos`) for
 - **File Monitoring**: Uses `inotify` to detect new files.
 - **Concurrent Uploads**: Uses multiple threads (10 workers) to process uploads.
 - **Connectivity**: Automatically switches between **Internal (LAN)** and **External (WAN)** URLs based on availability.
-- **Album Management**: Creates albums on the server based on the local folder name (e.g., `~/Pictures/Vacation 2024` -> Album "Vacation 2024").
+- **Custom Album Mapping**: Select an existing remote Immich album, type a custom album name to create, or let the app automatically create albums based on the local folder name (e.g., `~/Pictures/Vacation 2024` -> Album "Vacation 2024").
 - **One-Way Sync**: Uploads media without modifying local files.
 - **Security**: Stores the API Key in the system keyring (libsecret/KWallet).
 - **Desktop Integration**:

--- a/build_test_appimage.sh
+++ b/build_test_appimage.sh
@@ -37,6 +37,11 @@ Type=Application
 Categories=Utility;Network;
 Comment=Automatic background sync for Immich
 Terminal=false
+Actions=Settings;
+
+[Desktop Action Settings]
+Name=Open Settings
+Exec=immich-sync --settings
 EOF
 cp AppDir/com.nickcardoso.immich_sync.desktop AppDir/usr/share/applications/com.nickcardoso.immich_sync.desktop
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,7 +64,7 @@ Encapsulates communication with the Immich Server.
 
 - **Dual-URL Support**: Checks logical connectivity to Internal (LAN) URL first, falling back to External (WAN) URL.
 - **Asset Upload**: Handles `multipart/form-data` uploads.
-- **Album Management**: Checks if a target album exists (based on folder name) and creates it if missing.
+- **Album Management**: Uploads are mapped to a configured `album_id`, a custom `album_name`, or dynamically matches the immediate parent folder name. The system queries the `ApiClient` to resolve or create the missing album dynamically over REST.
 
 ### 5. Settings UI (`src/settings_window.py`)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -42,7 +42,7 @@ If you didn't configure the application on the first run, right-click the tray i
 1. Under **Watch Folders**, click **+ Add Folder**.
 2. Select a local directory (e.g., `~/Pictures`, `~/Videos/Exports`).
 3. The application will monitor these folders recursively (including all sub-folders).
-4. *Smart Albums Feature*: If you drop files into `~/Pictures/Vacation`, the app will automatically create an album in Immich named "Vacation" and add the photos to it!
+4. *Smart Album Selection*: By default, if you drop files into `~/Pictures/Vacation`, the app will automatically create an album in Immich named "Vacation". You can also map specific watch folders directly to existing Immich albums by selecting them from the dropdown menu, or type a custom new album name to be created automatically.
 
 ---
 

--- a/install-appimage.sh
+++ b/install-appimage.sh
@@ -42,7 +42,7 @@ gtk-update-icon-cache "$HOME/.local/share/icons/hicolor" 2>/dev/null || true
 echo "Creating desktop entry..."
 cat > "$USER_APPS/$APP_NAME.desktop" <<DESKTOP
 [Desktop Entry]
-Name=Immich Sync
+Name=Immich Auto-Sync
 Comment=Automatic background sync for Immich
 Exec=$TARGET_APPIMAGE
 Icon=$APP_NAME
@@ -50,7 +50,12 @@ Terminal=false
 Type=Application
 Categories=Utility;Network;
 StartupNotify=false
-StartupWMClass=immich-sync
+StartupWMClass=immich-sync.desktop
+Actions=Settings;
+
+[Desktop Action Settings]
+Name=Open Settings
+Exec=$TARGET_APPIMAGE --settings
 DESKTOP
 chmod +x "$USER_APPS/$APP_NAME.desktop"
 

--- a/setup/immich-sync.desktop
+++ b/setup/immich-sync.desktop
@@ -11,3 +11,8 @@ X-GNOME-Autostart-enabled=true
 StartupNotify=false
 # Matches the window class set in src/settings_main.py
 StartupWMClass=immich-sync.desktop
+Actions=Settings;
+
+[Desktop Action Settings]
+Name=Open Settings
+Exec=/path/to/python3 /path/to/immich-sync/src/main.py --settings

--- a/src/api_client.py
+++ b/src/api_client.py
@@ -162,6 +162,20 @@ class ImmichApiClient:
             logging.error(f"Network Error during upload: {e}")
             return None
 
+    def get_albums(self):
+        """
+        Returns a list of dictionaries with 'id' and 'albumName' 
+        for UI presentation.
+        """
+        if not self.albums_fetched:
+            self._fetch_all_albums()
+            
+        if not self.active_url or not self.albums_fetched:
+             return []
+             
+        # Return directly from cache, recreating the map structure for UI
+        return [{"id": v, "albumName": k} for k, v in self.album_cache.items()]
+
     def _fetch_all_albums(self):
         """
         Fetches all owned albums.

--- a/src/config.py
+++ b/src/config.py
@@ -67,4 +67,12 @@ class Config:
     
     @property
     def watch_paths(self):
-        return self.data.get("watch_paths", [])
+        paths = self.data.get("watch_paths", [])
+        # Normalise to list of dicts if they are just strings (backwards compatibility)
+        normalized = []
+        for p in paths:
+            if isinstance(p, str):
+                normalized.append({"path": p, "album_id": None, "album_name": ""})
+            elif isinstance(p, dict):
+                normalized.append(p)
+        return normalized

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,8 @@ import sys
 import os
 import logging
 import signal
+import socket
+import subprocess
 
 from log_setup import setup_logging
 setup_logging()
@@ -16,11 +18,40 @@ os.environ["GDK_BACKEND"] = "x11"
 from monitor import Monitor
 from config import Config
 
+def check_single_instance_or_run_settings(args):
+    """
+    Ensures only one daemon runs. If another is already running, it forwards
+    any relevant commands (like opening settings).
+    """
+    lock_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        lock_socket.bind('\0immich-sync-daemon-lock')
+        
+        # If we got the lock, and they specifically ONLY asked for settings,
+        # we can just launch settings_main.py and keep daemon running if we want,
+        # but normally if they ask for settings and daemon isn't running, we just run daemon
+        # and open settings.
+        if args.settings:
+            script_path = os.path.join(os.path.dirname(__file__), "settings_main.py")
+            subprocess.Popen([sys.executable, script_path])
+        return lock_socket
+    except socket.error:
+        logging.info("Immich Auto-Sync daemon is already running.")
+        # If daemon is running and user clicked launcher, open settings.
+        script_path = os.path.join(os.path.dirname(__file__), "settings_main.py")
+        print("Daemon is already running. Opening settings window instead.")
+        proc = subprocess.Popen([sys.executable, script_path])
+        proc.wait() # Block until the settings window closes or forwards its request
+        sys.exit(0)
+
 def main():
     parser = argparse.ArgumentParser(description="Immich Sync - Linux Background Daemon")
     parser.add_argument("path", nargs="?", help="Override watch path (optional)", default=None)
     parser.add_argument("--no-tray", action="store_true", help="Run in terminal mode without system tray")
+    parser.add_argument("--settings", action="store_true", help="Launch settings window directly")
     args = parser.parse_args()
+
+    _lock = check_single_instance_or_run_settings(args)
 
     # Load configuration
     config = Config()

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -20,8 +20,10 @@ class ImmichEventHandler(FileSystemEventHandler):
     Only processes files with allowed extensions and ignores others (like .xmp sidecars).
     """
 
-    def __init__(self, queue_manager):
+    def __init__(self, queue_manager, path_config=None):
         self.queue_manager = queue_manager
+        # Mapping mapping from tracked base path -> config dict (e.g. {'album_id': '...', 'album_name': '...'})
+        self.path_config = path_config or {}
         # Limit concurrent file checks to avoid thread explosion on bulk copy
         self.executor = ThreadPoolExecutor(max_workers=5, thread_name_prefix="FileScanner")
     
@@ -39,9 +41,16 @@ class ImmichEventHandler(FileSystemEventHandler):
 
         logging.info(f"New file change detected: {file_path}")
         # Offload checks to a thread pool to avoid blocking the observer or spawning unlimited threads
-        self.executor.submit(self._process_file, file_path)
+        # find corresponding configured path
+        matched_config = None
+        for base_path, conf in self.path_config.items():
+            if file_path.startswith(base_path):
+                matched_config = conf
+                break
+                
+        self.executor.submit(self._process_file, file_path, matched_config)
 
-    def _process_file(self, file_path):
+    def _process_file(self, file_path, path_config=None):
         if self.wait_for_file_completion(file_path):
             checksum = calculate_checksum(file_path)
             if checksum:
@@ -49,7 +58,8 @@ class ImmichEventHandler(FileSystemEventHandler):
                 # Add to upload queue
                 task = {
                     'path': file_path,
-                    'checksum': checksum
+                    'checksum': checksum,
+                    'config': path_config
                 }
                 self.queue_manager.add_to_queue(task)
             else:
@@ -98,9 +108,17 @@ class Monitor:
     def start(self, blocking=True):
         self.queue_manager.start()
 
-        event_handler = ImmichEventHandler(self.queue_manager) # Pass queue manager
+        path_config_map = {}
+        for p in self.paths_to_watch:
+             if isinstance(p, dict):
+                 path_config_map[p["path"]] = p
+             else:
+                 path_config_map[p] = {"path": p}
+
+        event_handler = ImmichEventHandler(self.queue_manager, path_config_map)
         
-        for path in self.paths_to_watch:
+        for p in self.paths_to_watch:
+            path = p["path"] if isinstance(p, dict) else p
             if not os.path.exists(path):
                 logging.error(f"Error: The directory {path} does not exist. Skipping.")
                 continue

--- a/src/queue_manager.py
+++ b/src/queue_manager.py
@@ -171,17 +171,22 @@ class QueueManager:
             logging.info(f"Asset already exists on server: {file_path}")
             return True
 
-        # 2. Determine Album Name
-        # Use parent folder name relative to watch path root would be ideal, 
-        # but for now just immediate parent directory name is simple and effective.
-        parent_dir = os.path.basename(os.path.dirname(file_path))
-        album_name = parent_dir
+        # 2. Determine Album Name and ID
+        config = file_info.get('config', {})
+        album_id = config.get('album_id')
+        album_name = config.get('album_name')
         
-        logging.info(f"Preparing to add '{file_path}' to album '{album_name}'")
+        # Determine fallback name if no explicit config provided
+        if not album_id and (not album_name or album_name == "Default (Folder Name)"):
+            parent_dir = os.path.basename(os.path.dirname(file_path))
+            album_name = parent_dir
+            
+        logging.info(f"Preparing to add '{file_path}' to album '{album_name}' (ID: {album_id})")
         
         try:
-            # 3. Get or Create Album
-            album_id = self.api_client.get_or_create_album(album_name)
+            # 3. Get or Create Album if ID isn't known
+            if not album_id:
+                album_id = self.api_client.get_or_create_album(album_name)
             
             if album_id:
                 # 4. Add to Album

--- a/src/settings_main.py
+++ b/src/settings_main.py
@@ -6,6 +6,7 @@ setup_logging()
 
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import Qt
+from PySide6.QtNetwork import QLocalServer, QLocalSocket
 from settings_window import SettingsWindow
 
 def main():
@@ -22,9 +23,44 @@ def main():
 
     app = QApplication(sys.argv)
     
-    # Run the window
+    SERVER_NAME = "immich-sync-settings-ipc-v1"
+    
+    # Try connecting to existing instance
+    socket = QLocalSocket()
+    socket.connectToServer(SERVER_NAME)
+    if socket.waitForConnected(500):
+        logging.info("Settings window is already running. Forwarding request and exiting.")
+        msg = "about" if "--about" in sys.argv else "show"
+        socket.write(msg.encode('utf-8'))
+        socket.waitForBytesWritten()
+        socket.disconnectFromServer()
+        sys.exit(0)
+
+    # We are the single instance, so run the server
+    QLocalServer.removeServer(SERVER_NAME)
+    server = QLocalServer()
+    server.listen(SERVER_NAME)
+
     window = SettingsWindow()
     window.show()
+
+    def handle_new_connection():
+        client = server.nextPendingConnection()
+        if client:
+            client.waitForReadyRead(500)
+            msg = client.readAll().data().decode('utf-8')
+            
+            # Bring window to front
+            window.setWindowState(window.windowState() & ~Qt.WindowState.WindowMinimized | Qt.WindowState.WindowActive)
+            window.raise_()
+            window.activateWindow()
+            
+            if msg == "about":
+                window.show_about_dialog()
+            
+            client.disconnectFromServer()
+
+    server.newConnection.connect(handle_new_connection)
 
     if "--about" in sys.argv:
         window.show_about_dialog()

--- a/src/settings_window.py
+++ b/src/settings_window.py
@@ -1,7 +1,8 @@
 import sys
 import os
 import logging
-from PySide6.QtWidgets import (QApplication, QWidget, QVBoxLayout, QHBoxLayout, 
+from PySide6.QtWidgets import (
+    QTableWidget, QTableWidgetItem, QHeaderView, QComboBox,QApplication, QWidget, QVBoxLayout, QHBoxLayout, 
                                QLabel, QLineEdit, QPushButton, QListWidget, 
                                QListWidgetItem, QMessageBox, QFileDialog, QFormLayout, QProgressBar, QTextEdit, QDialog)
 from PySide6.QtGui import QIcon
@@ -210,7 +211,12 @@ class SettingsWindow(QWidget):
         watch_header.setStyleSheet("font-size: 18px; font-weight: bold; color: #ffffff; margin-top: 10px; margin-bottom: 5px;")
         layout.addWidget(watch_header)
         
-        self.path_list = QListWidget()
+        self.path_list = QTableWidget(0, 2)
+        self.path_list.setHorizontalHeaderLabels(["Folder Path", "Target Immich Album"])
+        self.path_list.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        self.path_list.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeToContents)
+        self.path_list.setSelectionBehavior(QTableWidget.SelectRows)
+        self.path_list.setEditTriggers(QTableWidget.NoEditTriggers)
         layout.addWidget(self.path_list)
         
         path_btn_layout = QHBoxLayout()
@@ -257,6 +263,20 @@ class SettingsWindow(QWidget):
             "<p><a href='https://github.com/nicx17/immich_sync_app'>https://github.com/nicx17/immich_sync_app</a></p>")
 
 
+    def _fetch_remote_albums(self):
+        internal = self.config.internal_url
+        external = self.config.external_url
+        api_key = self.config.get_api_key()
+        if api_key and (internal or external):
+            client = ImmichApiClient(internal, external, api_key)
+            # Try to fetch without failing hard
+            try:
+                if client.check_connection():
+                    return client.get_albums()
+            except Exception:
+                pass
+        return []
+
     def _load_values(self):
         self.internal_url_input.setText(self.config.internal_url)
         self.external_url_input.setText(self.config.external_url)
@@ -265,22 +285,63 @@ class SettingsWindow(QWidget):
         if api_key:
             self.api_key_input.setText(api_key)
             
-        self.path_list.clear()
-        for path in self.config.watch_paths:
-            self.path_list.addItem(path)
+        # Try to fetch albums for the dropdown
+        self.remote_albums = self._fetch_remote_albums()
+            
+        self.path_list.setRowCount(0)
+        for p in self.config.watch_paths:
+            if isinstance(p, dict):
+                self._add_path_to_table(p["path"], p.get("album_id"), p.get("album_name"))
+            else:
+                self._add_path_to_table(p, None, None)
+
+    def _add_path_to_table(self, folder, current_album_id=None, current_album_name=None):
+        row = self.path_list.rowCount()
+        self.path_list.insertRow(row)
+        
+        path_item = QTableWidgetItem(folder)
+        self.path_list.setItem(row, 0, path_item)
+        
+        combo = QComboBox()
+        combo.setEditable(True)
+        combo.setInsertPolicy(QComboBox.NoInsert)
+        combo.setToolTip("Select an existing album, or type a new album name to create.")
+        
+        combo.addItem("Default (Folder Name)", userData=None)
+        
+        # Populate with remote albums
+        if hasattr(self, 'remote_albums') and self.remote_albums:
+            for album in self.remote_albums:
+                combo.addItem(album['albumName'], userData=album['id'])
+                
+        # Set selection if it exists
+        if current_album_id:
+            idx = combo.findData(current_album_id)
+            if idx >= 0:
+                combo.setCurrentIndex(idx)
+        elif current_album_name and current_album_name != "Default (Folder Name)":
+            # If there's no ID, but a custom name was typed, show it
+            combo.setCurrentText(current_album_name)
+        
+        self.path_list.setCellWidget(row, 1, combo)
 
     def add_path(self):
         folder = QFileDialog.getExistingDirectory(self, "Select Folder to Watch")
         if folder:
             # Check if already exists
-            items = [self.path_list.item(i).text() for i in range(self.path_list.count())]
+            items = []
+            for i in range(self.path_list.rowCount()):
+                item = self.path_list.item(i, 0)
+                if item:
+                    items.append(item.text())
+                    
             if folder not in items:
-                self.path_list.addItem(folder)
+                self._add_path_to_table(folder)
 
     def remove_path(self):
         current_row = self.path_list.currentRow()
         if current_row >= 0:
-            self.path_list.takeItem(current_row)
+            self.path_list.removeRow(current_row)
 
     def test_connection(self):
         internal = self.internal_url_input.text().strip()
@@ -332,8 +393,33 @@ class SettingsWindow(QWidget):
         
         # Collect paths
         paths = []
-        for i in range(self.path_list.count()):
-            paths.append(self.path_list.item(i).text())
+        for i in range(self.path_list.rowCount()):
+            path_item = self.path_list.item(i, 0)
+            if not path_item: continue
+            folder = path_item.text()
+            
+            combo = self.path_list.cellWidget(i, 1)
+            if combo:
+                album_name = combo.currentText().strip()
+                # Check if this exact text exists in the list to determine if it's custom
+                idx = combo.findText(album_name)
+                if idx >= 0:
+                    album_id = combo.itemData(idx)
+                else:
+                    album_id = None # Custom text implies a new uncreated album
+                
+                if not album_name:
+                    album_name = "Default (Folder Name)"
+            else:
+                album_name = "Default (Folder Name)"
+                album_id = None
+            
+            paths.append({
+                "path": folder,
+                "album_id": album_id,
+                "album_name": album_name
+            })
+            
         self.config.data["watch_paths"] = paths
         
         logging.info(f"Saving {len(paths)} watch paths: {paths}")


### PR DESCRIPTION
This commit introduces major architectural and UX improvements across the application:

* Architecture & IPC:
  - Established Unix Domain Sockets to enforce a strict single-instance headless daemon.
  - Implemented QLocalServer/QLocalSocket to pass UI launch requests to an existing window context instead of duplicating windows.
  - Fixed a critical AppImage process isolation bug by ensuring the main daemon awaits (`.wait()`) PySide6 subprocesses before terminating.

* UI & Album Configurations:
  - Adapted the `watch_paths` state to support dictionaries containing explicit `album_name` and `album_id` targets.
  - Rebuilt the settings path list using QTableWidget with embedded, editable QComboBox drop-downs.
  - ImmichApiClient now queries the server for existing remote albums to populate the settings UI.
  - Added support for custom album names on the fly: users can select an existing album, type a custom name to create later, or leave blank to rely on auto-folder fallback.

* Logging & Notifications:
  - Centralized detached application logging to `~/.config/immich-sync/app.log` via RotatingFileHandler.
  - Inserted a global `sys.excepthook` to capture silent AppImage UI crashes.
  - Suppressed the GNOME notification spam for single file uploads, prioritizing batch completion messages.

* CI/CD & Documentation:
  - Added the application logo and interface screenshots to README.md.
  - Updated USER_GUIDE.md and ARCHITECTURE.md to accurately outline the new custom album selection logic.
  - Implemented GitHub Actions for CodeQL static analysis (v4).
  - Cleaned up obsolete patch development scripts.