### PR TITLE
feat: enhance settings window with folder rules and diagnostics export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A queue inspector in the settings window with recent queue activity, failed-item visibility, per-item retry actions, `Retry All Failed`, and `Clear Failed Queue`.
+- Manual sync controls in both the settings window and tray menu with `Pause / Resume` and `Sync Now` actions.
+- Per-folder sync rules for ignoring hidden files, limiting maximum file size, and restricting allowed file extensions.
+- A diagnostics export bundle that writes a support-friendly snapshot containing a summary, config copy, status cache, retry queue, sync index, and log file without including the API key.
+- Best-effort environment-aware pausing for metered-network and battery-power operation.
+
+### Changed
+- Startup scans and live monitoring now apply the same per-folder rule checks and temporary-file filtering before queueing uploads.
+- Shared runtime state now records recent queue events, pause reasons, the last completed file, and diagnostics export counts for better visibility and supportability.
+- The settings window now separates `Setup` and `Controls`, uses a slimmer layout, and keeps `Close`, `Quit`, and `Save & Restart` pinned in a footer.
+- Documentation now covers the new sync controls, diagnostics workflow, per-folder rules, and current test/packaging flow.
+- CI and Flatpak publishing documentation now match the current `cargo fmt`, `cargo clippy --locked`, `cargo test --locked`, and containerized Flatpak build setup.
+
 ## [6.0.0] - 2026-03-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ Mimick monitors local directories (e.g., `~/Pictures`, `~/Videos`) for new files
 - **SHA-1 Checksumming**: Deduplication via checksum before upload — exact same logic as the Immich mobile apps.
 - **Concurrent Uploads**: 10 parallel worker tasks stream files directly from disk, keeping RAM usage constant.
 - **Offline Reliability**: Failed uploads are persisted to `~/.cache/mimick/retries.json` and replayed automatically on next launch.
+- **Queue Inspector & Retry Tools**: Inspect recent queue activity, retry one failed file, retry all failed uploads, or clear the failed queue from the settings window.
+- **Sync Controls**: Pause or resume uploads and trigger a manual `Sync Now` pass from either the tray or the settings window.
 - **Connectivity**: Automatically switches between **Internal (LAN)** and **External (WAN)** URLs based on availability. At least one must be enabled (enforced by the UI).
+- **Per-Folder Rules**: Each watched folder can optionally ignore hidden paths, cap file size, or allow only selected file extensions.
+- **Diagnostics Export**: Generate a support bundle with logs, queue state, sync index, and a human-readable summary without exposing your API key.
+- **Network / Power Awareness**: Optionally defer uploads while on a metered connection or running on battery power.
 - **Custom Album Mapping**: Select an existing remote album, type a custom name, or let the app create an album from the local folder name (e.g., `~/Pictures/Vacation 2024` → Album `Vacation 2024`).
 - **One-Way Sync**: Uploads media without modifying local files.
 - **Security**: API Key stored in the system keyring via `secret-tool` (libsecret).
@@ -94,13 +99,24 @@ Compare the printed fingerprint to the value above. The email address alone is n
 
 Launch Mimick from your Application Launcher. The settings window opens automatically on first launch.
 
+The window is split into two pages:
+
+* **Setup** for server details, behavior switches, watch folders, and folder rules
+* **Controls** for status, queue actions, manual sync, pause/resume, and diagnostics export
+
 1. **Internal URL** — LAN address (e.g., `http://192.168.1.50:2283`).
 2. **External URL** — WAN/Public address (e.g., `https://photos.example.com`). *At least one must be enabled.*
 3. **API Key** — Generate in Immich Web UI under Account Settings > API Keys. Needs **Asset** and **Album** read/create permissions.
 4. **Watch Paths** — Add folders to monitor with the built-in folder picker. Each folder can be assigned a target Immich album.
 5. **Run on Startup** — Enable this in the **Behavior** section to start Mimick automatically when you log in.
-6. **Save & Restart** — Applies your settings and relaunches Mimick automatically.
-7. **Close / Quit** — `Close` hides the settings window and leaves Mimick running; `Quit` fully exits the app.
+6. **Folder Rules** — Each watched folder can open a rules dialog to ignore hidden paths, set a max size in MB, or restrict uploads to specific extensions.
+7. **Sync Controls** — Use **Pause**, **Resume**, or **Sync Now** from the settings window or tray menu when you want manual control.
+8. **Queue Inspector** — Review recent queue events, inspect failed uploads, retry individual files, retry all failures, or clear the failed queue.
+9. **Export Diagnostics** — Create a support bundle from the settings window when troubleshooting sync issues.
+10. **Save & Restart** — Applies your settings and relaunches Mimick automatically.
+11. **Close / Quit** — `Close` hides the settings window and leaves Mimick running; `Quit` fully exits the app.
+
+The bottom footer keeps **Close**, **Quit**, and **Save & Restart** visible even when the page content needs scrolling.
 
 ### Autostart
 
@@ -132,6 +148,29 @@ Mimick is a background app, so closing the settings window does not quit it.
 
 * Use **Close** in the settings window or the window close button to hide the window and keep Mimick running in the tray.
 * Use **Quit** from the tray menu, the settings window, or the launcher action to stop the app completely.
+
+### Queue and Diagnostics Tools
+
+Mimick now includes a small control center for active troubleshooting and recovery.
+
+On the **Controls** page:
+
+* **Sync Now** reruns the watched-folder scan immediately.
+* **Pause** toggles upload activity without quitting Mimick.
+* **Queue Inspector** shows failed items and recent queue activity from the current session.
+* **Retry All Failed** requeues everything currently stored in the failed list.
+* **Retry** on a single failed row requeues only that item.
+* **Clear Failed Queue** removes persisted failed items you no longer want Mimick to retry.
+* **Export Diagnostics** writes a bundle with `summary.txt`, `config.json`, `status.json`, `retries.json`, `synced_index.json`, and `mimick.log` when those files are available.
+
+### Network and Power-Aware Behavior
+
+If enabled in the **Behavior** section, Mimick can pause uploads automatically:
+
+* on metered connections, detected best-effort via `nmcli`
+* while running on battery power, detected best-effort from `/sys/class/power_supply`
+
+These options defer uploads rather than changing your watch configuration, so syncing resumes when conditions improve or when you manually resume.
 
 ---
 
@@ -196,6 +235,9 @@ flatpak run io.github.nicx17.mimick
 ## Documentation
 - [Troubleshooting](docs/TROUBLESHOOTING.md)
 - [User Guide](docs/USER_GUIDE.md)
+- [Configuration Guide](docs/CONFIGURATION.md)
+- [Development Guide](docs/DEVELOPMENT.md)
+- [Testing Guide](docs/TESTING.md)
 - [Security Policy](SECURITY.md)
 
 ## Trust and Verification

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,16 +15,19 @@ graph TD
         Main --> Monitor[File Monitor - notify crate]
         Main --> QueueManager[Queue Manager]
         Main --> SharedState["Arc&lt;Mutex&lt;AppState&gt;&gt; - in memory"]
+        Main --> RuntimeEnv[Runtime Environment Checks]
 
         Monitor -->|File Events + SHA-1| QueueManager
         QueueManager -->|3 async workers| API[Immich API Client - shared]
         QueueManager -->|Update directly| SharedState
+        QueueManager -->|Pause policy checks| RuntimeEnv
 
         API -->|LAN / WAN failover| Immich[(Immich Server)]
     end
 
     subgraph Settings UI [Settings Window - GTK4 / Libadwaita]
         Window[Settings Window - built once, hidden on close] -->|500ms timer - lock only| SharedState
+        Window -->|Diagnostics export| Diagnostics[diagnostics.rs]
     end
 
     Main -->|present / set_visible| Window
@@ -34,12 +37,15 @@ graph TD
         Keyring[System Keyring - secret-tool]
         RetryFile["retries.json (~/.cache/mimick/) - written on shutdown only"]
         StateFile["status.json (~/.cache/mimick/) - written on shutdown only"]
+        SyncIndex["synced_index.json (~/.cache/mimick/)"]
     end
 
     Window -->|Read/Write| Config
     Window -->|Read/Write| Keyring
     Main -->|Read on startup, Write on exit| StateFile
     QueueManager -->|Write on exit| RetryFile
+    Main -->|Read/Write| SyncIndex
+    Diagnostics -->|Copy selected files| Storage
 ```
 
 ## Component Details
@@ -57,6 +63,8 @@ Initializes the GTK4 `adw::Application` with ID `io.github.nicx17.mimick`. Only 
 Uses the `notify` crate for inotify-based filesystem events.
 
 - Filters to media extensions only
+- Applies per-folder rules before queueing files
+- Ignores temporary files until the final media filename exists
 - 2-second debounce per path
 - Per-file `wait_for_file_completion` (async, Tokio task — no OS thread per file)
 - SHA-1 checksum via 64KB chunked `spawn_blocking` (no load into RAM)
@@ -69,6 +77,8 @@ Thread-safe upload orchestrator using a single `Arc<Mutex<AppState>>` for all co
 - Workers update `AppState` directly in memory — no disk writes during uploads
 - **In-memory retry list** (`Arc<std::sync::Mutex<Vec<FileTask>>>`): retries on next successful upload (network recovery), flushed to disk only on graceful shutdown via `QueueManager::flush_retries()`
 - Reads persisted retries from disk on startup (crash recovery); re-queues after 5s delay
+- Supports manual `Pause / Resume`, `Sync Now`, queue inspection, per-item retry, retry-all, and failed-queue clearing
+- Records recent queue events and pause reasons in shared state for UI visibility and diagnostics
 - `QM_HANDLE: OnceLock<Arc<QueueManager>>` allows `main()` to call `flush_retries()` after `app.run()` returns
 
 ### 4. API Client (`src/api_client.rs`)
@@ -87,16 +97,28 @@ Thread-safe upload orchestrator using a single `Arc<Mutex<AppState>>` for all co
 - `Arc<Mutex<AppState>>` passed in directly; the 500ms `glib::timeout_add_local` timer reads it without any disk I/O
 - Album list fetched via the shared `Arc<ImmichApiClient>` on first show; a `glib::WeakRef` guard on the window ensures the async task returns early if the window is closed before the API responds
 - Test Connection button uses the shared client — no new reqwest pool per click
+- Uses a two-page `Setup` / `Controls` layout with a persistent footer for `Close`, `Quit`, and `Save & Restart`
+- Includes queue inspector, diagnostics export, per-folder rule editing, and manual sync controls
 
 ### 6. System Tray (`src/tray_icon.rs`)
 
 - Uses `ksni` (D-Bus StatusNotifierItem)
-- Clicking "Settings" sends `true` on a `tokio::sync::watch` channel — **no child process spawned**
+- Clicking tray actions sends signals back to the GTK main loop — **no child process spawned**
 - A `glib::timeout_add_local(250ms)` in the GTK main loop polls an `Arc<Mutex<bool>>` flag set by the Tokio watch-forward task; on trigger, calls `open_settings_if_needed` in-process
 
-### 7. State & Persistence
+### 7. Runtime Environment (`src/runtime_env.rs`)
 
-- **`AppState`**: in-memory struct shared by workers and UI via `Arc<Mutex<AppState>>`; `active_workers: usize` field (skipped in serde) tracks in-flight uploads for idle detection
+Best-effort helpers used by queue policy:
+
+- `nmcli` parsing to detect metered or guessed-metered connections
+- `/sys/class/power_supply` inspection to detect battery-powered operation
+
+These checks are advisory and only affect uploads when the corresponding behavior switches are enabled.
+
+### 8. State & Persistence
+
+- **`AppState`**: in-memory struct shared by workers and UI via `Arc<Mutex<AppState>>`; includes pause state, pause reason, last completed file, diagnostics export count, and recent queue events
 - **`StateManager`** (`src/state_manager.rs`): reads saved state on startup for crash recovery; writes on graceful shutdown only
 - **Retry queue**: in-memory during session; disk path `~/.cache/mimick/retries.json` written only on exit
+- **Sync index**: persisted at `~/.cache/mimick/synced_index.json` to skip unchanged files across restarts and to detect album-target changes
 - **Notifications**: `notify-send` via `std::process::Command::spawn()` + `child.wait()` (reaps child immediately, no zombies); called via `tokio::task::spawn_blocking` to avoid blocking the worker thread

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -6,15 +6,25 @@ This document covers all configurable aspects of `mimick`.
 
 The most convenient way to configure the application is via the built-in Settings Window.
 
+The window is divided into two pages:
+
+- **Setup** for configuration fields and watch-folder management
+- **Controls** for operational actions like sync, pause, queue inspection, and diagnostics export
+
 1. Right-click the **System Tray Icon**.
 2. Select **Settings**.
 3. Modify your Internal/External URLs and API key.
 4. Add or remove watch directories with the built-in folder picker.
-5. Toggle **Run on Startup** if you want Mimick to launch automatically after login.
-6. Click **Save & Restart**.
-7. Use **Close** to hide the window or **Quit** to exit the app entirely.
+5. Configure per-folder rules if you want to ignore hidden paths, cap upload size, or restrict extensions.
+6. Toggle **Run on Startup**, **Pause on Metered Network**, or **Pause on Battery Power** in the **Behavior** section.
+7. Use **Queue Inspector** to inspect failures and retry work without restarting.
+8. Use **Sync Now**, **Pause**, and **Export Diagnostics** for manual control and troubleshooting.
+9. Click **Save & Restart**.
+10. Use **Close** to hide the window or **Quit** to exit the app entirely.
 
 `Save & Restart` now relaunches Mimick after writing the updated configuration so new folder watches and connectivity settings take effect immediately.
+
+The footer keeps **Close**, **Quit**, and **Save & Restart** visible on both pages even when the content scrolls.
 
 The settings window close button behaves like **Close** and keeps the background daemon running.
 
@@ -34,13 +44,23 @@ The configuration is stored in a JSON file located at:
 {
     "watch_paths": [
         "/home/user/Pictures",
-        "/home/user/DCIM" 
+        {
+            "path": "/home/user/DCIM",
+            "album_name": "Phone Uploads",
+            "rules": {
+                "ignore_hidden": true,
+                "max_file_size_mb": 500,
+                "allowed_extensions": ["jpg", "png", "mp4"]
+            }
+        }
     ],
     "internal_url": "http://192.168.1.10:2283",
     "external_url": "https://immich.example.com",
     "internal_url_enabled": true,
     "external_url_enabled": true,
-    "run_on_startup": false
+    "run_on_startup": false,
+    "pause_on_metered_network": false,
+    "pause_on_battery_power": false
 }
 ```
 
@@ -48,12 +68,27 @@ The configuration is stored in a JSON file located at:
 
 | Key | Description | Example |
 | :--- | :--- | :--- |
-| `watch_paths` | A list of selected directories to monitor recursively. In Flatpak builds, these should be added from the settings window so portal access is granted; they may be stored as portal-backed paths under `/run/user/.../doc/...`. | `["/home/user/Screenshots"]` |
+| `watch_paths` | A list of selected directories to monitor recursively. Entries may be plain strings for older configs or objects containing `path`, optional album targeting fields, and `rules`. In Flatpak builds, add them from the settings window so portal access is granted; they may be stored as portal-backed paths under `/run/user/.../doc/...`. | `["/home/user/Screenshots"]` |
 | `internal_url` | The LAN IP/Hostname of your Immich instance. Used when local connectivity is detected. | `http://192.168.1.10:2283` |
 | `external_url` | The WAN/Public URL (reverse proxy). Used when away from home. | `https://photos.mydomain.com` |
 | `internal_url_enabled` | Toggle allowing the Daemon to attempt LAN connectivity. | `true` |
 | `external_url_enabled` | Toggle allowing the Daemon to attempt WAN connectivity. | `true` |
 | `run_on_startup` | Whether Mimick should register itself for automatic login startup. | `false` |
+| `pause_on_metered_network` | Whether uploads should pause while the active network connection appears metered. | `false` |
+| `pause_on_battery_power` | Whether uploads should pause while the system appears to be running on battery. | `false` |
+
+### `watch_paths` Object Form
+
+When a watch path is stored as an object, these fields can appear:
+
+| Key | Description |
+| :--- | :--- |
+| `path` | Absolute or portal-backed directory path being watched. |
+| `album_id` | Optional cached Immich album ID. |
+| `album_name` | Optional album name or user-entered target label. |
+| `rules.ignore_hidden` | Skip any file inside a hidden path component such as `.cache` or `.stfolder`. |
+| `rules.max_file_size_mb` | Optional maximum file size in megabytes. Files larger than this are skipped before queueing. |
+| `rules.allowed_extensions` | Optional allowlist of extensions. Values are normalized case-insensitively and leading dots are ignored. |
 
 ## Local State and Cache Files
 
@@ -62,6 +97,9 @@ In addition to `config.json`, Mimick stores runtime state in the user cache dire
 - `~/.cache/mimick/mimick.log`: rotating application logs with timestamps, levels, and source modules.
 - `~/.cache/mimick/retries.json`: queued retry items that could not be uploaded before shutdown.
 - `~/.cache/mimick/synced_index.json`: the local sync index used by startup rescans to skip already-synced unchanged files and detect album-target changes.
+- `~/.cache/mimick/status.json`: last saved application status written during graceful shutdown.
+
+Diagnostics exports copy these files into a timestamped `mimick-diagnostics-*` directory together with a generated `summary.txt` support report when the source files exist.
 
 ## API Key Security
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -46,6 +46,14 @@ This guide is for developers who want to contribute to `mimick`.
     cargo run -- --settings # Run and immediately open the settings window
     ```
 
+6. **Lint and Test Before Opening a PR:**
+
+    ```bash
+    cargo fmt --all -- --check
+    cargo clippy --all-targets --all-features -- -D warnings
+    cargo test
+    ```
+
 ## Logging and Debugging
 
 The application uses `flexi_logger`. 
@@ -60,10 +68,9 @@ RUST_LOG=debug cargo run
 
 ## Running Tests
 
-The project uses Rust's built-in testing framework. Most business logic (queue parsing, SHA1 calculators, path handlers) can be tested.
+The project uses Rust's built-in testing framework for configuration parsing, folder rules, queue-state bookkeeping, diagnostics export, monitor filtering, runtime environment parsing, and other non-UI behavior.
 
 ```bash
-# Run all unit tests
 cargo test
 ```
 
@@ -75,25 +82,38 @@ Unlike traditional Python/PySide loops, `mimick` is built on GTK4 and multi-thre
 2. `settings_window.rs`: Uses declarative GTK Builder pattern to construct the UI. The UI reads status via a shared `Arc<Mutex<AppState>>` memory lock rather than disk polling.
 3. GTK restricts all UI modifications to the main thread. To update the UI from async workers, use generic channels or `glib::timeout_add_local`.
 
+Recent operational features are spread across a few focused modules:
+
+- `queue_manager.rs`: upload workers, retry controls, pause/resume state, queue event recording
+- `state_manager.rs`: persisted app state plus recent queue-event history
+- `runtime_env.rs`: best-effort metered-network and battery-power detection
+- `diagnostics.rs`: support bundle export that omits secrets
+- `settings_window.rs`: queue inspector, diagnostics export, per-folder rule editing, and manual sync controls
+
 ## Packaging
 
 To test the final executable bundle via Flatpak:
 
 ```bash
-# Clean the build directory
-rm -rf build-dir
-# Build the flatpak
-flatpak-builder --user --install --force-clean build-dir io.github.nicx17.mimick.yml
+flatpak-builder --user --install --force-clean build-dir io.github.nicx17.mimick.local.yml
 ```
 
 Once installed, you can run it via your application menu or `flatpak run io.github.nicx17.mimick`.
 Note that modifying `Cargo.toml` or `Cargo.lock` requires you to re-run `uv run flatpak-cargo-generator.py Cargo.lock -o cargo-sources.json` so the Flatpak offline vendor set stays in sync.
+
+GitHub Actions currently mirrors the same native quality gate with:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --locked --all-targets --all-features -- -D warnings`
+- `cargo test --locked`
+
+The published Flatpak repository is built in a containerized Flatpak workflow rather than by installing Flatpak tooling directly on the host runner.
 
 ## Contributing Workflow
 
 1. **Fork** the repository.
 2. **Clone** your fork.
 3. Create a **feature branch**: `git checkout -b feature/my-new-feature`.
-4. Run `cargo clippy` to ensure your code matches Rust idioms.
+4. Run formatting, clippy, and tests locally.
 5. Commit your changes.
 6. Submit a **Pull Request**.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -20,6 +20,14 @@ To run the entire test suite simply execute:
 cargo test
 ```
 
+To mirror the main CI quality gate locally:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+```
+
 ### Checking Specific Modules
 You can target specific modules or functions:
 ```bash
@@ -38,19 +46,22 @@ Tests in Rust are written inline within identical files to the logic they test, 
 
 | Source File | Test Location | Description |
 | :--- | :--- | :--- |
-| `src/monitor.rs` | `mod tests` | Tests chunked SHA-1 generation (`compute_sha1_chunked`) for reliable and memory-safe deduplication. |
-| `src/config.rs` | `mod tests` | Tests JSON serde serialization/deserialization and default path resolutions. |
-| `src/queue_manager.rs` | N/A | Tests pending refactor for Tokio channel boundaries. |
+| `src/config.rs` | `mod tests` | Tests JSON serde behavior plus folder-rule matching, hidden-path filtering, and extension normalization. |
+| `src/monitor.rs` | `mod tests` | Tests monitor-side filtering such as temporary-file detection before queueing. |
+| `src/runtime_env.rs` | `mod tests` | Tests metered-network parsing and battery-power decision logic without depending on the host system. |
+| `src/diagnostics.rs` | `mod tests` | Tests support-summary generation and diagnostics bundle export contents. |
+| `src/state_manager.rs` | `mod tests` | Tests queue-event updates and event-history truncation rules. |
 
 ---
 
 ## 4. Current Coverage Gaps
 
-While core data structures and parsers are tested, the following areas currently have **limited coverage** and rely heavily on manual UI testing during development:
+While core data structures and support logic are tested, the following areas still have **limited coverage** and rely heavily on manual UI or integration testing during development:
 
-1.  **`src/settings_window.rs`**: GTK4 GUI views. Automated testing for GTK widgets requires specialized runners (like `xvfb`) and GTK main-loop integrations.
-2.  **`src/api_client.rs`**: Network endpoints. Testing requires mocking `reqwest` clients or firing against a live Immich sandbox instance.
-3.  **`src/main.rs` / `src/tray_icon.rs`**: Daemon lifecycle and D-Bus trait integrations. 
+1. **`src/settings_window.rs`**: GTK4/libadwaita UI interactions such as dialogs, queue inspector rendering, and per-folder rules editing.
+2. **`src/api_client.rs`**: Network endpoints still need deeper mocked or sandboxed Immich coverage.
+3. **`src/main.rs` / `src/tray_icon.rs`**: Full daemon lifecycle, tray signaling, and application-instance behavior remain mostly manual/integration tested.
+4. **`src/queue_manager.rs`**: Core behavior is exercised indirectly, but more direct async worker tests would still be valuable.
 
 ## 5. Writing New Tests
 
@@ -60,3 +71,4 @@ When adding a new feature, always consider creating a corresponding inline `#[te
 *   **Never hit the real network:** Use a mock HTTP responder if testing API consumers.
 *   **Never modify the real disk:** Use the `tempfile` crate (already in `[dev-dependencies]`) to create temporary, auto-cleaning directories for file I/O tests.
 *   **Keep them fast:** Do not inject artificial `tokio::time::sleep()` delays unless absolutely necessary for channel sync tests.
+*   **Prefer pure helpers for environment-sensitive logic:** Parse command output or power-supply state via helper functions so the behavior can be tested deterministically.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -24,6 +24,21 @@ If Immich re-uploads existing files:
 If you are running on a server without a desktop session (e.g., via SSH only), `secret-tool` might fail to unlock the login keyring.
 - **Solution:** Use `dbus-run-session` or configure `pam_gnome_keyring` to unlock on login.
 
+### 5. Mimick Stays Paused
+If uploads do not resume on their own:
+- Open the settings window and check the current status text. Mimick now records the pause reason.
+- If you manually paused it, use **Pause / Resume** from the tray or settings window.
+- If **Pause on Metered Network** is enabled, Mimick may pause while `nmcli` reports a metered or guessed-metered connection.
+- If **Pause on Battery Power** is enabled, Mimick may pause while the system appears to be running on battery according to `/sys/class/power_supply`.
+
+### 6. Files Never Enter the Queue
+If a file seems to be ignored completely:
+- Check the per-folder rules for that watch path.
+- Hidden files and files inside hidden directories can now be excluded intentionally.
+- Large files can be skipped by the max-size rule.
+- Extension allowlists only accept matching file extensions after normalization.
+- Temporary files are ignored until the final media filename appears.
+
 ## Logs & Diagnostics
 
 ### Clearing the Upload Queue (Local Cache)
@@ -44,6 +59,17 @@ The application writes rotating debug logs to `.cache`. If something breaks with
 tail -f ~/.cache/mimick/mimick.log
 ```
 Each log line includes a timestamp, level, and source module.
+
+### Export a Diagnostics Bundle
+If you need to file a bug or inspect the app state in one place, use **Export Diagnostics** from the settings window. The export creates a `mimick-diagnostics-*` folder containing:
+- `summary.txt`
+- `config.json`
+- `status.json`
+- `retries.json`
+- `synced_index.json`
+- `mimick.log`
+
+The generated summary omits the API key on purpose.
 
 ### Manual Debugging
 Run the application directly in a terminal to see `stdout` logs:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -15,6 +15,8 @@ Once the application is running, a blue "Immich" icon will appear in your system
 Clicking on the tray icon reveals a menu:
 
 * **Settings**: Opens the configuration and status window.
+* **Pause / Resume**: Temporarily stop uploads without quitting the app, then continue later.
+* **Sync Now**: Trigger an immediate rescan of watched folders and queue any eligible files right away.
 * **Quit**: Safely shuts down the application and stops all background syncing.
 
 You can also use the launcher action for **Quit Mimick** to stop the already-running app without opening the settings window.
@@ -26,6 +28,11 @@ You can also use the launcher action for **Quit Mimick** to stop the already-run
 ### Accessing Settings
 
 Right-click the tray icon and select **Settings**, or launch with `mimick --settings`.
+
+The settings window is split into two pages:
+
+* **Setup**: server details, behavior switches, watch folders, and folder rules
+* **Controls**: sync status, queue tools, pause/resume, manual sync, and diagnostics export
 
 ### Connectivity & Server Details
 
@@ -46,6 +53,10 @@ Right-click the tray icon and select **Settings**, or launch with `mimick --sett
 2. Select a local directory (e.g., `~/Pictures`, `~/Videos/Exports`).
 3. The application monitors these folders recursively.
 4. **Album Selection**: Each folder row has a dropdown to assign an Immich album. Choose an existing album, type a custom name (a new album will be created), or leave as "Default (Folder Name)" to auto-name from the folder.
+5. **Folder Rules**: Each folder can open a rules dialog for extra filtering:
+    * **Ignore hidden files and folders**
+    * **Maximum file size (MB)**
+    * **Allowed extensions** as a comma-separated allowlist like `jpg, png, mp4`
 
 Flatpak builds only have access to folders that you add through this picker. If you are upgrading from an older build that had wider filesystem access, remove and re-add existing watch folders once.
 
@@ -58,9 +69,16 @@ Use the **Run on Startup** switch in the **Behavior** section if you want Mimick
 * Flatpak builds ask the desktop for permission using the background portal.
 * Native builds create `~/.config/autostart/io.github.nicx17.mimick.desktop`.
 
+You can also enable:
+
+* **Pause on Metered Network**: Mimick defers uploads when the active connection appears metered.
+* **Pause on Battery Power**: Mimick defers uploads while the system appears to be running on battery.
+
 ### Saving Changes
 
 Click **Save & Restart** after changing settings. Mimick saves the updated configuration, closes the current instance, and launches a fresh one so the new watcher and connection settings take effect immediately.
+
+The footer keeps **Close**, **Quit**, and **Save & Restart** visible even if the current page needs scrolling.
 
 ### Closing vs Quitting
 
@@ -69,6 +87,42 @@ The settings window has separate actions for hiding the window and quitting the 
 * **Close** hides the settings window and keeps Mimick running in the background.
 * **Quit** fully exits Mimick.
 * The window titlebar close button behaves the same as **Close**.
+
+### Controls Page
+
+The **Controls** page groups the live actions you may want while Mimick is already running:
+
+* **Sync Now** to trigger an immediate watched-folder scan
+* **Pause / Resume** to stop and continue uploads manually
+* **Queue Inspector** for failure recovery
+* **Export Diagnostics** for support bundles
+
+### Queue Inspector and Recovery
+
+Inside it you can:
+
+* review recent queue events from the current session
+* see failed items waiting to be retried
+* retry one failed item
+* retry all failed items
+* clear the failed queue
+
+This is useful when a server outage, permission issue, or bad file temporarily blocks uploads.
+
+### Diagnostics Export
+
+Use **Export Diagnostics** in the settings window when you need a support snapshot.
+
+The export creates a timestamped `mimick-diagnostics-*` folder containing:
+
+* `summary.txt`
+* `config.json`
+* `status.json`
+* `retries.json`
+* `synced_index.json`
+* `mimick.log`
+
+The summary intentionally omits your API key.
 
 ---
 
@@ -103,10 +157,13 @@ Open the **Settings** window to see what is currently happening:
 
 * **Idle** — Nothing is uploading. Shows total processed count.
 * **Uploading** — Shows the current filename and a progress bar for the active batch.
+* **Paused** — Mimick is intentionally holding uploads. The UI shows the pause reason, such as a manual pause, metered network, or battery-power policy.
 
 ### Offline Reliability
 
 If an upload fails, the file is saved to `~/.cache/mimick/retries.json`. On the next launch, any persisted retries are automatically re-queued and uploaded.
+
+Files blocked by folder rules are skipped before they ever enter the queue. Temporary files are also ignored until the final media file exists.
 
 ---
 
@@ -120,6 +177,12 @@ Currently, Mimick ignores metadata sidecar files (`.xmp`, etc.). Immich has limi
 
 **Q: What happens if my server is offline?**
 The upload will fail gracefully and the file is saved to the retry queue (`~/.cache/mimick/retries.json`). On next launch, it will be automatically retried.
+
+**Q: Why is Mimick paused even though I did not click Pause?**
+Check the **Behavior** section. If **Pause on Metered Network** or **Pause on Battery Power** is enabled, Mimick can pause itself automatically when those conditions are detected.
+
+**Q: What does Sync Now do?**
+It reruns the watched-folder scan immediately so you do not need to restart Mimick to pick up missed or newly eligible files.
 
 **Q: The tray icon does not appear on GNOME.**
 GNOME requires the "AppIndicator and KStatusNotifierItem Support" extension. Install it from the GNOME Extensions website. Without it, the warning `Watcher(ServiceUnknown)` is expected and harmless — the app still runs fully in the background.

--- a/roadmap.md
+++ b/roadmap.md
@@ -55,18 +55,44 @@
 
 ## Planned
 
-### Next Up
+### Priority Now
 
-- [ ] **Fix bug** multiple settings window spawning. lock to single window
-- [ ] **Headless Operation** should operate without window being visible.. background process
+- [x] **Queue Inspector** — Failed items and recent queue activity are visible from the Controls page, with retry tools for recovery.
+- [x] **Retry Controls** — `Retry all`, single-item `Retry`, and `Clear failed queue` are available from the queue inspector.
+- [x] **Pause / Resume Sync** — Global pause works from the tray and settings window, with visible paused status and reason.
+- [x] **Sync Now** — Manual rescan is available from the Controls page and tray menu.
+- [x] **Per-Folder Rules** — Hidden-path filtering, extension allowlists, temp-file ignores, and optional max file size limits are supported.
+- [x] **Diagnostics Bundle** — Logs, config/state snapshots, and recent queue details can be exported into one support-friendly bundle.
+- [x] **Network / Power Awareness** — Uploads can defer on metered connections or while running on battery power.
 
-- [ ] **Flatpak manifest** — Flathub-ready packaging with `xdg-desktop-portal` filesystem constraints.
-- [ ] **Complete folder sync** — Two-way sync mode: toggle to sync remote deletions/additions back to local.
+### Next Wave
+
+- [ ] **Upload Limits** — User-configurable concurrency limit, bandwidth cap, and quiet hours.
+- [ ] **Notifications That Matter** — Summaries for sync success/failure, connectivity loss, permission loss, and album recreation events.
+- [ ] **Health Dashboard** — Show last successful sync, current server route, watched folder count, pending queue size, retry count, and latest error.
+- [ ] **Permission Health Checks** — Detect broken Flatpak portal access or lost folder permissions and guide the user to reauthorize them.
+- [ ] **Safer Startup Catch-Up Controls** — Let users choose full catch-up, recent-only catch-up, or new-files-only behavior.
+- [ ] **Per-Folder Status** — Track last sync time, pending count, target album, and last error per watch path.
+
+### UX Improvements
+
+- [ ] **First-Run Wizard** — Guided setup for server test, API key, first watch folder, and startup behavior.
+- [ ] **Better Album Picker** — Searchable album list, recent albums, inline create-new, and a clearer `use folder name` option.
+- [x] **Split Setup / Controls Window** — Separate configuration from live actions and keep footer actions visible while scrolling.
+- [ ] **Status in Tray** — Surface idle / syncing / paused / offline / error state directly in the tray menu and tooltip.
+- [ ] **Actionable Errors** — Translate generic failures into concrete guidance like invalid API key, missing album, network timeout, or folder access loss.
+- [ ] **Dry Run / Preview Mode** — Show what would be uploaded before enabling a new folder or changing rules.
+- [ ] **Verify Existing Remote State** — Audit a folder against the local sync index and highlight drift or mismatches.
+
+### Platform & Packaging
+
+- [ ] **Flatpak manifest hardening** — Keep improving portal-first packaging and release reliability for the hosted Flatpak repo.
 - [ ] **Arch AUR submission** — Publish PKGBUILD to AUR as `mimick`.
-
-### Future
-- [ ] **Exponential backoff** on retries (currently immediate re-queue on next launch).
-- [ ] **Progress notification** — Native desktop notification with upload count, not just log.
-- [ ] **Tray icon dynamic states** — Distinct icons for idle / uploading / error.
-- [ ] **Selective sync** — File type filter toggles per watch folder in the UI.
 - [ ] **ARM64 AppImage** — Cross-compile and package for Raspberry Pi / ARM desktops.
+
+### Longer-Term Product Ideas
+
+- [ ] **Complete folder sync** — Optional two-way sync mode that can reflect remote additions or deletions locally.
+- [ ] **Exponential backoff** — Smarter retry scheduling instead of immediate replay on restart.
+- [ ] **Progress notifications** — Desktop notifications with counts and outcomes, not just logs.
+- [ ] **Tray icon dynamic states** — Distinct icons for idle, syncing, paused, and error conditions.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,66 @@
 
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
+
+/// Per-folder filters and guardrails applied before a file is queued for upload.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct FolderRules {
+    #[serde(default)]
+    pub ignore_hidden: bool,
+    #[serde(default)]
+    pub max_file_size_mb: Option<u64>,
+    #[serde(default)]
+    pub allowed_extensions: Vec<String>,
+}
+
+impl FolderRules {
+    pub fn normalized_extensions(&self) -> Vec<String> {
+        self.allowed_extensions
+            .iter()
+            .map(|ext| ext.trim().trim_start_matches('.').to_ascii_lowercase())
+            .filter(|ext| !ext.is_empty())
+            .collect()
+    }
+
+    pub fn matches(&self, path: &Path) -> bool {
+        if self.ignore_hidden
+            && path.components().any(|component| {
+                component
+                    .as_os_str()
+                    .to_str()
+                    .map(|part| part.starts_with('.') && part.len() > 1)
+                    .unwrap_or(false)
+            })
+        {
+            return false;
+        }
+
+        if let Some(limit_mb) = self.max_file_size_mb
+            && let Ok(metadata) = std::fs::metadata(path)
+            && metadata.len() > limit_mb.saturating_mul(1024 * 1024)
+        {
+            return false;
+        }
+
+        let normalized = self.normalized_extensions();
+        if !normalized.is_empty() {
+            let ext = path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext.to_ascii_lowercase());
+            if ext
+                .as_deref()
+                .is_none_or(|ext| !normalized.iter().any(|allowed| allowed == ext))
+            {
+                return false;
+            }
+        }
+
+        true
+    }
+}
 
 /// A watch path entry stored in config.
 ///
@@ -18,6 +77,8 @@ pub enum WatchPathEntry {
         album_id: Option<String>,
         #[serde(default)]
         album_name: Option<String>,
+        #[serde(default)]
+        rules: FolderRules,
     },
 }
 
@@ -41,6 +102,13 @@ impl WatchPathEntry {
             WatchPathEntry::WithConfig { album_name, .. } => album_name.as_deref(),
         }
     }
+
+    pub fn rules(&self) -> FolderRules {
+        match self {
+            WatchPathEntry::Simple(_) => FolderRules::default(),
+            WatchPathEntry::WithConfig { rules, .. } => rules.clone(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -61,6 +129,10 @@ pub struct ConfigData {
     pub album_sync: bool,
     #[serde(default)]
     pub delete_after_sync: bool,
+    #[serde(default)]
+    pub pause_on_metered_network: bool,
+    #[serde(default)]
+    pub pause_on_battery_power: bool,
 }
 
 impl Default for ConfigData {
@@ -74,6 +146,8 @@ impl Default for ConfigData {
             run_on_startup: false,
             album_sync: false,
             delete_after_sync: false,
+            pause_on_metered_network: false,
+            pause_on_battery_power: false,
         }
     }
 }
@@ -250,6 +324,7 @@ mod tests {
             path: "/b".into(),
             album_id: None,
             album_name: None,
+            rules: FolderRules::default(),
         });
 
         let config = Config {
@@ -259,5 +334,54 @@ mod tests {
 
         let strings = config.watch_path_strings();
         assert_eq!(strings, vec!["/a".to_string(), "/b".to_string()]);
+    }
+
+    #[test]
+    fn test_folder_rules_match_extension_and_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("photo.jpg");
+        fs::write(&path, vec![0u8; 1024]).unwrap();
+
+        let rules = FolderRules {
+            ignore_hidden: false,
+            max_file_size_mb: Some(1),
+            allowed_extensions: vec!["jpg".into(), "png".into()],
+        };
+
+        assert!(rules.matches(&path));
+
+        let restricted = FolderRules {
+            ignore_hidden: false,
+            max_file_size_mb: Some(0),
+            allowed_extensions: vec!["png".into()],
+        };
+
+        assert!(!restricted.matches(&path));
+    }
+
+    #[test]
+    fn test_folder_rules_ignore_hidden_path_components() {
+        let dir = tempfile::tempdir().unwrap();
+        let hidden_dir = dir.path().join(".hidden");
+        fs::create_dir_all(&hidden_dir).unwrap();
+        let hidden_file = hidden_dir.join("photo.jpg");
+        fs::write(&hidden_file, vec![0u8; 16]).unwrap();
+
+        let rules = FolderRules {
+            ignore_hidden: true,
+            ..FolderRules::default()
+        };
+
+        assert!(!rules.matches(&hidden_file));
+    }
+
+    #[test]
+    fn test_normalized_extensions_trims_and_lowercases() {
+        let rules = FolderRules {
+            allowed_extensions: vec![" JPG ".into(), ".PNG".into(), "".into()],
+            ..FolderRules::default()
+        };
+
+        assert_eq!(rules.normalized_extensions(), vec!["jpg", "png"]);
     }
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,191 @@
+//! Export a support-friendly diagnostics bundle without including secrets.
+
+use crate::config::Config;
+use crate::state_manager::AppState;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn export_bundle(destination_root: &Path, state: &AppState) -> io::Result<PathBuf> {
+    let config = Config::new();
+    let cache_root = dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("mimick");
+    export_bundle_with_paths(destination_root, state, &config, &cache_root)
+}
+
+fn export_bundle_with_paths(
+    destination_root: &Path,
+    state: &AppState,
+    config: &Config,
+    cache_root: &Path,
+) -> io::Result<PathBuf> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let bundle_dir = destination_root.join(format!("mimick-diagnostics-{}", timestamp));
+    fs::create_dir_all(&bundle_dir)?;
+
+    let summary_path = bundle_dir.join("summary.txt");
+    fs::write(summary_path, build_summary(config, state))?;
+
+    copy_if_exists(&config.config_file, &bundle_dir.join("config.json"))?;
+    copy_if_exists(
+        &cache_path(cache_root, "status.json"),
+        &bundle_dir.join("status.json"),
+    )?;
+    copy_if_exists(
+        &cache_path(cache_root, "retries.json"),
+        &bundle_dir.join("retries.json"),
+    )?;
+    copy_if_exists(
+        &cache_path(cache_root, "synced_index.json"),
+        &bundle_dir.join("synced_index.json"),
+    )?;
+    copy_if_exists(
+        &cache_path(cache_root, "mimick.log"),
+        &bundle_dir.join("mimick.log"),
+    )?;
+
+    Ok(bundle_dir)
+}
+
+fn build_summary(config: &Config, state: &AppState) -> String {
+    let mut lines = Vec::new();
+    lines.push("Mimick diagnostics export".to_string());
+    lines.push(format!("Version: {}", env!("CARGO_PKG_VERSION")));
+    lines.push(format!("App status: {}", state.status));
+    lines.push(format!("Paused: {}", state.paused));
+    lines.push(format!(
+        "Pause reason: {}",
+        state.pause_reason.as_deref().unwrap_or("none")
+    ));
+    lines.push(format!("Queue size: {}", state.queue_size));
+    lines.push(format!("Processed count: {}", state.processed_count));
+    lines.push(format!("Failed count: {}", state.failed_count));
+    lines.push(format!(
+        "Current file: {}",
+        state.current_file.as_deref().unwrap_or("none")
+    ));
+    lines.push(format!(
+        "Last completed file: {}",
+        state.last_completed_file.as_deref().unwrap_or("none")
+    ));
+    lines.push(format!(
+        "Last error: {}",
+        state.last_error.as_deref().unwrap_or("none")
+    ));
+    lines.push(format!(
+        "Configured watch paths: {}",
+        config.data.watch_paths.len()
+    ));
+    lines.push(format!(
+        "Pause on metered network: {}",
+        config.data.pause_on_metered_network
+    ));
+    lines.push(format!(
+        "Pause on battery power: {}",
+        config.data.pause_on_battery_power
+    ));
+    lines.push("API key: omitted".to_string());
+    lines.push(String::new());
+    lines.push("Recent queue events:".to_string());
+    for event in &state.recent_events {
+        lines.push(format!(
+            "- {} [{}] attempts={} detail={}",
+            event.path,
+            event.status,
+            event.attempts,
+            event.detail.as_deref().unwrap_or("none")
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn copy_if_exists(from: &Path, to: &Path) -> io::Result<()> {
+    if from.exists() {
+        fs::copy(from, to)?;
+    }
+    Ok(())
+}
+
+fn cache_path(cache_root: &Path, name: &str) -> PathBuf {
+    cache_root.join(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_summary, export_bundle_with_paths};
+    use crate::config::{Config, ConfigData, WatchPathEntry};
+    use crate::state_manager::{AppState, QueueEvent};
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_build_summary_contains_recent_events_and_omits_api_key() {
+        let config = Config {
+            data: ConfigData {
+                watch_paths: vec![WatchPathEntry::Simple("/photos".into())],
+                pause_on_metered_network: true,
+                pause_on_battery_power: false,
+                ..ConfigData::default()
+            },
+            config_file: PathBuf::from("config.json"),
+        };
+        let mut state = AppState {
+            status: "paused".into(),
+            paused: true,
+            pause_reason: Some("Paused by user".into()),
+            ..AppState::default()
+        };
+        state.recent_events.push(QueueEvent {
+            path: "/photos/a.jpg".into(),
+            status: "failed".into(),
+            detail: Some("Queued for retry".into()),
+            attempts: 2,
+            timestamp: 1.0,
+        });
+
+        let summary = build_summary(&config, &state);
+        assert!(summary.contains("App status: paused"));
+        assert!(summary.contains("Configured watch paths: 1"));
+        assert!(summary.contains("API key: omitted"));
+        assert!(summary.contains("/photos/a.jpg [failed] attempts=2"));
+    }
+
+    #[test]
+    fn test_export_bundle_writes_summary_and_cache_files() {
+        let dir = tempdir().unwrap();
+        let dest_root = dir.path().join("exports");
+        let cache_root = dir.path().join("cache");
+        let config_root = dir.path().join("config");
+        fs::create_dir_all(&cache_root).unwrap();
+        fs::create_dir_all(&config_root).unwrap();
+
+        let config_path = config_root.join("config.json");
+        fs::write(&config_path, "{\"internal_url\":\"http://localhost\"}").unwrap();
+        fs::write(cache_root.join("status.json"), "{\"status\":\"idle\"}").unwrap();
+        fs::write(cache_root.join("retries.json"), "[]").unwrap();
+        fs::write(cache_root.join("synced_index.json"), "{\"files\":{}}").unwrap();
+        fs::write(cache_root.join("mimick.log"), "hello log").unwrap();
+
+        let config = Config {
+            data: ConfigData::default(),
+            config_file: config_path,
+        };
+        let state = AppState::default();
+
+        let bundle_dir =
+            export_bundle_with_paths(&dest_root, &state, &config, &cache_root).unwrap();
+        assert!(bundle_dir.join("summary.txt").exists());
+        assert!(bundle_dir.join("config.json").exists());
+        assert!(bundle_dir.join("status.json").exists());
+        assert!(bundle_dir.join("retries.json").exists());
+        assert!(bundle_dir.join("synced_index.json").exists());
+        assert!(bundle_dir.join("mimick.log").exists());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,12 @@ use tokio::sync::mpsc;
 mod api_client;
 mod autostart;
 mod config;
+mod diagnostics;
 mod monitor;
 mod notifications;
 mod queue_manager;
 mod restart;
+mod runtime_env;
 mod settings_window;
 mod startup_scan;
 mod state_manager;
@@ -23,7 +25,7 @@ mod watch_path_display;
 use api_client::ImmichApiClient;
 use config::Config;
 use monitor::Monitor;
-use queue_manager::{FileTask, QueueManager};
+use queue_manager::{EnvironmentPolicy, FileTask, QueueManager};
 use restart::{launch_replacement, take_restart_request};
 use settings_window::build_settings_window;
 use startup_scan::queue_unsynced_files;
@@ -37,6 +39,9 @@ use flexi_logger::{FileSpec, Logger, WriteMode, colored_detailed_format, detaile
 static QM_HANDLE: std::sync::OnceLock<Arc<QueueManager>> = std::sync::OnceLock::new();
 /// Shared API client reused by the settings window and startup scan.
 static API_CLIENT_HANDLE: std::sync::OnceLock<Arc<ImmichApiClient>> = std::sync::OnceLock::new();
+/// Requests an immediate startup-style catch-up scan from UI or tray controls.
+static MANUAL_SYNC_TX: std::sync::OnceLock<tokio::sync::mpsc::UnboundedSender<()>> =
+    std::sync::OnceLock::new();
 
 #[tokio::main]
 async fn main() {
@@ -124,12 +129,15 @@ async fn main() {
             3,
             shared_state_startup.clone(),
             sync_index.clone(),
+            EnvironmentPolicy {
+                pause_on_metered_network: config.data.pause_on_metered_network,
+                pause_on_battery_power: config.data.pause_on_battery_power,
+            },
         ));
 
         // Start the live filesystem watcher immediately.
         let (tx, mut rx) = mpsc::channel(32);
-        let watch_paths = config.watch_path_strings();
-        let monitor = Monitor::new(watch_paths);
+        let monitor = Monitor::new(config.data.watch_paths.clone());
         monitor.start(tx);
         log::info!("File monitor started");
 
@@ -148,6 +156,7 @@ async fn main() {
                         path: base,
                         album_id: aid,
                         album_name: aname,
+                        ..
                     } = entry
                         && path.starts_with(base.as_str())
                     {
@@ -174,7 +183,7 @@ async fn main() {
         let startup_sync_index = sync_index.clone();
 
         // Retain the queue manager so the shutdown path can flush retries to disk.
-        let _ = QM_HANDLE.set(qm);
+        let _ = QM_HANDLE.set(qm.clone());
 
         // The startup scan backfills anything that arrived while Mimick was not running.
         tokio::spawn(async move {
@@ -183,6 +192,27 @@ async fn main() {
                 .cloned()
                 .expect("API client should be initialized before startup scan");
             queue_unsynced_files(startup_paths, startup_qm, startup_sync_index, startup_api).await;
+        });
+
+        let (manual_sync_tx, mut manual_sync_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+        let _ = MANUAL_SYNC_TX.set(manual_sync_tx);
+        let manual_qm = qm.clone();
+        let manual_sync_index = sync_index.clone();
+        tokio::spawn(async move {
+            while manual_sync_rx.recv().await.is_some() {
+                let config = Config::new();
+                let api = API_CLIENT_HANDLE
+                    .get()
+                    .cloned()
+                    .expect("API client should be initialized before manual sync");
+                queue_unsynced_files(
+                    config.data.watch_paths.clone(),
+                    manual_qm.clone(),
+                    manual_sync_index.clone(),
+                    api,
+                )
+                .await;
+            }
         });
 
         let app_clone2 = app.clone();
@@ -195,6 +225,10 @@ async fn main() {
         let settings_flag_writer = settings_flag.clone(); // moves into tokio::spawn (Send ✓)
         let quit_flag = Arc::new(std::sync::Mutex::new(false));
         let quit_flag_writer = quit_flag.clone(); // moves into tokio::spawn (Send ✓)
+        let pause_flag = Arc::new(std::sync::Mutex::new(false));
+        let pause_flag_writer = pause_flag.clone();
+        let sync_now_flag = Arc::new(std::sync::Mutex::new(false));
+        let sync_now_flag_writer = sync_now_flag.clone();
 
         // GTK-side: poll the flag every 250ms on the main thread.
         // app_clone2 / shared_state2 are !Send — they stay here, never enter spawns.
@@ -210,7 +244,15 @@ async fn main() {
             };
             if settings_triggered {
                 let client = API_CLIENT_HANDLE.get().cloned();
-                open_settings_if_needed(&app_clone2, shared_state2.clone(), client);
+                let qm = QM_HANDLE.get().cloned();
+                let sync_now_tx = MANUAL_SYNC_TX.get().cloned();
+                open_settings_if_needed(
+                    &app_clone2,
+                    shared_state2.clone(),
+                    client,
+                    qm,
+                    sync_now_tx,
+                );
             }
 
             let quit_triggered = {
@@ -227,6 +269,38 @@ async fn main() {
                 return glib::ControlFlow::Break;
             }
 
+            let pause_triggered = {
+                let mut f = pause_flag.lock().unwrap();
+                if *f {
+                    *f = false;
+                    true
+                } else {
+                    false
+                }
+            };
+            if pause_triggered && let Some(qm) = QM_HANDLE.get() {
+                let paused = !qm.is_paused();
+                let reason = if paused {
+                    Some("Paused by user".to_string())
+                } else {
+                    None
+                };
+                qm.set_paused(paused, reason);
+            }
+
+            let sync_now_triggered = {
+                let mut f = sync_now_flag.lock().unwrap();
+                if *f {
+                    *f = false;
+                    true
+                } else {
+                    false
+                }
+            };
+            if sync_now_triggered && let Some(tx) = MANUAL_SYNC_TX.get() {
+                let _ = tx.send(());
+            }
+
             glib::ControlFlow::Continue
         });
 
@@ -235,26 +309,44 @@ async fn main() {
         tokio::spawn(async move {
             log::info!("Starting system tray");
             match build_tray().await {
-                Ok((_handle, mut settings_rx, mut quit_rx)) => loop {
-                    tokio::select! {
-                        res = settings_rx.changed() => {
-                            if res.is_err() {
-                                break;
+                Ok((_handle, mut settings_rx, mut quit_rx, mut pause_rx, mut sync_now_rx)) => {
+                    loop {
+                        tokio::select! {
+                            res = settings_rx.changed() => {
+                                if res.is_err() {
+                                    break;
+                                }
+                                if *settings_rx.borrow() {
+                                    *settings_flag_writer.lock().unwrap() = true;
+                                }
                             }
-                            if *settings_rx.borrow() {
-                                *settings_flag_writer.lock().unwrap() = true;
+                            res = quit_rx.changed() => {
+                                if res.is_err() {
+                                    break;
+                                }
+                                if *quit_rx.borrow() {
+                                    *quit_flag_writer.lock().unwrap() = true;
+                                }
                             }
-                        }
-                        res = quit_rx.changed() => {
-                            if res.is_err() {
-                                break;
+                            res = pause_rx.changed() => {
+                                if res.is_err() {
+                                    break;
+                                }
+                                if *pause_rx.borrow() {
+                                    *pause_flag_writer.lock().unwrap() = true;
+                                }
                             }
-                            if *quit_rx.borrow() {
-                                *quit_flag_writer.lock().unwrap() = true;
+                            res = sync_now_rx.changed() => {
+                                if res.is_err() {
+                                    break;
+                                }
+                                if *sync_now_rx.borrow() {
+                                    *sync_now_flag_writer.lock().unwrap() = true;
+                                }
                             }
                         }
                     }
-                },
+                }
                 Err(e) => log::warn!("System tray failed to start: {:?}", e),
             }
         });
@@ -281,7 +373,9 @@ async fn main() {
 
         if open_settings {
             let client = API_CLIENT_HANDLE.get().cloned();
-            open_settings_if_needed(app, shared_state_cmdline.clone(), client);
+            let qm = QM_HANDLE.get().cloned();
+            let sync_now_tx = MANUAL_SYNC_TX.get().cloned();
+            open_settings_if_needed(app, shared_state_cmdline.clone(), client, qm, sync_now_tx);
         }
 
         app.activate();
@@ -317,11 +411,13 @@ fn open_settings_if_needed(
     app: &adw::Application,
     shared_state: Arc<Mutex<AppState>>,
     api_client: Option<Arc<ImmichApiClient>>,
+    queue_manager: Option<Arc<QueueManager>>,
+    sync_now_tx: Option<tokio::sync::mpsc::UnboundedSender<()>>,
 ) {
     if let Some(win) = app.windows().first() {
         win.present();
     } else {
         log::debug!("Opening settings window");
-        build_settings_window(app, shared_state, api_client);
+        build_settings_window(app, shared_state, api_client, queue_manager, sync_now_tx);
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,5 +1,6 @@
 //! Live filesystem monitoring, file-settling checks, and checksum generation.
 
+use crate::config::WatchPathEntry;
 use crate::watch_path_display::display_watch_path;
 use notify::{Config as NotifyConfig, EventKind, PollWatcher, RecursiveMode, Watcher};
 use sha1::{Digest, Sha1};
@@ -22,11 +23,11 @@ const IDLE_TIMEOUT_SECS: u64 = 300;
 const FLATPAK_POLL_INTERVAL_MS: u64 = 2000;
 
 pub struct Monitor {
-    watch_paths: Vec<String>,
+    watch_paths: Vec<WatchPathEntry>,
 }
 
 impl Monitor {
-    pub fn new(watch_paths: Vec<String>) -> Self {
+    pub fn new(watch_paths: Vec<WatchPathEntry>) -> Self {
         Self { watch_paths }
     }
 
@@ -46,18 +47,18 @@ impl Monitor {
             };
 
             let mut any_watching = false;
-            for path in &watch_paths {
-                let p = Path::new(path);
+            for entry in &watch_paths {
+                let p = Path::new(entry.path());
                 if p.exists() {
                     match watcher.watch(p, RecursiveMode::Recursive) {
                         Ok(_) => {
-                            log::info!("Watching: {}", display_watch_path(path));
+                            log::info!("Watching: {}", display_watch_path(entry.path()));
                             any_watching = true;
                         }
-                        Err(e) => log::warn!("Failed to watch '{}': {:?}", path, e),
+                        Err(e) => log::warn!("Failed to watch '{}': {:?}", entry.path(), e),
                     }
                 } else {
-                    log::warn!("Watch path does not exist, skipping: {}", path);
+                    log::warn!("Watch path does not exist, skipping: {}", entry.path());
                 }
             }
 
@@ -98,6 +99,13 @@ impl Monitor {
                                 }
 
                                 let path_str = path.to_string_lossy().into_owned();
+                                if is_temporary_file(&path)
+                                    || !matching_entry_for_path(&path_str, &watch_paths)
+                                        .map(|entry| entry.rules().matches(&path))
+                                        .unwrap_or(true)
+                                {
+                                    continue;
+                                }
 
                                 // Bail immediately if we're already waiting on this file to finish.
                                 if active_tasks.lock().unwrap().contains(&path_str) {
@@ -258,10 +266,34 @@ pub(crate) fn is_supported_media_path(path: &Path) -> bool {
     MEDIA_EXTENSIONS.contains(&ext_str)
 }
 
+pub(crate) fn is_temporary_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| {
+            let name = name.to_ascii_lowercase();
+            name.ends_with(".tmp")
+                || name.ends_with(".part")
+                || name.ends_with(".crdownload")
+                || name.ends_with('~')
+        })
+        .unwrap_or(false)
+}
+
+fn matching_entry_for_path<'a>(
+    path: &str,
+    entries: &'a [WatchPathEntry],
+) -> Option<&'a WatchPathEntry> {
+    entries
+        .iter()
+        .filter(|entry| path.starts_with(entry.path()))
+        .max_by_key(|entry| entry.path().len())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{compute_sha1_chunked, is_flatpak_sandbox};
+    use super::{compute_sha1_chunked, is_flatpak_sandbox, is_temporary_file};
     use std::io::Write;
+    use std::path::Path;
     use tempfile::NamedTempFile;
 
     #[test]
@@ -277,5 +309,13 @@ mod tests {
     #[test]
     fn test_flatpak_detection_is_false_in_unit_tests() {
         assert!(!is_flatpak_sandbox());
+    }
+
+    #[test]
+    fn test_temporary_file_detection() {
+        assert!(is_temporary_file(Path::new("/tmp/video.mp4.part")));
+        assert!(is_temporary_file(Path::new("/tmp/upload.jpg.tmp")));
+        assert!(is_temporary_file(Path::new("/tmp/image.png~")));
+        assert!(!is_temporary_file(Path::new("/tmp/final.jpg")));
     }
 }

--- a/src/queue_manager.rs
+++ b/src/queue_manager.rs
@@ -2,6 +2,7 @@
 
 use crate::api_client::ImmichApiClient;
 use crate::notifications;
+use crate::runtime_env;
 use crate::state_manager::AppState;
 use crate::sync_index::{SyncIndex, SyncTarget};
 use std::collections::HashSet;
@@ -40,12 +41,19 @@ pub struct QueueManager {
     retry_path: PathBuf,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct EnvironmentPolicy {
+    pub pause_on_metered_network: bool,
+    pub pause_on_battery_power: bool,
+}
+
 impl QueueManager {
     pub fn new(
         api_client: Arc<ImmichApiClient>,
         workers: usize,
         shared_state: Arc<std::sync::Mutex<AppState>>,
         sync_index: Arc<std::sync::Mutex<SyncIndex>>,
+        policy: EnvironmentPolicy,
     ) -> Self {
         let (tx, rx) = mpsc::channel::<FileTask>(64);
         let rx = Arc::new(Mutex::new(rx));
@@ -105,11 +113,14 @@ impl QueueManager {
 
                     match task {
                         Some(file_task) => {
+                            wait_until_allowed(&state_ref, policy).await;
+
                             // Update the shared progress snapshot before handing off to the API.
                             let (pc, tq) = {
                                 let mut s = state_ref.lock().unwrap();
                                 s.active_workers += 1;
                                 s.status = "uploading".to_string();
+                                s.pause_reason = None;
                                 s.current_file = Some(file_task.path.clone());
                                 s.queue_size = s.total_queued.saturating_sub(s.processed_count);
                                 s.progress = if s.total_queued > 0 {
@@ -118,6 +129,8 @@ impl QueueManager {
                                 } else {
                                     0
                                 };
+                                let attempts = current_attempt_count(&s, &file_task.path);
+                                s.record_event(file_task.path.clone(), "uploading", None, attempts);
                                 (s.processed_count, s.total_queued)
                             };
 
@@ -173,6 +186,17 @@ impl QueueManager {
                                         let _ = tx_clone.send(t).await;
                                     }
                                 }
+
+                                let mut s = state_ref.lock().unwrap();
+                                let attempts = current_attempt_count(&s, &file_task.path);
+                                s.last_completed_file = Some(file_task.path.clone());
+                                s.last_error = None;
+                                s.record_event(
+                                    file_task.path.clone(),
+                                    "completed",
+                                    Some(format!("Finished in {:.2}s", elapsed)),
+                                    attempts,
+                                );
                             } else {
                                 log::warn!(
                                     "Upload FAILED: {} ({:.2}s). Adding to retry queue.",
@@ -180,9 +204,18 @@ impl QueueManager {
                                     elapsed
                                 );
                                 // Keep failed tasks in memory until the next graceful shutdown.
-                                retry_ref.lock().unwrap().push(file_task);
+                                retry_ref.lock().unwrap().push(file_task.clone());
                                 let mut s = state_ref.lock().unwrap();
                                 s.failed_count += 1;
+                                s.last_error =
+                                    Some(format!("Upload failed for {}", file_task.path));
+                                let attempts = current_attempt_count(&s, &file_task.path);
+                                s.record_event(
+                                    file_task.path.clone(),
+                                    "failed",
+                                    Some("Queued for retry".to_string()),
+                                    attempts,
+                                );
                             }
 
                             // Update processed count and determine idle state.
@@ -194,7 +227,11 @@ impl QueueManager {
 
                                 if s.processed_count >= s.total_queued && s.active_workers == 0 {
                                     s.queue_size = 0;
-                                    s.status = "idle".to_string();
+                                    s.status = if s.paused {
+                                        "paused".to_string()
+                                    } else {
+                                        "idle".to_string()
+                                    };
                                     s.progress = 100;
                                     log::info!("All {} file(s) processed. Idle.", s.total_queued);
                                     Some(format!(
@@ -269,6 +306,15 @@ impl QueueManager {
             let mut s = self.shared_state.lock().unwrap();
             s.total_queued += 1;
             s.queue_size = s.total_queued.saturating_sub(s.processed_count);
+            let attempts = current_attempt_count(&s, &task.path);
+            s.record_event(
+                task.path.clone(),
+                "pending",
+                task.album_name
+                    .clone()
+                    .map(|name| format!("Target album: {}", name)),
+                attempts,
+            );
         }
         if let Err(e) = self.sender.send(task).await {
             log::error!("Failed to send task to queue: {}", e);
@@ -284,6 +330,86 @@ impl QueueManager {
         true
     }
 
+    pub fn set_paused(&self, paused: bool, reason: Option<String>) {
+        let mut state = self.shared_state.lock().unwrap();
+        state.paused = paused;
+        state.pause_reason = reason;
+        state.status = if paused {
+            "paused".to_string()
+        } else if state.active_workers > 0 {
+            "uploading".to_string()
+        } else {
+            "idle".to_string()
+        };
+    }
+
+    pub fn is_paused(&self) -> bool {
+        self.shared_state.lock().unwrap().paused
+    }
+
+    pub fn recent_events(&self) -> Vec<crate::state_manager::QueueEvent> {
+        self.shared_state.lock().unwrap().recent_events.clone()
+    }
+
+    pub fn failed_tasks(&self) -> Vec<FileTask> {
+        self.retry_list.lock().unwrap().clone()
+    }
+
+    pub fn clear_failed(&self) -> usize {
+        let tasks = {
+            let mut retries = self.retry_list.lock().unwrap();
+            std::mem::take(&mut *retries)
+        };
+        if tasks.is_empty() {
+            return 0;
+        }
+
+        {
+            let mut pending = self.pending_paths.lock().unwrap();
+            for task in &tasks {
+                pending.remove(&task.path);
+            }
+        }
+
+        let mut state = self.shared_state.lock().unwrap();
+        state.failed_count = state.failed_count.saturating_sub(tasks.len());
+        for task in &tasks {
+            let attempts = current_attempt_count(&state, &task.path);
+            state.record_event(
+                task.path.clone(),
+                "cleared",
+                Some("Removed from retry queue".to_string()),
+                attempts,
+            );
+        }
+
+        tasks.len()
+    }
+
+    pub async fn retry_all_failed(&self) -> usize {
+        let tasks = {
+            let mut retries = self.retry_list.lock().unwrap();
+            std::mem::take(&mut *retries)
+        };
+        self.requeue_failed(tasks, "Manual retry".to_string()).await
+    }
+
+    pub async fn retry_failed_path(&self, path: &str) -> bool {
+        let task = {
+            let mut retries = self.retry_list.lock().unwrap();
+            let index = retries.iter().position(|task| task.path == path);
+            index.map(|index| retries.remove(index))
+        };
+
+        if let Some(task) = task {
+            self.requeue_failed(vec![task], "Manual retry".to_string())
+                .await
+                > 0
+        } else {
+            false
+        }
+    }
+
     /// Persist any in-memory retry items so they survive a clean shutdown.
     pub fn flush_retries(&self) {
         let retries = self.retry_list.lock().unwrap();
@@ -294,6 +420,79 @@ impl QueueManager {
                 retries.len()
             );
         }
+    }
+
+    async fn requeue_failed(&self, tasks: Vec<FileTask>, detail: String) -> usize {
+        if tasks.is_empty() {
+            return 0;
+        }
+
+        {
+            let mut state = self.shared_state.lock().unwrap();
+            state.failed_count = state.failed_count.saturating_sub(tasks.len());
+            state.total_queued += tasks.len();
+            state.queue_size = state.total_queued.saturating_sub(state.processed_count);
+            for task in &tasks {
+                let attempts = current_attempt_count(&state, &task.path).saturating_add(1);
+                state.record_event(task.path.clone(), "pending", Some(detail.clone()), attempts);
+            }
+        }
+
+        let mut queued = 0usize;
+        for task in tasks {
+            if self.sender.send(task).await.is_ok() {
+                queued += 1;
+            }
+        }
+        queued
+    }
+}
+
+fn current_attempt_count(state: &AppState, path: &str) -> u32 {
+    state
+        .recent_events
+        .iter()
+        .find(|event| event.path == path)
+        .map(|event| event.attempts)
+        .unwrap_or(1)
+}
+
+async fn wait_until_allowed(
+    state_ref: &Arc<std::sync::Mutex<AppState>>,
+    policy: EnvironmentPolicy,
+) {
+    loop {
+        let defer_reason = if state_ref.lock().unwrap().paused {
+            state_ref
+                .lock()
+                .unwrap()
+                .pause_reason
+                .clone()
+                .or_else(|| Some("Paused by user".to_string()))
+        } else if policy.pause_on_metered_network && runtime_env::is_metered_connection() {
+            Some("Deferred on metered network".to_string())
+        } else if policy.pause_on_battery_power && runtime_env::is_on_battery_power() {
+            Some("Deferred while on battery power".to_string())
+        } else {
+            None
+        };
+
+        if let Some(reason) = defer_reason {
+            {
+                let mut state = state_ref.lock().unwrap();
+                state.status = "paused".to_string();
+                state.pause_reason = Some(reason);
+            }
+            tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+            continue;
+        }
+
+        let mut state = state_ref.lock().unwrap();
+        if state.status == "paused" && !state.paused {
+            state.status = "idle".to_string();
+            state.pause_reason = None;
+        }
+        break;
     }
 }
 

--- a/src/runtime_env.rs
+++ b/src/runtime_env.rs
@@ -1,0 +1,130 @@
+//! Best-effort system condition checks used to defer uploads when requested.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Return whether the current primary network connection is metered.
+pub fn is_metered_connection() -> bool {
+    let output = match Command::new("nmcli")
+        .args([
+            "-t",
+            "-f",
+            "GENERAL.METERED",
+            "connection",
+            "show",
+            "--active",
+        ])
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return false,
+    };
+
+    is_metered_connection_from_nmcli_output(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Return whether the system appears to be running on battery power.
+pub fn is_on_battery_power() -> bool {
+    let power_supply_root = Path::new("/sys/class/power_supply");
+    let entries = match fs::read_dir(power_supply_root) {
+        Ok(entries) => entries,
+        Err(_) => return false,
+    };
+
+    let mut statuses = Vec::new();
+
+    for entry in entries.flatten() {
+        let supply_path = entry.path();
+        let supply_type = fs::read_to_string(supply_path.join("type"))
+            .ok()
+            .map(|value| value.trim().to_string());
+        let online = fs::read_to_string(supply_path.join("online"))
+            .ok()
+            .map(|value| value.trim() == "1");
+        let status = fs::read_to_string(supply_path.join("status"))
+            .ok()
+            .map(|value| value.trim().to_ascii_lowercase());
+        statuses.push((supply_type, online, status));
+    }
+
+    is_on_battery_power_from_statuses(&statuses)
+}
+
+fn is_metered_connection_from_nmcli_output(stdout: &str) -> bool {
+    let stdout = stdout.to_ascii_lowercase();
+    stdout.contains("yes") || stdout.contains("guessed-yes")
+}
+
+fn is_on_battery_power_from_statuses(
+    statuses: &[(Option<String>, Option<bool>, Option<String>)],
+) -> bool {
+    let mut found_battery = false;
+    let mut mains_online = false;
+
+    for (supply_type, online, status) in statuses {
+        match supply_type.as_deref() {
+            Some("Mains") | Some("USB") | Some("USB_C") => {
+                if online.unwrap_or(false) {
+                    mains_online = true;
+                }
+            }
+            Some("Battery") => {
+                found_battery = true;
+                let status = status.as_deref().unwrap_or_default();
+                if status == "charging" || status == "full" {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    found_battery && !mains_online
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        is_metered_connection, is_metered_connection_from_nmcli_output, is_on_battery_power,
+        is_on_battery_power_from_statuses,
+    };
+
+    #[test]
+    fn runtime_checks_are_safe() {
+        let _ = is_metered_connection();
+        let _ = is_on_battery_power();
+    }
+
+    #[test]
+    fn test_metered_connection_parser() {
+        assert!(is_metered_connection_from_nmcli_output(
+            "GENERAL.METERED:yes\n"
+        ));
+        assert!(is_metered_connection_from_nmcli_output(
+            "GENERAL.METERED:guessed-yes\n"
+        ));
+        assert!(!is_metered_connection_from_nmcli_output(
+            "GENERAL.METERED:no\n"
+        ));
+    }
+
+    #[test]
+    fn test_battery_power_detection_from_statuses() {
+        assert!(is_on_battery_power_from_statuses(&[
+            (Some("Battery".into()), None, Some("discharging".into())),
+            (Some("Mains".into()), Some(false), None),
+        ]));
+
+        assert!(!is_on_battery_power_from_statuses(&[
+            (Some("Battery".into()), None, Some("charging".into())),
+            (Some("Mains".into()), Some(true), None),
+        ]));
+
+        assert!(!is_on_battery_power_from_statuses(&[(
+            Some("Mains".into()),
+            Some(true),
+            None,
+        )]));
+    }
+}

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -1,23 +1,27 @@
 //! GTK4/Libadwaita settings window and status dashboard.
 
 use crate::autostart;
-use crate::config::WatchPathEntry;
+use crate::config::{FolderRules, WatchPathEntry};
+use crate::diagnostics;
 use adw::prelude::*;
 use glib::clone;
 use gtk::prelude::*;
 use gtk::{
     Box, Button, DropDown, Entry, FileDialog, ListBox, Orientation, PasswordEntry, ProgressBar,
-    ScrolledWindow, StringList, Switch,
+    ScrolledWindow, Stack, StringList, Switch,
 };
 use libadwaita as adw;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::path::Path;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::api_client::ImmichApiClient;
 use crate::config::Config;
+use crate::queue_manager::QueueManager;
 use crate::restart::request_restart;
 use crate::state_manager::AppState;
 use crate::watch_path_display::{display_watch_path, watch_path_subtitle};
@@ -28,6 +32,7 @@ struct FolderRowData {
     pub dropdown: DropDown,
     pub string_list: StringList,
     pub custom_entry: Entry,
+    pub rules: Rc<RefCell<FolderRules>>,
 }
 
 /// Build the main settings window and wire it to the shared app state.
@@ -35,13 +40,15 @@ pub fn build_settings_window(
     app: &adw::Application,
     shared_state: Arc<Mutex<AppState>>,
     api_client: Option<Arc<ImmichApiClient>>,
+    queue_manager: Option<Arc<QueueManager>>,
+    sync_now_tx: Option<UnboundedSender<()>>,
 ) {
     // Use an ApplicationWindow so Libadwaita manages the titlebar and window lifecycle.
     let window = adw::ApplicationWindow::builder()
         .application(app)
         .title("Mimick Settings")
-        .default_width(680)
-        .default_height(820)
+        .default_width(660)
+        .default_height(840)
         .build();
     let app_clone = app.clone();
 
@@ -59,6 +66,15 @@ pub fn build_settings_window(
     let header_bar = adw::HeaderBar::new();
     vbox.append(&header_bar);
 
+    let page_stack = Stack::builder()
+        .hexpand(true)
+        .vexpand(true)
+        .transition_type(gtk::StackTransitionType::SlideLeftRight)
+        .build();
+    let stack_switcher = gtk::StackSwitcher::new();
+    stack_switcher.set_stack(Some(&page_stack));
+    header_bar.set_title_widget(Some(&stack_switcher));
+
     // About Button
     let about_btn = Button::builder()
         .icon_name("help-about-symbolic")
@@ -70,36 +86,56 @@ pub fn build_settings_window(
     });
     header_bar.pack_start(&about_btn);
 
-    // Main scrollable area
-    let scroll = ScrolledWindow::builder()
+    let setup_scroll = ScrolledWindow::builder()
         .hscrollbar_policy(gtk::PolicyType::Never)
         .vscrollbar_policy(gtk::PolicyType::Automatic)
         .vexpand(true)
         .build();
-    vbox.append(&scroll);
-
-    // Clamp
-    let clamp = adw::Clamp::builder()
-        .maximum_size(680)
-        .margin_top(12)
-        .margin_bottom(12)
-        .margin_start(12)
-        .margin_end(12)
+    let controls_scroll = ScrolledWindow::builder()
+        .hscrollbar_policy(gtk::PolicyType::Never)
+        .vscrollbar_policy(gtk::PolicyType::Automatic)
+        .vexpand(true)
         .build();
-    scroll.set_child(Some(&clamp));
+    page_stack.add_titled(&setup_scroll, Some("setup"), "Setup");
+    page_stack.add_titled(&controls_scroll, Some("controls"), "Controls");
+    page_stack.set_visible_child_name("setup");
+    vbox.append(&page_stack);
 
-    // Main Page Box
-    let page_box = Box::builder()
+    let setup_clamp = adw::Clamp::builder()
+        .maximum_size(640)
+        .margin_top(8)
+        .margin_bottom(8)
+        .margin_start(10)
+        .margin_end(10)
+        .build();
+    setup_scroll.set_child(Some(&setup_clamp));
+
+    let controls_clamp = adw::Clamp::builder()
+        .maximum_size(640)
+        .margin_top(8)
+        .margin_bottom(8)
+        .margin_start(10)
+        .margin_end(10)
+        .build();
+    controls_scroll.set_child(Some(&controls_clamp));
+
+    let setup_page_box = Box::builder()
         .orientation(Orientation::Vertical)
-        .spacing(24)
+        .spacing(18)
         .build();
-    clamp.set_child(Some(&page_box));
+    setup_clamp.set_child(Some(&setup_page_box));
+
+    let controls_page_box = Box::builder()
+        .orientation(Orientation::Vertical)
+        .spacing(18)
+        .build();
+    controls_clamp.set_child(Some(&controls_page_box));
 
     // --- PROGRESS GROUP ---
     let progress_group = adw::PreferencesGroup::builder()
         .title("Sync Status")
         .build();
-    page_box.append(&progress_group);
+    controls_page_box.append(&progress_group);
 
     let status_row = adw::ActionRow::builder()
         .title("Idle")
@@ -120,7 +156,7 @@ pub fn build_settings_window(
     let conn_group = adw::PreferencesGroup::builder()
         .title("Connectivity")
         .build();
-    page_box.append(&conn_group);
+    setup_page_box.append(&conn_group);
 
     // Internal URL
     let internal_row = adw::ActionRow::builder()
@@ -319,7 +355,7 @@ pub fn build_settings_window(
     ));
 
     let behavior_group = adw::PreferencesGroup::builder().title("Behavior").build();
-    page_box.append(&behavior_group);
+    setup_page_box.append(&behavior_group);
 
     let startup_row = adw::SwitchRow::builder()
         .title("Run on Startup")
@@ -327,12 +363,24 @@ pub fn build_settings_window(
         .build();
     behavior_group.add(&startup_row);
 
+    let metered_row = adw::SwitchRow::builder()
+        .title("Pause on Metered Network")
+        .subtitle("Defer uploads while the active connection is marked as metered.")
+        .build();
+    behavior_group.add(&metered_row);
+
+    let battery_row = adw::SwitchRow::builder()
+        .title("Pause on Battery Power")
+        .subtitle("Defer uploads while the system appears to be running on battery.")
+        .build();
+    behavior_group.add(&battery_row);
+
     // --- WATCH FOLDERS GROUP ---
     let folders_group = adw::PreferencesGroup::builder()
         .title("Watch Folders")
         .description("Add folders with the picker so Mimick can keep access to them.")
         .build();
-    page_box.append(&folders_group);
+    setup_page_box.append(&folders_group);
 
     let config = Config::new();
     let startup_initial = config.data.run_on_startup;
@@ -462,41 +510,185 @@ pub fn build_settings_window(
         );
     });
 
-    // Window actions
-    let actions_group = adw::PreferencesGroup::new();
-    page_box.append(&actions_group);
+    let controls_group = adw::PreferencesGroup::builder().title("Actions").build();
+    controls_page_box.append(&controls_group);
 
-    let actions_box = Box::builder()
-        .orientation(Orientation::Horizontal)
-        .spacing(12)
-        .halign(gtk::Align::End)
+    let controls_box = Box::builder()
+        .orientation(Orientation::Vertical)
+        .spacing(10)
         .margin_top(6)
         .margin_bottom(6)
         .margin_start(6)
         .margin_end(6)
         .build();
-    actions_group.add(&actions_box);
+    controls_group.add(&controls_box);
+
+    let primary_actions_row = Box::builder()
+        .orientation(Orientation::Horizontal)
+        .spacing(10)
+        .build();
+    controls_box.append(&primary_actions_row);
+
+    let secondary_actions_row = Box::builder()
+        .orientation(Orientation::Horizontal)
+        .spacing(10)
+        .build();
+    controls_box.append(&secondary_actions_row);
+
+    let sync_now_btn = Button::builder()
+        .label("Sync Now")
+        .css_classes(vec!["suggested-action".to_string()])
+        .hexpand(true)
+        .build();
+    primary_actions_row.append(&sync_now_btn);
+
+    let pause_btn = Button::builder().label("Pause").hexpand(true).build();
+    primary_actions_row.append(&pause_btn);
+
+    let queue_btn = Button::builder()
+        .label("Queue Inspector")
+        .hexpand(true)
+        .build();
+    secondary_actions_row.append(&queue_btn);
+
+    let export_btn = Button::builder()
+        .label("Export Diagnostics")
+        .hexpand(true)
+        .build();
+    secondary_actions_row.append(&export_btn);
+
+    let footer_separator = gtk::Separator::new(Orientation::Horizontal);
+    vbox.append(&footer_separator);
+
+    let footer_box = Box::builder()
+        .orientation(Orientation::Horizontal)
+        .spacing(12)
+        .margin_top(10)
+        .margin_bottom(10)
+        .margin_start(12)
+        .margin_end(12)
+        .build();
+    let footer_spacer = Box::builder().hexpand(true).build();
+    footer_box.append(&footer_spacer);
 
     let close_btn = Button::builder().label("Close").build();
-    actions_box.append(&close_btn);
+    footer_box.append(&close_btn);
 
     let quit_btn = Button::builder()
         .label("Quit")
         .css_classes(vec!["destructive-action".to_string()])
         .build();
-    actions_box.append(&quit_btn);
+    footer_box.append(&quit_btn);
 
     let save_btn = Button::builder()
         .label("Save & Restart")
         .css_classes(vec!["suggested-action".to_string()])
         .build();
-    actions_box.append(&save_btn);
+    footer_box.append(&save_btn);
+    vbox.append(&footer_box);
 
     close_btn.connect_clicked(clone!(
         #[weak]
         window,
         move |_| {
             window.set_visible(false);
+        }
+    ));
+
+    if let Some(qm) = queue_manager.clone() {
+        let qm_for_inspector = qm.clone();
+        queue_btn.connect_clicked(clone!(
+            #[weak]
+            window,
+            move |_| {
+                show_queue_inspector(&window, qm_for_inspector.clone());
+            }
+        ));
+
+        let qm_for_pause = qm.clone();
+        pause_btn.connect_clicked(clone!(
+            #[weak]
+            pause_btn,
+            move |_| {
+                let paused = !qm_for_pause.is_paused();
+                qm_for_pause.set_paused(paused, paused.then(|| "Paused by user".to_string()));
+                pause_btn.set_label(if paused { "Resume" } else { "Pause" });
+            }
+        ));
+    } else {
+        queue_btn.set_sensitive(false);
+        pause_btn.set_sensitive(false);
+    }
+
+    if let Some(sync_now_tx) = sync_now_tx.clone() {
+        sync_now_btn.connect_clicked(move |_| {
+            let _ = sync_now_tx.send(());
+        });
+    } else {
+        sync_now_btn.set_sensitive(false);
+    }
+
+    export_btn.connect_clicked(clone!(
+        #[weak]
+        window,
+        #[strong]
+        shared_state,
+        move |_| {
+            let dialog = FileDialog::builder()
+                .title("Choose Diagnostics Export Folder")
+                .build();
+            let state = shared_state.clone();
+            dialog.select_folder(
+                Some(&window),
+                gtk::gio::Cancellable::NONE,
+                clone!(
+                    #[weak]
+                    window,
+                    move |res| {
+                        if let Ok(folder) = res
+                            && let Some(path) = folder.path()
+                        {
+                            let state_snapshot = state.lock().unwrap().clone();
+                            glib::MainContext::default().spawn_local(clone!(
+                                #[weak]
+                                window,
+                                async move {
+                                    let export_result = tokio::task::spawn_blocking(move || {
+                                        diagnostics::export_bundle(&path, &state_snapshot)
+                                    })
+                                    .await;
+
+                                    let (heading, body) = match export_result {
+                                        Ok(Ok(bundle_dir)) => (
+                                            "Diagnostics Exported",
+                                            format!(
+                                                "Saved diagnostics bundle to {}",
+                                                bundle_dir.display()
+                                            ),
+                                        ),
+                                        Ok(Err(err)) => (
+                                            "Diagnostics Export Failed",
+                                            format!("Could not write diagnostics bundle: {}", err),
+                                        ),
+                                        Err(err) => (
+                                            "Diagnostics Export Failed",
+                                            format!("Diagnostics task could not complete: {}", err),
+                                        ),
+                                    };
+
+                                    let dialog = adw::MessageDialog::builder()
+                                        .transient_for(&window)
+                                        .heading(heading)
+                                        .body(&body)
+                                        .build();
+                                    dialog.add_response("ok", "OK");
+                                    dialog.present();
+                                }
+                            ));
+                        }
+                    }
+                ),
+            );
         }
     ));
 
@@ -524,6 +716,10 @@ pub fn build_settings_window(
         #[weak]
         startup_row,
         #[weak]
+        metered_row,
+        #[weak]
+        battery_row,
+        #[weak]
         save_btn,
         #[strong]
         app_clone,
@@ -539,12 +735,16 @@ pub fn build_settings_window(
             let internal_url = internal_entry.text().to_string();
             let external_url = external_entry.text().to_string();
             let run_on_startup = startup_row.is_active();
+            let pause_on_metered_network = metered_row.is_active();
+            let pause_on_battery_power = battery_row.is_active();
             let mut watch_paths = Vec::new();
             let albums_map: HashMap<String, String> = albums.borrow().iter().cloned().collect();
 
             for row_data in tracked_rows.borrow().iter() {
                 let folder = row_data.path.clone();
                 let selected_idx = row_data.dropdown.selected();
+                let rules = row_data.rules.borrow().clone();
+                let has_rules = rules != FolderRules::default();
 
                 let album_name = if selected_idx == row_data.string_list.n_items() - 1 {
                     row_data.custom_entry.text().to_string()
@@ -554,14 +754,21 @@ pub fn build_settings_window(
                     "Default (Folder Name)".to_string()
                 };
 
-                if album_name.is_empty() || album_name == "Default (Folder Name)" {
+                if (album_name.is_empty() || album_name == "Default (Folder Name)") && !has_rules {
                     watch_paths.push(WatchPathEntry::Simple(folder));
                 } else {
                     let album_id = albums_map.get(&album_name).cloned();
                     watch_paths.push(WatchPathEntry::WithConfig {
                         path: folder,
                         album_id,
-                        album_name: Some(album_name),
+                        album_name: if album_name.is_empty()
+                            || album_name == "Default (Folder Name)"
+                        {
+                            None
+                        } else {
+                            Some(album_name)
+                        },
+                        rules,
                     });
                 }
             }
@@ -618,6 +825,8 @@ pub fn build_settings_window(
                     new_config.data.external_url = external_url;
                     new_config.data.watch_paths = watch_paths;
                     new_config.data.run_on_startup = run_on_startup;
+                    new_config.data.pause_on_metered_network = pause_on_metered_network;
+                    new_config.data.pause_on_battery_power = pause_on_battery_power;
 
                     if !api_key.is_empty() {
                         new_config.set_api_key(&api_key);
@@ -651,6 +860,8 @@ pub fn build_settings_window(
     internal_entry.set_sensitive(config.data.internal_url_enabled);
     external_entry.set_sensitive(config.data.external_url_enabled);
     startup_row.set_active(config.data.run_on_startup);
+    metered_row.set_active(config.data.pause_on_metered_network);
+    battery_row.set_active(config.data.pause_on_battery_power);
 
     if let Some(key) = config.get_api_key() {
         api_key_entry.set_text(&key);
@@ -711,10 +922,21 @@ pub fn build_settings_window(
             status_row,
             #[weak]
             progress_bar,
+            #[weak]
+            pause_btn,
             #[upgrade_or]
             glib::ControlFlow::Break,
             move || {
-                let (status, progress, processed, total, failed, current_file) = {
+                let (
+                    status,
+                    progress,
+                    processed,
+                    total,
+                    failed,
+                    current_file,
+                    paused,
+                    pause_reason,
+                ) = {
                     let s = shared_state.lock().unwrap();
                     (
                         s.status.clone(),
@@ -723,10 +945,22 @@ pub fn build_settings_window(
                         s.total_queued,
                         s.failed_count,
                         s.current_file.clone().unwrap_or_else(|| "...".to_string()),
+                        s.paused,
+                        s.pause_reason.clone(),
                     )
                 }; // lock released here
 
-                if status == "idle" {
+                pause_btn.set_label(if paused { "Resume" } else { "Pause" });
+
+                if status == "paused" || paused {
+                    status_row.set_title("Paused");
+                    status_row.set_subtitle(
+                        pause_reason
+                            .as_deref()
+                            .unwrap_or("Sync has been temporarily paused."),
+                    );
+                    progress_bar.set_fraction((progress as f64) / 100.0);
+                } else if status == "idle" {
                     if failed > 0 {
                         status_row.set_title("Offline / Waiting");
                         status_row.set_subtitle(&format!("{} item(s) pending network", failed));
@@ -798,6 +1032,7 @@ fn add_folder_row(
         .valign(gtk::Align::Center)
         .visible(false)
         .build();
+    let rules = Rc::new(RefCell::new(entry.rules()));
 
     if let Some(name) = entry.album_name()
         && name != "Default (Folder Name)"
@@ -840,10 +1075,30 @@ fn add_folder_row(
         .valign(gtk::Align::Center)
         .css_classes(vec!["destructive-action".to_string()])
         .build();
+    let rules_btn = Button::builder()
+        .label("Rules")
+        .tooltip_text("Edit folder rules")
+        .valign(gtk::Align::Center)
+        .build();
 
     let list_clone = list.clone();
     let tracked_clone = tracked_rows.clone();
     let path_clone = path.clone();
+    let rules_clone = rules.clone();
+    let path_for_rules = path.clone();
+
+    rules_btn.connect_clicked(clone!(
+        #[weak]
+        row,
+        move |_| {
+            if let Some(window) = row
+                .root()
+                .and_then(|root| root.downcast::<adw::ApplicationWindow>().ok())
+            {
+                show_folder_rules_dialog(&window, &path_for_rules, rules_clone.clone());
+            }
+        }
+    ));
 
     remove_btn.connect_clicked(clone!(
         #[weak]
@@ -853,6 +1108,7 @@ fn add_folder_row(
             tracked_clone.borrow_mut().retain(|r| r.path != path_clone);
         }
     ));
+    row.add_suffix(&rules_btn);
     row.add_suffix(&remove_btn);
 
     list.append(&row);
@@ -861,7 +1117,249 @@ fn add_folder_row(
         dropdown,
         string_list,
         custom_entry,
+        rules,
     });
+}
+
+fn show_folder_rules_dialog(
+    parent: &adw::ApplicationWindow,
+    folder_path: &str,
+    rules_state: Rc<RefCell<FolderRules>>,
+) {
+    let dialog = adw::Window::builder()
+        .transient_for(parent)
+        .modal(true)
+        .title("Folder Rules")
+        .default_width(420)
+        .build();
+    let content = Box::builder()
+        .orientation(Orientation::Vertical)
+        .spacing(12)
+        .margin_top(12)
+        .margin_bottom(12)
+        .margin_start(12)
+        .margin_end(12)
+        .build();
+    dialog.set_content(Some(&content));
+
+    let title = gtk::Label::builder()
+        .label(format!("Rules for {}", display_watch_path(folder_path)))
+        .halign(gtk::Align::Start)
+        .wrap(true)
+        .build();
+    content.append(&title);
+
+    let current = rules_state.borrow().clone();
+
+    let ignore_hidden = adw::SwitchRow::builder()
+        .title("Ignore Hidden Files / Folders")
+        .subtitle("Skip paths that contain hidden components such as .cache or .thumbnails.")
+        .active(current.ignore_hidden)
+        .build();
+    content.append(&ignore_hidden);
+
+    let max_size_entry = Entry::builder()
+        .placeholder_text("Max file size in MB, leave blank for no limit")
+        .text(
+            current
+                .max_file_size_mb
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        )
+        .build();
+    content.append(&max_size_entry);
+
+    let extensions_entry = Entry::builder()
+        .placeholder_text("Allowed extensions, comma separated, leave blank for default media list")
+        .text(current.allowed_extensions.join(", "))
+        .build();
+    content.append(&extensions_entry);
+
+    let actions = Box::builder()
+        .orientation(Orientation::Horizontal)
+        .spacing(8)
+        .halign(gtk::Align::End)
+        .build();
+    let cancel_btn = Button::builder().label("Cancel").build();
+    let save_btn = Button::builder()
+        .label("Save")
+        .css_classes(vec!["suggested-action".to_string()])
+        .build();
+    actions.append(&cancel_btn);
+    actions.append(&save_btn);
+    content.append(&actions);
+
+    cancel_btn.connect_clicked(clone!(
+        #[weak]
+        dialog,
+        move |_| {
+            dialog.close();
+        }
+    ));
+
+    save_btn.connect_clicked(clone!(
+        #[weak]
+        dialog,
+        move |_| {
+            let max_file_size_mb = max_size_entry.text().trim().parse::<u64>().ok();
+            let allowed_extensions = extensions_entry
+                .text()
+                .split(',')
+                .map(|part| part.trim().trim_start_matches('.').to_ascii_lowercase())
+                .filter(|part| !part.is_empty())
+                .collect::<Vec<_>>();
+
+            *rules_state.borrow_mut() = FolderRules {
+                ignore_hidden: ignore_hidden.is_active(),
+                max_file_size_mb,
+                allowed_extensions,
+            };
+            dialog.close();
+        }
+    ));
+
+    dialog.present();
+}
+
+fn show_queue_inspector(parent: &adw::ApplicationWindow, queue_manager: Arc<QueueManager>) {
+    let dialog = adw::Window::builder()
+        .transient_for(parent)
+        .modal(true)
+        .title("Queue Inspector")
+        .default_width(760)
+        .default_height(560)
+        .build();
+    let content = Box::builder()
+        .orientation(Orientation::Vertical)
+        .spacing(12)
+        .margin_top(12)
+        .margin_bottom(12)
+        .margin_start(12)
+        .margin_end(12)
+        .build();
+    dialog.set_content(Some(&content));
+
+    let actions = Box::builder()
+        .orientation(Orientation::Horizontal)
+        .spacing(8)
+        .halign(gtk::Align::End)
+        .build();
+    content.append(&actions);
+
+    let retry_all_btn = Button::builder().label("Retry All Failed").build();
+    let clear_failed_btn = Button::builder().label("Clear Failed Queue").build();
+    actions.append(&retry_all_btn);
+    actions.append(&clear_failed_btn);
+
+    let failed_group = adw::PreferencesGroup::builder()
+        .title("Failed Retry Queue")
+        .build();
+    content.append(&failed_group);
+
+    let failed_tasks = queue_manager.failed_tasks();
+    if failed_tasks.is_empty() {
+        failed_group.add(
+            &adw::ActionRow::builder()
+                .title("No failed items")
+                .subtitle("The retry queue is currently empty.")
+                .build(),
+        );
+    } else {
+        for task in failed_tasks {
+            let row = adw::ActionRow::builder()
+                .title(
+                    Path::new(&task.path)
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .unwrap_or(task.path.as_str()),
+                )
+                .subtitle(&task.path)
+                .build();
+            let retry_btn = Button::builder().label("Retry").build();
+            let task_path = task.path.clone();
+            let qm = queue_manager.clone();
+            retry_btn.connect_clicked(move |btn| {
+                btn.set_sensitive(false);
+                let qm = qm.clone();
+                let task_path = task_path.clone();
+                glib::MainContext::default().spawn_local(async move {
+                    let _ = qm.retry_failed_path(&task_path).await;
+                });
+            });
+            row.add_suffix(&retry_btn);
+            failed_group.add(&row);
+        }
+    }
+
+    let events_group = adw::PreferencesGroup::builder()
+        .title("Recent Queue Activity")
+        .build();
+    content.append(&events_group);
+
+    let events_scroll = ScrolledWindow::builder()
+        .min_content_height(280)
+        .vexpand(true)
+        .build();
+    let events_list = ListBox::builder()
+        .selection_mode(gtk::SelectionMode::None)
+        .css_classes(vec!["boxed-list".to_string()])
+        .build();
+    events_scroll.set_child(Some(&events_list));
+    events_group.add(&events_scroll);
+
+    for event in queue_manager.recent_events() {
+        let row = adw::ActionRow::builder()
+            .title(
+                Path::new(&event.path)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or(event.path.as_str()),
+            )
+            .subtitle(format!(
+                "{} | attempts={}{}",
+                event.status,
+                event.attempts,
+                event
+                    .detail
+                    .as_ref()
+                    .map(|detail| format!(" | {}", detail))
+                    .unwrap_or_default()
+            ))
+            .build();
+        row.add_prefix(
+            &gtk::Label::builder()
+                .label(display_watch_path(&event.path))
+                .wrap(true)
+                .halign(gtk::Align::Start)
+                .build(),
+        );
+        events_list.append(&row);
+    }
+
+    let qm_retry_all = queue_manager.clone();
+    retry_all_btn.connect_clicked(move |btn| {
+        btn.set_sensitive(false);
+        let qm = qm_retry_all.clone();
+        glib::MainContext::default().spawn_local(async move {
+            let _ = qm.retry_all_failed().await;
+        });
+    });
+
+    let qm_clear = queue_manager.clone();
+    clear_failed_btn.connect_clicked(move |_| {
+        let _ = qm_clear.clear_failed();
+    });
+
+    let close_btn = Button::builder().label("Close").build();
+    close_btn.connect_clicked(clone!(
+        #[weak]
+        dialog,
+        move |_| {
+            dialog.close();
+        }
+    ));
+    content.append(&close_btn);
+    dialog.present();
 }
 
 fn show_about_dialog(parent: &adw::ApplicationWindow) {

--- a/src/startup_scan.rs
+++ b/src/startup_scan.rs
@@ -2,7 +2,7 @@
 
 use crate::api_client::ImmichApiClient;
 use crate::config::WatchPathEntry;
-use crate::monitor::{compute_sha1_chunked, is_supported_media_path};
+use crate::monitor::{compute_sha1_chunked, is_supported_media_path, is_temporary_file};
 use crate::queue_manager::{FileTask, QueueManager};
 use crate::sync_index::{SyncDecision, SyncIndex, SyncTarget};
 use std::collections::{HashMap, HashSet};
@@ -67,6 +67,9 @@ pub async fn queue_unsynced_files(
                         }
 
                         if !is_supported_media_path(&path) {
+                            continue;
+                        }
+                        if is_temporary_file(&path) || !entry.rules().matches(&path) {
                             continue;
                         }
 

--- a/src/state_manager.rs
+++ b/src/state_manager.rs
@@ -5,6 +5,18 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
+/// Rolling queue/event status used by the settings window inspector.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct QueueEvent {
+    pub path: String,
+    pub status: String,
+    #[serde(default)]
+    pub detail: Option<String>,
+    #[serde(default)]
+    pub attempts: u32,
+    pub timestamp: f64,
+}
+
 /// Shared progress counters exposed to the settings window.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AppState {
@@ -20,6 +32,18 @@ pub struct AppState {
     pub status: String,
     pub progress: u8,
     pub timestamp: f64,
+    #[serde(default)]
+    pub paused: bool,
+    #[serde(default)]
+    pub pause_reason: Option<String>,
+    #[serde(default)]
+    pub last_error: Option<String>,
+    #[serde(default)]
+    pub last_completed_file: Option<String>,
+    #[serde(default)]
+    pub diagnostics_exports: usize,
+    #[serde(default)]
+    pub recent_events: Vec<QueueEvent>,
 }
 
 impl Default for AppState {
@@ -34,7 +58,51 @@ impl Default for AppState {
             status: "idle".to_string(),
             progress: 0,
             timestamp: 0.0,
+            paused: false,
+            pause_reason: None,
+            last_error: None,
+            last_completed_file: None,
+            diagnostics_exports: 0,
+            recent_events: Vec::new(),
         }
+    }
+}
+
+impl AppState {
+    const MAX_EVENTS: usize = 80;
+
+    pub fn record_event(
+        &mut self,
+        path: impl Into<String>,
+        status: impl Into<String>,
+        detail: Option<String>,
+        attempts: u32,
+    ) {
+        let path = path.into();
+        let status = status.into();
+        let timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f64();
+
+        if let Some(existing) = self.recent_events.iter_mut().find(|evt| evt.path == path) {
+            existing.status = status;
+            existing.detail = detail;
+            existing.attempts = attempts;
+            existing.timestamp = timestamp;
+        } else {
+            self.recent_events.push(QueueEvent {
+                path,
+                status,
+                detail,
+                attempts,
+                timestamp,
+            });
+        }
+
+        self.recent_events
+            .sort_by(|a, b| b.timestamp.total_cmp(&a.timestamp));
+        self.recent_events.truncate(Self::MAX_EVENTS);
     }
 }
 
@@ -147,5 +215,27 @@ mod tests {
         let read_state = manager.read_state();
         assert_eq!(read_state.status, "syncing");
         assert_eq!(read_state.progress, 50);
+    }
+
+    #[test]
+    fn test_record_event_updates_existing_entry() {
+        let mut state = AppState::default();
+        state.record_event("/tmp/a.jpg", "pending", Some("queued".into()), 1);
+        state.record_event("/tmp/a.jpg", "failed", Some("retry".into()), 2);
+
+        assert_eq!(state.recent_events.len(), 1);
+        assert_eq!(state.recent_events[0].status, "failed");
+        assert_eq!(state.recent_events[0].attempts, 2);
+        assert_eq!(state.recent_events[0].detail.as_deref(), Some("retry"));
+    }
+
+    #[test]
+    fn test_record_event_truncates_history() {
+        let mut state = AppState::default();
+        for i in 0..100 {
+            state.record_event(format!("/tmp/{i}.jpg"), "pending", None, 1);
+        }
+
+        assert_eq!(state.recent_events.len(), 80);
     }
 }

--- a/src/tray_icon.rs
+++ b/src/tray_icon.rs
@@ -11,6 +11,10 @@ pub struct MimickTray {
     pub settings_tx: watch::Sender<bool>,
     /// Sender used to request a graceful application quit from the GTK main loop.
     pub quit_tx: watch::Sender<bool>,
+    /// Sender used to toggle paused state from the tray.
+    pub pause_tx: watch::Sender<bool>,
+    /// Sender used to request an immediate catch-up scan.
+    pub sync_now_tx: watch::Sender<bool>,
 }
 
 impl ksni::Tray for MimickTray {
@@ -38,6 +42,22 @@ impl ksni::Tray for MimickTray {
                 ..Default::default()
             }
             .into(),
+            StandardItem {
+                label: "Pause / Resume".into(),
+                activate: Box::new(|tray: &mut Self| {
+                    let _ = tray.pause_tx.send(true);
+                }),
+                ..Default::default()
+            }
+            .into(),
+            StandardItem {
+                label: "Sync Now".into(),
+                activate: Box::new(|tray: &mut Self| {
+                    let _ = tray.sync_now_tx.send(true);
+                }),
+                ..Default::default()
+            }
+            .into(),
             MenuItem::Separator,
             StandardItem {
                 label: "Quit".into(),
@@ -57,14 +77,20 @@ pub async fn build_tray() -> Result<
         ksni::Handle<MimickTray>,
         watch::Receiver<bool>,
         watch::Receiver<bool>,
+        watch::Receiver<bool>,
+        watch::Receiver<bool>,
     ),
     ksni::Error,
 > {
     let (settings_tx, settings_rx) = watch::channel(false);
     let (quit_tx, quit_rx) = watch::channel(false);
+    let (pause_tx, pause_rx) = watch::channel(false);
+    let (sync_now_tx, sync_now_rx) = watch::channel(false);
     let tray = MimickTray {
         settings_tx,
         quit_tx,
+        pause_tx,
+        sync_now_tx,
     };
     let handle = if ashpd::is_sandboxed() {
         // Flatpak sessions already broker the item through the watcher, so we avoid owning
@@ -73,5 +99,5 @@ pub async fn build_tray() -> Result<
     } else {
         tray.spawn().await?
     };
-    Ok((handle, settings_rx, quit_rx))
+    Ok((handle, settings_rx, quit_rx, pause_rx, sync_now_rx))
 }


### PR DESCRIPTION
- Added a new dialog for editing folder rules in the settings window.
- Implemented diagnostics export functionality to gather application state and configuration.
- Introduced pause/resume functionality in the tray icon with corresponding actions.
- Updated AppState to track recent queue events and added methods for event recording.
- Enhanced startup scan to respect folder rules and ignore temporary files.
- Added runtime checks for metered connections and battery power status.
- Refactored settings window layout for better organization and usability.