### PR TITLE
Add startup catch-up sync with album reassociation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A startup catch-up scan that walks watched folders on launch and queues media that was missed while Mimick was not running.
+- A local sync index that records previously synced files so unchanged media can be skipped quickly on later startups.
+
+### Changed
+- Changing the target Immich album for a watched folder now causes unchanged files to be reassociated to the new album on a later startup instead of being ignored.
+- If a previously targeted album no longer exists, Mimick now refreshes album resolution and retries with the current configured album target.
+- Terminal and file logs now include timestamped detailed formatting for easier troubleshooting.
+- Flatpak tray integration now uses a narrower StatusNotifier permission model and no longer requests broad `org.kde.*` bus-name ownership.
+
 ## [5.0.1] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Mimick monitors local directories (e.g., `~/Pictures`, `~/Videos`) for new files
 - **One-Way Sync**: Uploads media without modifying local files.
 - **Security**: API Key stored in the system keyring via `secret-tool` (libsecret).
 - **Autostart**: Optional login startup with desktop-portal permission inside Flatpak and native autostart integration outside Flatpak.
+- **Startup Catch-Up**: On launch, Mimick scans watched folders for media that has not been synced yet and queues only new, changed, or retargeted files.
 - **Clear Window Controls**: `Close` hides the settings window, while `Quit` stops the app completely.
 - **Desktop Integration**:
   - GTK4 / Libadwaita settings UI (dark mode by default).
@@ -98,6 +99,15 @@ Mimick now uses selected-folder access instead of full home-directory access in 
 * If you are upgrading from an older build that had full home access, re-add your existing watch folders once so the new permission model can take effect.
 * Portal-backed folders may appear by name in the UI and logs instead of showing the raw `/run/user/.../doc/...` sandbox path.
 
+### Existing Files and Album Changes
+
+Mimick does not only sync files created while it is already running.
+
+* On startup, Mimick rescans watched folders and queues media that has not been synced yet.
+* A local sync index is used so unchanged files that are already known to be synced are skipped quickly.
+* If you change the target Immich album for a watched folder, unchanged files can be reassociated to the new album on the next startup without forcing a full reupload.
+* If a previously targeted album was deleted, Mimick refreshes album resolution and recreates or rebinds the target album as needed.
+
 ### Quitting vs Closing
 
 Mimick is a background app, so closing the settings window does not quit it.
@@ -150,6 +160,8 @@ cargo run                   # start in background mode
 cargo run -- --settings     # open the settings window immediately
 
 ```
+
+Logs written to the terminal and to `~/.cache/mimick/mimick.log` now include timestamps.
 
 ### Local Flatpak Build
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -18,6 +18,10 @@ The most convenient way to configure the application is via the built-in Setting
 
 The settings window close button behaves like **Close** and keeps the background daemon running.
 
+When Mimick starts, it also rescans the configured watch folders for media that has not been synced yet. A local sync index is used so unchanged files that were already synced are skipped quickly instead of being reuploaded every launch.
+
+If you change the target album for a watched folder, Mimick can reassociate unchanged files to the new album on a later startup. If the previously used album was deleted, Mimick refreshes the album lookup and retries with the current configured album name.
+
 ## Manual Configuration (JSON)
 
 The configuration is stored in a JSON file located at:
@@ -50,6 +54,14 @@ The configuration is stored in a JSON file located at:
 | `internal_url_enabled` | Toggle allowing the Daemon to attempt LAN connectivity. | `true` |
 | `external_url_enabled` | Toggle allowing the Daemon to attempt WAN connectivity. | `true` |
 | `run_on_startup` | Whether Mimick should register itself for automatic login startup. | `false` |
+
+## Local State and Cache Files
+
+In addition to `config.json`, Mimick stores runtime state in the user cache directory:
+
+- `~/.cache/mimick/mimick.log`: rotating application logs with timestamps, levels, and source modules.
+- `~/.cache/mimick/retries.json`: queued retry items that could not be uploaded before shutdown.
+- `~/.cache/mimick/synced_index.json`: the local sync index used by startup rescans to skip already-synced unchanged files and detect album-target changes.
 
 ## API Key Security
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -51,6 +51,7 @@ This guide is for developers who want to contribute to `mimick`.
 The application uses `flexi_logger`. 
 - By default, `cargo run` prints `INFO` level logs to the terminal.
 - Logs are simultaneously written to disk at `~/.cache/mimick/mimick.log`.
+- Both terminal and file logs use timestamped detailed formatting.
 - To increase verbosity, set the `RUST_LOG` environment variable:
 
 ```bash

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -43,6 +43,7 @@ The application writes rotating debug logs to `.cache`. If something breaks with
 ```bash
 tail -f ~/.cache/mimick/mimick.log
 ```
+Each log line includes a timestamp, level, and source module.
 
 ### Manual Debugging
 Run the application directly in a terminal to see `stdout` logs:
@@ -51,7 +52,7 @@ mimick
 # or if developing:
 cargo run
 ```
-Look for lines starting with `ERROR` or `WARN`.
+Terminal logs also include timestamps. Look for lines starting with `ERROR` or `WARN`.
 
 ### Check Configuration Validity
 Verify your config file is valid JSON:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -76,12 +76,26 @@ The settings window has separate actions for hiding the window and quitting the 
 
 ### Automatic Detection
 
-Once configured, the application runs silently in the background. When you add a new photo to a watched folder, `mimick` detects it via filesystem monitoring:
+Once configured, the application runs silently in the background. It handles syncing in two ways:
+
+1. On startup, Mimick rescans watched folders for media that has not been synced yet.
+2. While running, Mimick watches those folders for newly added or changed media.
+
+For live changes, `mimick` detects files via filesystem monitoring:
 
 1. Waits for the file size to stabilise (file is fully written to disk).
 2. Calculates a SHA-1 checksum for deduplication.
 3. Streams the file to Immich using the standard asset API.
 4. Adds the asset to the configured album.
+
+### Existing Files and Reassignment
+
+Mimick keeps a local sync index so it can avoid reprocessing files that are already known to be synced.
+
+* Unchanged files that were already synced are skipped during startup rescans.
+* Files whose content changed are rehashed and uploaded again.
+* If you change the target album for a watched folder, Mimick can reassociate unchanged files to the new album on a later startup without needing to reupload the media data.
+* If the previously targeted album was deleted, Mimick refreshes the album mapping and retries using the current configured album name.
 
 ### Sync Status
 

--- a/site/index.html
+++ b/site/index.html
@@ -14,7 +14,10 @@
         rel="stylesheet"
         href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Newsreader:opsz,wght@6..72,400;6..72,500&display=swap"
     >
-    <link rel="icon" href="icon.png" type="image/png">
+    <meta name="theme-color" content="#f7f2ea">
+    <link rel="icon" href="icon.png" sizes="192x192" type="image/png">
+    <link rel="shortcut icon" href="icon.png" type="image/png">
+    <link rel="apple-touch-icon" href="icon.png">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -306,6 +306,15 @@ impl ImmichApiClient {
         }
     }
 
+    pub async fn refresh_album_cache(&self) {
+        {
+            let mut cache = self.album_cache.lock().await;
+            cache.clear();
+        }
+        *self.albums_fetched.lock().await = false;
+        self.fetch_all_albums().await;
+    }
+
     /// Return a snapshot of all cached albums as a list of (albumName, id)
     pub async fn get_all_albums(&self) -> Vec<(String, String)> {
         if !*self.albums_fetched.lock().await {
@@ -376,6 +385,68 @@ impl ImmichApiClient {
             }
         }
         self.create_album(album_name).await
+    }
+
+    pub async fn resolve_album_by_name(
+        &self,
+        album_name: &str,
+        force_refresh: bool,
+    ) -> Option<String> {
+        if force_refresh {
+            self.refresh_album_cache().await;
+        }
+        self.get_or_create_album(album_name).await
+    }
+
+    /// Check whether an asset already exists on the server by checksum and return its asset ID.
+    pub async fn find_existing_asset_id(&self, checksum: &str) -> Option<String> {
+        let base_url = self.get_active_url().await?;
+        let url = format!("{}/api/assets/bulk-upload-check", base_url);
+        let body = serde_json::json!({
+            "assets": [
+                {
+                    "id": checksum,
+                    "checksum": checksum
+                }
+            ]
+        });
+
+        match self
+            .client
+            .post(&url)
+            .header("x-api-key", &self.api_key)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .json(&body)
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                let json = resp.json::<serde_json::Value>().await.ok()?;
+                json["results"]
+                    .as_array()
+                    .and_then(|results| results.first())
+                    .and_then(|item| item["assetId"].as_str())
+                    .map(ToString::to_string)
+            }
+            Ok(resp) => {
+                log::warn!(
+                    "Bulk upload check failed for checksum {}: {}",
+                    checksum,
+                    resp.status()
+                );
+                None
+            }
+            Err(err) => {
+                log::warn!(
+                    "Bulk upload check request failed for checksum {}: {}",
+                    checksum,
+                    err
+                );
+                None
+            }
+        }
     }
 
     /// Add a list of asset IDs to an album.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,9 @@ mod notifications;
 mod queue_manager;
 mod restart;
 mod settings_window;
+mod startup_scan;
 mod state_manager;
+mod sync_index;
 mod tray_icon;
 mod watch_path_display;
 
@@ -22,10 +24,12 @@ use monitor::Monitor;
 use queue_manager::{FileTask, QueueManager};
 use restart::{launch_replacement, take_restart_request};
 use settings_window::build_settings_window;
+use startup_scan::queue_unsynced_files;
 use state_manager::{AppState, StateManager};
+use sync_index::SyncIndex;
 use tray_icon::build_tray;
 
-use flexi_logger::{FileSpec, Logger, WriteMode};
+use flexi_logger::{FileSpec, Logger, WriteMode, colored_detailed_format, detailed_format};
 
 /// Holds the primary instance's QueueManager so the shutdown path can flush retries to disk.
 static QM_HANDLE: std::sync::OnceLock<Arc<QueueManager>> = std::sync::OnceLock::new();
@@ -48,6 +52,8 @@ async fn main() {
                 .suppress_timestamp() // "mimick.log" instead of "mimick_2026-03-09_10-33-35.log"
                 .suffix("log"),
         )
+        .format_for_files(detailed_format)
+        .format_for_stdout(colored_detailed_format)
         // Also print to stdout for systemd / terminal users
         .duplicate_to_stdout(flexi_logger::Duplicate::All)
         .write_mode(WriteMode::Direct)
@@ -106,11 +112,13 @@ async fn main() {
             api_key,
         ));
         let _ = API_CLIENT_HANDLE.set(api_client.clone());
+        let sync_index = Arc::new(Mutex::new(SyncIndex::new()));
 
         let qm = Arc::new(QueueManager::new(
             api_client,
             3,
             shared_state_startup.clone(),
+            sync_index.clone(),
         ));
 
         // Start file monitor using plain path strings
@@ -145,19 +153,32 @@ async fn main() {
                     }
                 }
 
-                qm_clone
+                let _ = qm_clone
                     .add_to_queue(FileTask {
                         path,
                         checksum,
                         album_id,
                         album_name,
+                        reassociate_only: false,
                     })
                     .await;
             }
         });
 
+        let startup_qm = qm.clone();
+        let startup_paths = config.data.watch_paths.clone();
+        let startup_sync_index = sync_index.clone();
+
         // Store in the global handle so main() can call flush_retries() on graceful shutdown.
         let _ = QM_HANDLE.set(qm);
+
+        tokio::spawn(async move {
+            let startup_api = API_CLIENT_HANDLE
+                .get()
+                .cloned()
+                .expect("API client should be initialized before startup scan");
+            queue_unsynced_files(startup_paths, startup_qm, startup_sync_index, startup_api).await;
+        });
 
         let app_clone2 = app.clone();
         let app_clone3 = app.clone();

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
 /// Whitelisted media extensions (matches Python ALLOWED_EXTENSIONS)
-const MEDIA_EXTENSIONS: &[&str] = &[
+pub(crate) const MEDIA_EXTENSIONS: &[&str] = &[
     "jpg", "jpeg", "png", "heic", "mp4", "mov", "gif", "webp", "tiff", "tif", "raw", "arw", "dng",
 ];
 
@@ -230,7 +230,7 @@ async fn wait_for_file_completion(path: &str) -> bool {
 }
 
 /// Compute SHA-1 in 64KB chunks — handles large files without loading all into RAM.
-fn compute_sha1_chunked(path: &str) -> io::Result<String> {
+pub(crate) fn compute_sha1_chunked(path: &str) -> io::Result<String> {
     const BUF_SIZE: usize = 65536;
     let file = fs::File::open(path)?;
     let mut reader = BufReader::with_capacity(BUF_SIZE, file);
@@ -244,6 +244,18 @@ fn compute_sha1_chunked(path: &str) -> io::Result<String> {
         hasher.update(&buf[..n]);
     }
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+pub(crate) fn is_supported_media_path(path: &Path) -> bool {
+    if path.is_dir() {
+        return false;
+    }
+
+    let ext = path
+        .extension()
+        .map(|e| e.to_string_lossy().to_lowercase());
+    let ext_str = ext.as_deref().unwrap_or("");
+    MEDIA_EXTENSIONS.contains(&ext_str)
 }
 
 #[cfg(test)]

--- a/src/queue_manager.rs
+++ b/src/queue_manager.rs
@@ -1,6 +1,8 @@
 use crate::api_client::ImmichApiClient;
 use crate::notifications;
 use crate::state_manager::AppState;
+use crate::sync_index::{SyncIndex, SyncTarget};
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -17,6 +19,9 @@ pub struct FileTask {
     /// Album name to look up or create
     #[serde(default)]
     pub album_name: Option<String>,
+    /// True when the file content is already known to exist and only album reassociation is needed.
+    #[serde(default)]
+    pub reassociate_only: bool,
 }
 
 pub struct QueueManager {
@@ -26,6 +31,9 @@ pub struct QueueManager {
     shared_state: Arc<std::sync::Mutex<AppState>>,
     /// In-memory retry list — no per-failure disk writes.
     retry_list: Arc<std::sync::Mutex<Vec<FileTask>>>,
+    /// Paths already queued or awaiting retry. Prevents duplicate queue entries
+    /// when the startup scan and live watcher see the same file.
+    pending_paths: Arc<std::sync::Mutex<HashSet<String>>>,
     retry_path: PathBuf,
 }
 
@@ -34,6 +42,7 @@ impl QueueManager {
         api_client: Arc<ImmichApiClient>,
         workers: usize,
         shared_state: Arc<std::sync::Mutex<AppState>>,
+        sync_index: Arc<std::sync::Mutex<SyncIndex>>,
     ) -> Self {
         let (tx, rx) = mpsc::channel::<FileTask>(64);
         let rx = Arc::new(Mutex::new(rx));
@@ -60,11 +69,15 @@ impl QueueManager {
 
         // In-memory retry list: no disk writes during a session.
         let retry_list = Arc::new(std::sync::Mutex::new(Vec::<FileTask>::new()));
+        let pending_paths = Arc::new(std::sync::Mutex::new(
+            loaded_retries.iter().map(|task| task.path.clone()).collect(),
+        ));
 
         let qm = Self {
             sender: tx,
             shared_state: shared_state.clone(),
             retry_list: retry_list.clone(),
+            pending_paths: pending_paths.clone(),
             retry_path: retry_path.clone(),
         };
 
@@ -74,6 +87,8 @@ impl QueueManager {
             let api = api_client.clone();
             let state_ref = shared_state.clone();
             let retry_ref = retry_list.clone();
+            let pending_ref = pending_paths.clone();
+            let sync_index_ref = sync_index.clone();
 
             tokio::spawn(async move {
                 log::debug!("Worker {} started", i);
@@ -110,11 +125,27 @@ impl QueueManager {
                             );
 
                             let t_start = std::time::Instant::now();
-                            let success = handle_upload(&api, &file_task).await;
+                            let sync_target = handle_upload(&api, &file_task).await;
+                            let success = sync_target.is_some();
                             let elapsed = t_start.elapsed().as_secs_f32();
 
                             if success {
                                 log::info!("Upload SUCCESS: {} ({:.2}s)", file_task.path, elapsed);
+                                pending_ref.lock().unwrap().remove(&file_task.path);
+
+                                if let Some(target) = sync_target.as_ref() {
+                                    if let Err(err) = sync_index_ref
+                                        .lock()
+                                        .unwrap()
+                                        .record_synced(&file_task.path, &file_task.checksum, target)
+                                    {
+                                        log::warn!(
+                                            "Failed to update sync index for '{}': {}",
+                                            file_task.path,
+                                            err
+                                        );
+                                    }
+                                }
 
                                 // Atomically drain the in-memory retry list (fast, no I/O).
                                 let retries: Vec<FileTask> = {
@@ -218,8 +249,17 @@ impl QueueManager {
     }
 
     /// Add a file task to the upload queue.
-    pub async fn add_to_queue(&self, task: FileTask) {
+    pub async fn add_to_queue(&self, task: FileTask) -> bool {
         log::debug!("Queuing: {}", task.path);
+        {
+            let mut pending = self.pending_paths.lock().unwrap();
+            if pending.contains(&task.path) {
+                log::debug!("Skipping already pending task: {}", task.path);
+                return false;
+            }
+            pending.insert(task.path.clone());
+        }
+
         {
             let mut s = self.shared_state.lock().unwrap();
             s.total_queued += 1;
@@ -227,7 +267,11 @@ impl QueueManager {
         }
         if let Err(e) = self.sender.send(task).await {
             log::error!("Failed to send task to queue: {}", e);
+            self.pending_paths.lock().unwrap().remove(&e.0.path);
+            return false;
         }
+
+        true
     }
 
     /// Persist any remaining in-memory retry items to disk (call on graceful shutdown).
@@ -244,15 +288,28 @@ impl QueueManager {
 }
 
 /// Upload a file and add it to the appropriate album.
-async fn handle_upload(api: &ImmichApiClient, task: &FileTask) -> bool {
-    let asset_id = api.upload_asset(&task.path, &task.checksum).await;
+async fn handle_upload(api: &ImmichApiClient, task: &FileTask) -> Option<SyncTarget> {
+    let asset_id = if task.reassociate_only {
+        match api.find_existing_asset_id(&task.checksum).await {
+            Some(existing) => Some(existing),
+            None => api.upload_asset(&task.path, &task.checksum).await,
+        }
+    } else {
+        api.upload_asset(&task.path, &task.checksum).await
+    };
 
     let asset_id = match asset_id {
-        None => return false,
-        Some(ref id) if id == "DUPLICATE" => {
-            log::info!("Asset already on server: {}", task.path);
-            return true;
-        }
+        None => return None,
+        Some(ref id) if id == "DUPLICATE" => match api.find_existing_asset_id(&task.checksum).await {
+            Some(existing) => existing,
+            None => {
+                log::info!("Asset already on server: {}", task.path);
+                return Some(SyncTarget {
+                    album_name: task.album_name.clone().or_else(|| infer_album_name(&task.path)),
+                    album_id: task.album_id.clone(),
+                });
+            }
+        },
         Some(id) => id,
     };
 
@@ -268,7 +325,7 @@ async fn handle_upload(api: &ImmichApiClient, task: &FileTask) -> bool {
 
     log::info!("Adding '{}' to album '{}'", task.path, album_name);
 
-    let final_album_id = if let Some(ref id) = task.album_id {
+    let mut final_album_id = if let Some(ref id) = task.album_id {
         if !id.is_empty() {
             Some(id.clone())
         } else {
@@ -278,16 +335,49 @@ async fn handle_upload(api: &ImmichApiClient, task: &FileTask) -> bool {
         api.get_or_create_album(&album_name).await
     };
 
-    if let Some(album_id) = final_album_id {
-        api.add_assets_to_album(&album_id, &[asset_id]).await;
+    if let Some(album_id) = final_album_id.clone() {
+        if !api.add_assets_to_album(&album_id, std::slice::from_ref(&asset_id)).await {
+            if let Some(album_name) = task.album_name.clone().or_else(|| infer_album_name(&task.path)) {
+                log::warn!(
+                    "Album '{}' may be stale or deleted. Refreshing album resolution.",
+                    album_id
+                );
+                final_album_id = api
+                    .resolve_album_by_name(&album_name, true)
+                    .await;
+                if let Some(ref refreshed_id) = final_album_id {
+                    if !api
+                        .add_assets_to_album(refreshed_id, std::slice::from_ref(&asset_id))
+                        .await
+                    {
+                        return None;
+                    }
+                } else {
+                    return None;
+                }
+            } else {
+                return None;
+            }
+        }
     } else {
         log::warn!(
             "Could not resolve album '{}'. Asset uploaded but not added to album.",
             album_name
         );
+        return None;
     }
 
-    true
+    Some(SyncTarget {
+        album_name: Some(album_name),
+        album_id: final_album_id,
+    })
+}
+
+fn infer_album_name(path: &str) -> Option<String> {
+    std::path::Path::new(path)
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
 }
 
 fn save_retries(path: &PathBuf, tasks: &[FileTask]) {
@@ -337,6 +427,7 @@ mod tests {
             checksum: "sha123".to_string(),
             album_id: Some("id1".to_string()),
             album_name: Some("Album".to_string()),
+            reassociate_only: false,
         };
         let js = serde_json::to_string(&task).unwrap();
         assert!(js.contains("sha123"));
@@ -356,6 +447,7 @@ mod tests {
             checksum: "hash1".to_string(),
             album_id: None,
             album_name: None,
+            reassociate_only: false,
         };
 
         let tasks = vec![task];

--- a/src/startup_scan.rs
+++ b/src/startup_scan.rs
@@ -1,0 +1,233 @@
+use crate::api_client::ImmichApiClient;
+use crate::config::WatchPathEntry;
+use crate::monitor::{compute_sha1_chunked, is_supported_media_path};
+use crate::queue_manager::{FileTask, QueueManager};
+use crate::sync_index::{SyncDecision, SyncIndex, SyncTarget};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+struct ScanCandidate {
+    path: String,
+    album_id: Option<String>,
+    album_name: Option<String>,
+    reassociate_only: bool,
+    checksum: Option<String>,
+}
+
+pub async fn queue_unsynced_files(
+    watch_paths: Vec<WatchPathEntry>,
+    queue_manager: Arc<QueueManager>,
+    sync_index: Arc<Mutex<SyncIndex>>,
+    api_client: Arc<ImmichApiClient>,
+) {
+    if watch_paths.is_empty() {
+        return;
+    }
+
+    let mut seen_paths = HashSet::new();
+    let mut candidates = Vec::new();
+    let mut skipped_current = 0usize;
+    let mut scan_errors = 0usize;
+    let mut album_id_cache: HashMap<String, Option<String>> = HashMap::new();
+
+    for entry in &watch_paths {
+        let root = Path::new(entry.path());
+        if !root.exists() {
+            log::warn!(
+                "Startup scan skipped missing watch path: {}",
+                root.display()
+            );
+            continue;
+        }
+
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            let read_dir = match std::fs::read_dir(&dir) {
+                Ok(iter) => iter,
+                Err(err) => {
+                    scan_errors += 1;
+                    log::warn!("Startup scan could not read '{}': {}", dir.display(), err);
+                    continue;
+                }
+            };
+
+            for child in read_dir {
+                match child {
+                    Ok(entry_fs) => {
+                        let path = entry_fs.path();
+                        if path.is_dir() {
+                            stack.push(path);
+                            continue;
+                        }
+
+                        if !is_supported_media_path(&path) {
+                            continue;
+                        }
+
+                        let path_str = path.to_string_lossy().into_owned();
+                        seen_paths.insert(path_str.clone());
+                        let album_name = effective_album_name(entry, &path);
+                        let album_id = resolve_target_album_id(
+                            &api_client,
+                            &album_name,
+                            &mut album_id_cache,
+                        )
+                        .await;
+                        let target = SyncTarget {
+                            album_name: Some(album_name.clone()),
+                            album_id: album_id.clone(),
+                        };
+
+                        let decision = match sync_index.lock().unwrap().sync_decision(&path, &target) {
+                            Ok(decision) => decision,
+                            Err(err) => {
+                                scan_errors += 1;
+                                log::warn!(
+                                    "Startup scan could not inspect '{}': {}",
+                                    path.display(),
+                                    err
+                                );
+                                continue;
+                            }
+                        };
+
+                        match decision {
+                            SyncDecision::UpToDate => {
+                                skipped_current += 1;
+                            }
+                            SyncDecision::NeedsUpload => {
+                                candidates.push(ScanCandidate {
+                                    path: path_str,
+                                    album_id,
+                                    album_name: Some(album_name),
+                                    reassociate_only: false,
+                                    checksum: None,
+                                });
+                            }
+                            SyncDecision::NeedsReassociate => {
+                                let checksum = sync_index
+                                    .lock()
+                                    .unwrap()
+                                    .stored_checksum(&path_str);
+                                candidates.push(ScanCandidate {
+                                    path: path_str,
+                                    album_id,
+                                    album_name: Some(album_name),
+                                    reassociate_only: true,
+                                    checksum,
+                                });
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        scan_errors += 1;
+                        log::warn!("Startup scan directory entry error: {}", err);
+                    }
+                }
+            }
+        }
+    }
+
+    if let Err(err) = sync_index.lock().unwrap().prune_missing(&seen_paths) {
+        log::warn!("Failed to prune sync index after startup scan: {}", err);
+    }
+
+    if candidates.is_empty() {
+        log::info!(
+            "Startup scan complete: no unsynced files found ({} already current, {} error(s)).",
+            skipped_current,
+            scan_errors
+        );
+        return;
+    }
+
+    log::info!(
+        "Startup scan found {} unsynced file(s) ({} already current, {} error(s)).",
+        candidates.len(),
+        skipped_current,
+        scan_errors
+    );
+
+    let mut queued = 0usize;
+    for candidate in candidates {
+        let checksum = if let Some(checksum) = candidate.checksum.clone() {
+            checksum
+        } else {
+            let path_for_hash = candidate.path.clone();
+            match tokio::task::spawn_blocking(move || compute_sha1_chunked(&path_for_hash)).await {
+                Ok(Ok(checksum)) => checksum,
+                Ok(Err(err)) => {
+                    log::warn!(
+                        "Startup scan could not checksum '{}': {}",
+                        candidate.path,
+                        err
+                    );
+                    continue;
+                }
+                Err(err) => {
+                    log::warn!(
+                        "Startup scan checksum task failed for '{}': {}",
+                        candidate.path,
+                        err
+                    );
+                    continue;
+                }
+            }
+        };
+
+        if queue_manager
+            .add_to_queue(FileTask {
+                path: candidate.path,
+                checksum,
+                album_id: candidate.album_id,
+                album_name: candidate.album_name,
+                reassociate_only: candidate.reassociate_only,
+            })
+            .await
+        {
+            queued += 1;
+        }
+    }
+
+    log::info!("Startup scan queued {} unsynced file(s).", queued);
+}
+
+fn effective_album_name(entry: &WatchPathEntry, path: &Path) -> String {
+    match entry.album_name() {
+        Some(name) if !name.is_empty() && name != "Default (Folder Name)" => name.to_string(),
+        _ => path
+            .parent()
+            .and_then(|p| p.file_name())
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "Mimick".to_string()),
+    }
+}
+
+async fn resolve_target_album_id(
+    api_client: &ImmichApiClient,
+    album_name: &str,
+    album_id_cache: &mut HashMap<String, Option<String>>,
+) -> Option<String> {
+    if let Some(cached) = album_id_cache.get(album_name) {
+        return cached.clone();
+    }
+
+    let resolved = api_client.resolve_album_by_name(album_name, false).await;
+    album_id_cache.insert(album_name.to_string(), resolved.clone());
+    resolved
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::monitor::is_supported_media_path;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_supported_media_path_filter() {
+        assert!(is_supported_media_path(&PathBuf::from("image.jpg")));
+        assert!(is_supported_media_path(&PathBuf::from("movie.mp4")));
+        assert!(!is_supported_media_path(&PathBuf::from("notes.txt")));
+    }
+}

--- a/src/sync_index.rs
+++ b/src/sync_index.rs
@@ -1,0 +1,271 @@
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct SyncedFileRecord {
+    pub size: u64,
+    pub modified_ms: u64,
+    pub checksum: String,
+    #[serde(default)]
+    pub album_name: Option<String>,
+    #[serde(default)]
+    pub album_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SyncTarget {
+    pub album_name: Option<String>,
+    pub album_id: Option<String>,
+}
+
+pub enum SyncDecision {
+    UpToDate,
+    NeedsUpload,
+    NeedsReassociate,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct SyncIndexData {
+    files: HashMap<String, SyncedFileRecord>,
+}
+
+pub struct SyncIndex {
+    index_file: PathBuf,
+    entries: HashMap<String, SyncedFileRecord>,
+}
+
+impl SyncIndex {
+    pub fn new() -> Self {
+        let index_file = dirs::cache_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join("mimick")
+            .join("synced_index.json");
+
+        let entries = load_entries(&index_file);
+
+        Self { index_file, entries }
+    }
+
+    pub fn sync_decision(&self, path: &Path, target: &SyncTarget) -> io::Result<SyncDecision> {
+        let metadata = fs::metadata(path)?;
+        let fingerprint = fingerprint_from_metadata(&metadata);
+        let key = path.to_string_lossy();
+
+        Ok(match self.entries.get(key.as_ref()) {
+            Some(record) => {
+                if record.size != fingerprint.0 || record.modified_ms != fingerprint.1 {
+                    SyncDecision::NeedsUpload
+                } else if record.album_name != target.album_name || record.album_id != target.album_id {
+                    SyncDecision::NeedsReassociate
+                } else {
+                    SyncDecision::UpToDate
+                }
+            }
+            None => SyncDecision::NeedsUpload,
+        })
+    }
+
+    pub fn record_synced(
+        &mut self,
+        path: &str,
+        checksum: &str,
+        target: &SyncTarget,
+    ) -> io::Result<()> {
+        let metadata = fs::metadata(path)?;
+        let (size, modified_ms) = fingerprint_from_metadata(&metadata);
+        self.entries.insert(
+            path.to_string(),
+            SyncedFileRecord {
+                size,
+                modified_ms,
+                checksum: checksum.to_string(),
+                album_name: target.album_name.clone(),
+                album_id: target.album_id.clone(),
+            },
+        );
+        self.save()
+    }
+
+    pub fn prune_missing(&mut self, seen_paths: &HashSet<String>) -> io::Result<()> {
+        let before = self.entries.len();
+        self.entries.retain(|path, _| seen_paths.contains(path));
+
+        if self.entries.len() != before {
+            self.save()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn stored_checksum(&self, path: &str) -> Option<String> {
+        self.entries.get(path).map(|record| record.checksum.clone())
+    }
+
+    fn save(&self) -> io::Result<()> {
+        if let Some(parent) = self.index_file.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let content = serde_json::to_string_pretty(&SyncIndexData {
+            files: self.entries.clone(),
+        })?;
+
+        let tmp_file = self.index_file.with_extension(format!(
+            "tmp.{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+
+        fs::write(&tmp_file, content)?;
+        fs::rename(&tmp_file, &self.index_file)?;
+        Ok(())
+    }
+}
+
+fn load_entries(index_file: &Path) -> HashMap<String, SyncedFileRecord> {
+    match fs::read_to_string(index_file) {
+        Ok(content) => match serde_json::from_str::<SyncIndexData>(&content) {
+            Ok(data) => data.files,
+            Err(err) => {
+                log::warn!("Failed to parse sync index '{}': {}", index_file.display(), err);
+                HashMap::new()
+            }
+        },
+        Err(_) => HashMap::new(),
+    }
+}
+
+fn fingerprint_from_metadata(metadata: &fs::Metadata) -> (u64, u64) {
+    let modified_ms = metadata
+        .modified()
+        .ok()
+        .and_then(|mtime| mtime.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or_default();
+
+    (metadata.len(), modified_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SyncDecision, SyncIndex, SyncTarget};
+    use std::collections::HashSet;
+    use std::fs;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_record_synced_then_skip_unchanged_file() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("photo.jpg");
+        fs::write(&file_path, b"hello").unwrap();
+
+        let mut index = SyncIndex {
+            index_file: dir.path().join("synced_index.json"),
+            entries: Default::default(),
+        };
+        let target = SyncTarget {
+            album_name: Some("Album".into()),
+            album_id: Some("album-1".into()),
+        };
+
+        assert!(matches!(
+            index.sync_decision(&file_path, &target).unwrap(),
+            SyncDecision::NeedsUpload
+        ));
+        index
+            .record_synced(file_path.to_str().unwrap(), "hash1", &target)
+            .unwrap();
+        assert!(matches!(
+            index.sync_decision(&file_path, &target).unwrap(),
+            SyncDecision::UpToDate
+        ));
+    }
+
+    #[test]
+    fn test_modified_file_needs_resync() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("photo.jpg");
+        fs::write(&file_path, b"hello").unwrap();
+
+        let mut index = SyncIndex {
+            index_file: dir.path().join("synced_index.json"),
+            entries: Default::default(),
+        };
+        let target = SyncTarget {
+            album_name: Some("Album".into()),
+            album_id: Some("album-1".into()),
+        };
+        index
+            .record_synced(file_path.to_str().unwrap(), "hash1", &target)
+            .unwrap();
+
+        let mut file = fs::OpenOptions::new().append(true).open(&file_path).unwrap();
+        file.write_all(b" world").unwrap();
+
+        assert!(matches!(
+            index.sync_decision(&file_path, &target).unwrap(),
+            SyncDecision::NeedsUpload
+        ));
+    }
+
+    #[test]
+    fn test_prune_missing_removes_deleted_entries() {
+        let dir = tempdir().unwrap();
+        let mut index = SyncIndex {
+            index_file: dir.path().join("synced_index.json"),
+            entries: Default::default(),
+        };
+
+        let file_path = dir.path().join("photo.jpg");
+        fs::write(&file_path, b"hello").unwrap();
+        let target = SyncTarget {
+            album_name: Some("Album".into()),
+            album_id: Some("album-1".into()),
+        };
+        index
+            .record_synced(file_path.to_str().unwrap(), "hash1", &target)
+            .unwrap();
+
+        index.prune_missing(&HashSet::new()).unwrap();
+        assert!(matches!(
+            index.sync_decision(&file_path, &target).unwrap(),
+            SyncDecision::NeedsUpload
+        ));
+    }
+
+    #[test]
+    fn test_album_change_requires_reassociate() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("photo.jpg");
+        fs::write(&file_path, b"hello").unwrap();
+
+        let mut index = SyncIndex {
+            index_file: dir.path().join("synced_index.json"),
+            entries: Default::default(),
+        };
+        let original = SyncTarget {
+            album_name: Some("Album A".into()),
+            album_id: Some("album-a".into()),
+        };
+        let updated = SyncTarget {
+            album_name: Some("Album B".into()),
+            album_id: Some("album-b".into()),
+        };
+
+        index
+            .record_synced(file_path.to_str().unwrap(), "hash1", &original)
+            .unwrap();
+
+        assert!(matches!(
+            index.sync_decision(&file_path, &updated).unwrap(),
+            SyncDecision::NeedsReassociate
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

This PR makes Mimick much more reliable when it has been offline or not running.

Mimick now performs a startup catch-up scan for watched folders, keeps a local sync index so unchanged files are skipped efficiently, and can reassociate existing media when a watched folder is retargeted to a different Immich album. It also improves recovery when a previously used album has been deleted and adds timestamped logging for easier troubleshooting.

## Highlights

- Added startup catch-up syncing for watched folders
- Added a persistent local sync index to avoid reprocessing unchanged files
- Added album reassociation when a watch folder's target album changes
- Added recovery for deleted or stale album targets
- Added timestamped terminal and file logs
- Updated user and configuration docs to reflect the new behavior

## User Impact

This means Mimick no longer only syncs files that appear while it is already running.

On startup, it now scans selected watch folders for media that has not been synced yet, queues only what is new or changed, and avoids unnecessary reuploads for files that are already known to be synced. If a watch folder is reassigned to a different album, Mimick can reuse existing assets and add them to the new album on a later startup.

## Technical Notes

- Introduced a new startup scan flow for watched directories
- Added a persistent sync index under the Mimick cache directory
- Reused checksum-based duplicate detection to find existing Immich assets
- Refreshed album resolution when stored album IDs became stale
- Switched logs to detailed timestamped formatting for both stdout and log files

## Verification

- `cargo test` passed (`23/23`)
