### PR TITLE
fix(ubuntu/core): UI graceful degradation, ABI crash fix, and thread locking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           
       - name: Install System Dependencies
         run: |
           # FUSE is needed to extract/run the AppImageTool on ubuntu runners
+          # We also pre-install build tools like libcairo since PyGObject will be installed natively
           sudo apt-get update
-          sudo apt-get install -y fuse file gir1.2-appindicator3-0.1 libgirepository1.0-dev libcairo2-dev python3-dbus || true
+          sudo apt-get install -y fuse file gir1.2-appindicator3-0.1 libgirepository1.0-dev libcairo2-dev pkg-config python3-dev || true
           
       - name: Run Build Script
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **File Move/Rename Support**: `ImmichEventHandler` now captures `on_moved` watchdog events. Temporary file downloads (e.g. `video.mp4.tmp` from web browsers, rsync, Syncthing) that later rename internally to a valid media extension are now successfully captured and pushed to the upload queue.
 
 ### Fixed
+- **Duplicate Album Creation Race Condition**: Implemented `threading.Lock()` on the `get_or_create_album` REST endpoint to ensure multiple simultaneous workers handling bulk image drops to new directories don't spawn multiple identical albums on the server if they bypass the cache at the same time.
+- **Ubuntu 24 Tray Icon Crash**: Added graceful try/except block wrapping around the `TrayIcon/pystray` initialization loop. On modern Desktop Environments (Ubuntu 24 Wayland / Mutter) that deny AppIndicator injection, the application no longer permanently fails. Instead it safely disables the visual tray while dropping seamlessly into a headless background daemon. Launching from the GUI menu with the tray disabled intelligently loads the Settings Window.
 - **Incomplete Video File Upload Bug (`wait_for_file_completion`)**: Prevented massive media files (like 30-minute GUI screencasts) from triggering early timeouts before they were fully written. Replaced absolute 10s wait logic with an adaptive 300-second *idle* timeout loop; continuously growing items dynamically rest the counter keeping uploads safe regardless of copy duration.
-- **Strict Directory Route Matching**: Replaced naive `.startswith()` Python logic in multi-folder checks directly to an explicit `os.path.commonpath()` hierarchical evaluation, preventing subfolders with similar names (e.g., `/home/pictures` and `/home/pictures_private`) from crossing trigger actions.
 
 
 ## [1.0.0] - 2026-03-06

--- a/build_test_appimage.sh
+++ b/build_test_appimage.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "Cleaning up old build artifacts..."
-rm -rf AppDir squashfs-root appimagetool-x86_64.AppImage Immich_Sync-x86_64.AppImage
+rm -rf AppDir squashfs-root appimagetool-x86_64.AppImage Immich_Sync-*.AppImage python-standalone.tar.gz
 
 echo "Downloading AppImageTool..."
 wget -q -c "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
@@ -10,7 +10,6 @@ chmod +x appimagetool-x86_64.AppImage
 
 echo "Creating AppDir structure..."
 mkdir -p AppDir/usr/bin
-mkdir -p AppDir/usr/lib/python3/site-packages
 mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
 mkdir -p AppDir/usr/share/metainfo
 mkdir -p AppDir/usr/share/applications
@@ -22,13 +21,20 @@ chmod +x AppDir/usr/bin/immich-sync
 
 cp src/assets/icon.png AppDir/immich-sync.png
 cp src/assets/icon.png AppDir/usr/share/icons/hicolor/256x256/apps/immich-sync.png
-cp setup/metainfo/com.nickcardoso.immich_sync.appdata.xml AppDir/usr/share/metainfo/com.nickcardoso.immich_sync.appdata.xml
+cp setup/metainfo/com.nickcardoso.immich_sync.appdata.xml AppDir/usr/share/metainfo/com.nickcardoso.immich_sync.appdata.xml 2>/dev/null || true
 
-echo "Installing dependencies..."
-pip install -r requirements.txt --target=AppDir/usr/lib/python3/site-packages
+echo "Downloading Standalone Portable Python (3.12)..."
+# We download a self-contained Python runtime so we never depend on the host OS Python version.
+wget -q -c "https://github.com/astral-sh/python-build-standalone/releases/download/20260303/cpython-3.12.13%2B20260303-x86_64-unknown-linux-gnu-install_only.tar.gz" -O python-standalone.tar.gz
+mkdir -p AppDir/usr/python
+tar -xzf python-standalone.tar.gz -C AppDir/usr/python --strip-components=1
+
+echo "Installing dependencies into the portable Python..."
+# We use the bundled python to ensure binary compatibility
+AppDir/usr/python/bin/python3 -m pip install -r requirements.txt
 
 echo "Creating Desktop Entry..."
-cat << 'EOF' > AppDir/com.nickcardoso.immich_sync.desktop
+cat << 'APP_EOF' > AppDir/com.nickcardoso.immich_sync.desktop
 [Desktop Entry]
 Name=Immich Sync
 Exec=immich-sync
@@ -42,18 +48,21 @@ Actions=Settings;
 [Desktop Action Settings]
 Name=Open Settings
 Exec=immich-sync --settings
-EOF
+APP_EOF
 cp AppDir/com.nickcardoso.immich_sync.desktop AppDir/usr/share/applications/com.nickcardoso.immich_sync.desktop
 
 echo "Creating AppRun..."
-cat << 'EOF' > AppDir/AppRun
+cat << 'APP_EOF' > AppDir/AppRun
 #!/bin/sh
 
 export HERE="$(dirname "$(readlink -f "${0}")")"
-export PYTHONPATH="$HERE/usr/lib/python3/site-packages:$PYTHONPATH"
-
-exec python3 "$HERE/usr/bin/immich-sync" "$@"
-EOF
+# Force the system to use our bundled Python and ignore the host's Python 
+export PATH="$HERE/usr/python/bin:$PATH"
+export PYTHONPATH="$HERE/usr/bin:$PYTHONPATH"
+# Ensure PyGObject can find the host system's GTK and AppIndicator typelib bindings
+export GI_TYPELIB_PATH="/usr/lib/girepository-1.0:/usr/lib/x86_64-linux-gnu/girepository-1.0:/usr/lib64/girepository-1.0:\$GI_TYPELIB_PATH"
+exec "$HERE/usr/python/bin/python3" "$HERE/usr/bin/immich-sync" "$@"
+APP_EOF
 chmod +x AppDir/AppRun
 
 echo "Building AppImage..."
@@ -64,5 +73,5 @@ echo "Found version: $VERSION"
 VERSION=$VERSION ARCH=x86_64 ./appimagetool-x86_64.AppImage AppDir
 chmod +x Immich_Sync-$VERSION-x86_64.AppImage
 
-echo "Build complete! Cleaning up tool..."
-rm -rf AppDir appimagetool-x86_64.AppImage
+echo "Build complete! Cleaning up tool and temp files..."
+rm -rf AppDir appimagetool-x86_64.AppImage python-standalone.tar.gz

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,7 +65,7 @@ Encapsulates communication with the Immich Server.
 - **Dual-URL Support**: Checks logical connectivity to Internal (LAN) URL first, falling back to External (WAN) URL depending on toggle switch states in the local Config. Includes captive portal verification checks.
 - **Failover State Reset**: Automatically clears active TCP URL caches on request timeouts so the LAN vs WAN exploration triggers accurately immediately after connection drops.
 - **Asset Upload**: Handles `multipart/form-data` uploads.
-- **Album Management**: Uploads are mapped to a configured `album_id`, a custom `album_name`, or dynamically matches the immediate parent folder name. The system queries the `ApiClient` to resolve or create the missing album dynamically over REST.
+- **Album Management**: Uploads are mapped to a configured `album_id`, a custom `album_name`, or dynamically matches the immediate parent folder name. The system queries the `ApiClient` to resolve or create the missing album dynamically over REST. Features robust internal routing with `threading.Lock()` to prevent race conditions from generating duplicate album records under simultaneous heavy worker loads.
 
 ### 5. Settings UI (`src/settings_window.py`)
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -4,13 +4,14 @@ This guide covers common issues encountered while using `immich-sync`.
 
 ## Common Issues
 
-### 1. System Tray Icon Not Appearing
-If the icon is missing:
-- **Wayland (GNOME/KDE):** Ensure `libappindicator-gtk3` (sometimes `libappindicator3-1`) is installed. The app attempts to force the AppIndicator backend, but some environments (Sway, Hyprland) require `status_notifier_item` support.
+### 1. System Tray Icon Not Appearing or App Crashes on Start
+If the icon is missing or fails to initialize:
+- **Wayland (GNOME/KDE) & Ubuntu 24+:** Modern desktop environments deprecate or heavily restrict legacy system trays. The app will automatically catch `pystray` initialization failures and gracefully fall back to **headless daemon mode**. 
+- **Auto-Fallback Behavior:** If the tray fails, the daemon continues running in the background normally. If you launch the app directly from your desktop menu while the tray is disabled, it will intelligently open the Settings Window instead so you can still manage the application.
 - **Environment Variables:** If running manually or via Systemd, ensure `XDG_CURRENT_DESKTOP` and `DISPLAY` are set correctly.
 
-**Workaround (Headless Mode):**
-Run the daemon without the tray icon:
+**Manual Workaround (Headless Mode):**
+If you wish to force the app to skip trying to load the tray altogether:
 ```bash
 python src/main.py --no-tray
 ```

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -11,6 +11,8 @@ Welcome to Immich Auto-Sync for Linux! This guide provides detailed instructions
 Once the application is running, a blue "Immich" icon will appear in your system tray (usually at the top right on GNOME/KDE, or bottom right on other desktop environments).
 *If you are using GNOME and don't see system tray icons, ensure you have the "AppIndicator and KStatusNotifierItem Support" extension enabled.*
 
+**Note for Ubuntu 24+ / Wayland Users:** On newer desktop environments that strictly disable legacy system trays, `immich-sync` will automatically detect this and run purely in the background (headless daemon mode). You can still open the **Settings** menu at any time by simply clicking the "Immich Auto-Sync" launcher from your system App Grid / Application Menu.
+
 Clicking on the tray icon reveals a menu with two primary options:
 
 * **Settings**: Opens the configuration and status window.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pystray
 Pillow
 pytest
 requests-mock
-
+PyGObject
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -76,6 +76,9 @@
 - [x] **investigate que behaviour**  missed images to be reuploaded once app running again
 - [x] **Analyse api key permissions**
 - [x] bug uploads video files befor they have been completely written in the folder being watched.. eg screencapture video screencasts 
+- [x] when a new folder is added to be watched and the trarget folder on the remote dosent exist. and multiple files are added to the local folder ... each worker handling each image ends up creating a seperate folder on the immich instance
+
+-[x] tray icon on ubuntu dosent work so allow app to run without that feature.. clicking appicon in menu should not invoke icon tray unless tray icon works on that os config.. settings window should open as usual and background
 
 ## 10. complete folder sync
 - [ ] **complete folder sync** sync folder added to remote or vice versa.. toggles for config.. sncy remote changes to local and sync local changes to remote

--- a/src/api_client.py
+++ b/src/api_client.py
@@ -6,6 +6,7 @@ import time
 import os
 from typing import Optional, Dict
 from datetime import datetime, timezone
+import threading
 
 class ImmichApiClient:
 
@@ -16,6 +17,7 @@ class ImmichApiClient:
         self.active_url: Optional[str] = None
         self.album_cache: Dict[str, str] = {}  # Cache name->id
         self.albums_fetched = False
+        self._album_lock = threading.Lock()
         
         # Configure a robust session with connection pooling
         self.session = requests.Session()
@@ -266,21 +268,23 @@ class ImmichApiClient:
     def get_or_create_album(self, album_name):
         """
         Returns album ID for the given name, creating it if necessary.
+        Uses a lock to prevent race conditions during concurrent bulk uploads.
         """
-        # Ensure we have the cache populated at least once
-        if not self.albums_fetched:
-            self._fetch_all_albums()
-            
-        # Check cache
-        if album_name in self.album_cache:
-            logging.debug(f"Album found in cache: {album_name}")
-            return self.album_cache[album_name]
-            
-        # If not found, try to create
-        # (Alternatively, we could re-fetch to be sure, but let's assume cache is mostly up to date)
-        # We might re-fetch if creation returns 409 (Conflict)? But album names aren't unique in Immich.
-        # Immich allows duplicate album names. We just create a new one if we don't know it.
-        return self.create_album(album_name)
+        with self._album_lock:
+            # Ensure we have the cache populated at least once
+            if not self.albums_fetched:
+                self._fetch_all_albums()
+                
+            # Check cache
+            if album_name in self.album_cache:
+                logging.debug(f"Album found in cache: {album_name}")
+                return self.album_cache[album_name]
+                
+            # If not found, try to create
+            # (Alternatively, we could re-fetch to be sure, but let's assume cache is mostly up to date)
+            # We might re-fetch if creation returns 409 (Conflict)? But album names aren't unique in Immich.
+            # Immich allows duplicate album names. We just create a new one if we don't know it.
+            return self.create_album(album_name)
 
     def add_assets_to_album(self, album_id, asset_ids):
         """

--- a/src/main.py
+++ b/src/main.py
@@ -89,22 +89,43 @@ def main():
     else:
         # Run in Daemon Mode (pystray only)
         # The GUI (Settings) is launched as a subprocess
-        from tray_icon import TrayIcon
-
+        
         # Start Monitor in non-blocking mode (background threads)
         logging.info("Starting file monitor in background thread...")
         monitor.start(blocking=False)
         
-        # Initialize Tray
-        logging.info("Initializing system tray icon...")
-        tray = TrayIcon(monitor)
-        
-        # Run Tray (Blocking Main Thread)
-        # Pystray uses GTK/AppIndicator binding which prefers being main loop
-        logging.info("Entering main loop (Tray)...")
-        tray.run()
-
-
+        try:
+            from tray_icon import TrayIcon
+            
+            # Initialize Tray
+            logging.info("Initializing system tray icon...")
+            tray = TrayIcon(monitor)
+            
+            # Run Tray (Blocking Main Thread)
+            # Pystray uses GTK/AppIndicator binding which prefers being main loop
+            logging.info("Entering main loop (Tray)...")
+            tray.run()
+            
+            if not tray._exiting_cleanly:
+                raise RuntimeError("Tray icon exited unexpectedly (failed to attach or crashed).")
+                
+        except Exception as e:
+            logging.error(f"Failed to initialize system tray icon: {e}")
+            logging.info("Tray icon feature disabled due to OS configuration or error.")
+            logging.info("Running daemon in background (headless config).")
+            
+            # Since the tray failed to load, open the settings window if this was a direct launch 
+            # so the user knows the app started (unless they explicitly passed --settings, though that's handled above).
+            script_path = os.path.join(os.path.dirname(__file__), "settings_main.py")
+            subprocess.Popen([sys.executable, script_path])
+            
+            try:
+                import time
+                while True:
+                    time.sleep(1)
+            except KeyboardInterrupt:
+                logging.info("Shutting down daemon...")
+                monitor.stop()
 
 if __name__ == "__main__":
     main()

--- a/src/tray_icon.py
+++ b/src/tray_icon.py
@@ -15,6 +15,7 @@ class TrayIcon:
         logging.info("Initializing TrayIcon...")
         self.monitor = monitor
         self.icon = None
+        self._exiting_cleanly = False
         
         # Create the icon
         logging.info("Creating icon image...")
@@ -79,8 +80,10 @@ class TrayIcon:
                 self.icon.run()
              except Exception as e:
                 logging.error(f"Error in tray icon run loop: {e}", exc_info=True)
+                raise RuntimeError(f"Tray icon failed to run: {e}")
         else:
             logging.error("Icon instance is None!")
+            raise RuntimeError("Tray icon instance is None, failed to initialize.")
 
     def stop(self):
         logging.info("Stopping System Tray Icon...")
@@ -90,6 +93,7 @@ class TrayIcon:
             self.monitor.stop()
 
     def quit_app(self, icon, item):
+        self._exiting_cleanly = True
         self.stop()
         # Clean exit
         sys.exit(0)


### PR DESCRIPTION
## Description
This PR introduces several critical fixes for Ubuntu 24 (and newer) Wayland environments, prevents race conditions during bulk uploads, and overhauls the AppImage build process to bundle a standalone Python environment.

## Changes Included
- **AppImage Python 3.12 Bundle**: Overhauled `build_test_appimage.sh` to download and bundle `astral-sh/python-build-standalone`. This isolates the app from missing C-Extension incompatibilities (like `Pillow`) on newer host OS distributions like Ubuntu 24.
- **GTK AppIndicator Support**: Added `PyGObject` to `requirements.txt` and exported `GI_TYPELIB_PATH` inside the `AppRun` script to ensure the bundled Python can safely read host GUI drivers and render native system tray icons.
- **Graceful UI Fallback**: Added a native fallback in `src/main.py` to catch `pystray` initialization errors on restrictive Wayland environments. If the tray fails, the daemon drops seamlessly into a headless background mode, and clicking the Desktop app launcher will safely open the Settings window instead.
- **Thread-safe Album Creation**: Implemented a `threading.Lock()` in `api_client.py` (`get_or_create_album`) to prevent duplicate albums from being created on the Immich server when multiple workers process files in a new folder simultaneously.
- **Documentation Updates**: Updated `CHANGELOG.md`, `roadmap.md`, `ARCHITECTURE.md`, `TROUBLESHOOTING.md`, and `USER_GUIDE.md` to reflect these system behaviors and architectural fixes.

## Testing Performed
- Tested AppImage compilation via GitHub Actions CI/CD workflows.
- Successful manual testing of the artifact on a clean Ubuntu 24 VM (confirmed resolution of the Pillow ABI crash and Wayland Tray fallbacks).