### PR TITLE
Harden diagnostics export and repository automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default ownership for this repository.
+* @nicx17
+
+# Keep repository automation and release wiring under maintainer review.
+/.github/ @nicx17
+/setup/ @nicx17
+/io.github.nicx17.mimick.yml @nicx17
+/io.github.nicx17.mimick.local.yml @nicx17
+/cargo-sources.json @nicx17

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,62 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+categories:
+  - title: 'Features'
+    labels:
+      - 'enhancement'
+  - title: 'Fixes'
+    labels:
+      - 'bug'
+  - title: 'Dependencies'
+    labels:
+      - 'dependencies'
+      - 'rust'
+      - 'github-actions'
+  - title: 'Documentation'
+    labels:
+      - 'documentation'
+
+exclude-labels:
+  - 'skip-changelog'
+
+autolabeler:
+  - label: 'documentation'
+    files:
+      - '*.md'
+      - 'docs/**'
+      - 'wiki/**'
+  - label: 'github-actions'
+    files:
+      - '.github/workflows/**'
+  - label: 'rust'
+    files:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'src/**'
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'enhancement'
+      - 'feature'
+  patch:
+    labels:
+      - 'bug'
+      - 'dependencies'
+      - 'documentation'
+      - 'rust'
+      - 'github-actions'
+  default: patch

--- a/.github/workflows/cargo-sources-guard.yml
+++ b/.github/workflows/cargo-sources-guard.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
 
       - name: Ensure Cargo lock changes update vendored sources
         shell: bash

--- a/.github/workflows/cargo-sources-guard.yml
+++ b/.github/workflows/cargo-sources-guard.yml
@@ -1,0 +1,57 @@
+name: Cargo Vendor Guard
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NODE_OPTIONS: "--no-deprecation"
+
+jobs:
+  verify-vendoring:
+    name: Verify cargo-sources.json
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Ensure Cargo lock changes update vendored sources
+        shell: bash
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          CHANGED_FILES="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- Cargo.toml Cargo.lock cargo-sources.json)"
+
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "No Cargo or vendored-source changes detected."
+            exit 0
+          fi
+
+          if grep -qx 'cargo-sources.json' <<< "$CHANGED_FILES"; then
+            echo "cargo-sources.json changed. Guard satisfied."
+            exit 0
+          fi
+
+          if ! grep -qx 'Cargo.lock' <<< "$CHANGED_FILES"; then
+            echo "Cargo.lock did not change. No vendored-source refresh required."
+            exit 0
+          fi
+
+          LOCK_NUMSTAT="$(git diff --numstat "$BASE_SHA" "$HEAD_SHA" -- Cargo.lock)"
+          ADDED_LINES="$(awk '{print $1}' <<< "$LOCK_NUMSTAT")"
+          DELETED_LINES="$(awk '{print $2}' <<< "$LOCK_NUMSTAT")"
+
+          if [[ "$ADDED_LINES" == "1" && "$DELETED_LINES" == "1" ]] && \
+             git diff -U1 "$BASE_SHA" "$HEAD_SHA" -- Cargo.lock | grep -q 'name = "mimick"'; then
+            echo "Detected a root package version-only Cargo.lock change. Vendored sources are unchanged."
+            exit 0
+          fi
+
+          echo "::error file=cargo-sources.json::Cargo.lock changed without cargo-sources.json. Run: uv run flatpak-cargo-generator.py Cargo.lock -o cargo-sources.json"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,6 @@ on:
       - "roadmap.md"
   pull_request:
     branches: ["main"]
-    paths-ignore:
-      - "docs/**"
-      - "wiki/**"
-      - "README.md"
-      - "CONTRIBUTING.md"
-      - "SECURITY.md"
-      - "roadmap.md"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NODE_OPTIONS: "--no-deprecation"
+
+jobs:
+  enable-auto-merge:
+    name: Enable auto-merge for approved dependency PRs
+    if: |
+      github.event.review.state == 'approved' &&
+      github.event.review.user.login == 'nicx17' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      !github.event.pull_request.draft &&
+      contains(github.event.pull_request.labels.*.name, 'dependencies')
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Enable native auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -1,0 +1,47 @@
+name: Docs Link Check
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "README.md"
+      - "docs/**"
+      - "wiki/**"
+      - ".github/workflows/docs-links.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "README.md"
+      - "docs/**"
+      - "wiki/**"
+      - ".github/workflows/docs-links.yml"
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NODE_OPTIONS: "--no-deprecation"
+
+jobs:
+  links:
+    name: Check docs links
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check markdown links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        with:
+          args: >-
+            --no-progress
+            --verbose
+            --exclude-mail
+            --exclude 'https://img.shields.io/.*'
+            README.md docs wiki
+          fail: true
+          jobSummary: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -38,7 +38,6 @@ jobs:
           args: >-
             --no-progress
             --verbose
-            --exclude-mail
             --exclude 'https://img.shields.io/.*'
             README.md docs wiki
           fail: true

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -1,0 +1,63 @@
+name: Maintainer Approval Gate
+
+on:
+  pull_request_target:
+    branches: ["main"]
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NODE_OPTIONS: "--no-deprecation"
+  REQUIRED_MAINTAINER: "nicx17"
+
+jobs:
+  approval-gate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify maintainer approval policy
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const maintainer = process.env.REQUIRED_MAINTAINER;
+            const pr = context.payload.pull_request;
+
+            if (!pr) {
+              core.setFailed("No pull request payload found.");
+              return;
+            }
+
+            if (pr.user.login === maintainer) {
+              core.info(`PR author is ${maintainer}; approval gate passes automatically.`);
+              return;
+            }
+
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              }
+            );
+
+            const maintainerReviews = reviews
+              .filter((review) => review.user?.login === maintainer)
+              .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at));
+
+            const latestReview = maintainerReviews.at(-1);
+
+            if (!latestReview || latestReview.state !== "APPROVED") {
+              core.setFailed(
+                `This pull request needs an approval from @${maintainer} before it can merge.`
+              );
+              return;
+            }
+
+            core.info(`Latest review from @${maintainer} is APPROVED.`);

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,26 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: ["main"]
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled, closed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NODE_OPTIONS: "--no-deprecation"
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Update draft release
+        uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![Rust](https://img.shields.io/badge/Rust-000000?style=for-the-badge&logo=rust&logoColor=white)
 ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
 ![GTK4](https://img.shields.io/badge/GTK4-7DF12B?style=for-the-badge&logo=gtk&logoColor=white)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-green.svg?style=for-the-badge)](https://www.gnu.org/licenses/gpl-3.0)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-green.svg?style=for-the-badge)](LICENSE)
 
 </div>
 
@@ -48,7 +48,7 @@ Mimick monitors local directories (e.g., `~/Pictures`, `~/Videos`) for new files
 - **Sync Controls**: Pause or resume uploads and trigger a manual `Sync Now` pass from either the tray or the settings window.
 - **Connectivity**: Automatically switches between **Internal (LAN)** and **External (WAN)** URLs based on availability. At least one must be enabled (enforced by the UI).
 - **Per-Folder Rules**: Each watched folder can optionally ignore hidden paths, cap file size, or allow only selected file extensions.
-- **Diagnostics Export**: Generate a support bundle with logs, queue state, sync index, and a human-readable summary without exposing your API key.
+- **Diagnostics Export**: Generate a redacted support bundle with queue state, sync summaries, and a human-readable report without exposing raw logs, URLs, or full local paths.
 - **Network / Power Awareness**: Optionally defer uploads while on a metered connection or running on battery power.
 - **Custom Album Mapping**: Select an existing remote album, type a custom name, or let the app create an album from the local folder name (e.g., `~/Pictures/Vacation 2024` → Album `Vacation 2024`).
 - **One-Way Sync**: Uploads media without modifying local files.
@@ -168,7 +168,7 @@ On the **Controls** page:
 * **Retry All Failed** requeues everything currently stored in the failed list.
 * **Retry** on a single failed row requeues only that item.
 * **Clear Failed Queue** removes persisted failed items you no longer want Mimick to retry.
-* **Export Diagnostics** writes a bundle with `summary.txt`, `config.json`, `status.json`, `retries.json`, `synced_index.json`, and `mimick.log` when those files are available.
+* **Export Diagnostics** writes a bundle with `summary.txt`, `config.redacted.json`, `status.redacted.json`, `retries.redacted.json`, `synced_index.redacted.json`, and `privacy-note.txt`.
 
 ### Network and Power-Aware Behavior
 
@@ -270,8 +270,8 @@ Pull requests are welcome. See `CONTRIBUTING.md` for commit and style guidelines
 
 ## Acknowledgments
 
-* Application icon illustration by [Round Icons](https://unsplash.com/@roundicons) on Unsplash.
+* Application icon illustration by Round Icons on Unsplash.
 
 ## License
 
-GNU General Public License v3.0 — see [LICENSE](https://github.com/nicx17/mimick/blob/main/LICENSE).
+GNU General Public License v3.0 — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Mimick monitors local directories (e.g., `~/Pictures`, `~/Videos`) for new files
 [![User Guide](https://img.shields.io/badge/User-Guide-2E8B57?style=for-the-badge&labelColor=2E8B57)](docs/USER_GUIDE.md)
 [![Configuration](https://img.shields.io/badge/Configuration-Guide-8A2BE2?style=for-the-badge&labelColor=8A2BE2)](docs/CONFIGURATION.md)
 [![Troubleshooting](https://img.shields.io/badge/Troubleshooting-Help-CB4B16?style=for-the-badge&labelColor=CB4B16)](docs/TROUBLESHOOTING.md)
+[![Repo Automation](https://img.shields.io/badge/Repo-Automation-444444?style=for-the-badge&labelColor=444444)](docs/REPOSITORY_AUTOMATION.md)
 [![Project Wiki](https://img.shields.io/badge/Project-Wiki-444444?style=for-the-badge&labelColor=444444)](https://github.com/nicx17/mimick/wiki)
 
 > [!NOTE]
@@ -247,6 +248,7 @@ flatpak run io.github.nicx17.mimick
 [![Development](https://img.shields.io/badge/Development-Guide-B8860B?style=for-the-badge&labelColor=B8860B)](docs/DEVELOPMENT.md)
 [![Testing](https://img.shields.io/badge/Testing-Guide-0E7490?style=for-the-badge&labelColor=0E7490)](docs/TESTING.md)
 [![Troubleshooting](https://img.shields.io/badge/Troubleshooting-Guide-CB4B16?style=for-the-badge&labelColor=CB4B16)](docs/TROUBLESHOOTING.md)
+[![Repo Automation](https://img.shields.io/badge/Repo-Automation-444444?style=for-the-badge&labelColor=444444)](docs/REPOSITORY_AUTOMATION.md)
 [![Security](https://img.shields.io/badge/Security-Policy-5B8C5A?style=for-the-badge&labelColor=5B8C5A)](SECURITY.md)
 
 ## Trust and Verification

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -99,7 +99,7 @@ In addition to `config.json`, Mimick stores runtime state in the user cache dire
 - `~/.cache/mimick/synced_index.json`: the local sync index used by startup rescans to skip already-synced unchanged files and detect album-target changes.
 - `~/.cache/mimick/status.json`: last saved application status written during graceful shutdown.
 
-Diagnostics exports copy these files into a timestamped `mimick-diagnostics-*` directory together with a generated `summary.txt` support report when the source files exist.
+Diagnostics exports write a timestamped `mimick-diagnostics-*` directory with a generated `summary.txt` plus redacted config, status, retry, and sync-index reports. Raw logs, API keys, full local paths, and raw server URLs are intentionally omitted.
 
 ## API Key Security
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -87,7 +87,7 @@ Recent operational features are spread across a few focused modules:
 - `queue_manager.rs`: upload workers, retry controls, pause/resume state, queue event recording
 - `state_manager.rs`: persisted app state plus recent queue-event history
 - `runtime_env.rs`: best-effort metered-network and battery-power detection
-- `diagnostics.rs`: support bundle export that omits secrets
+- `diagnostics.rs`: support bundle export that redacts secrets, raw logs, URLs, and full local paths
 - `settings_window.rs`: queue inspector, diagnostics export, per-folder rule editing, and manual sync controls
 
 ## Packaging
@@ -108,6 +108,8 @@ GitHub Actions currently mirrors the same native quality gate with:
 - `cargo test --locked`
 
 The published Flatpak repository is built in a containerized Flatpak workflow rather than by installing Flatpak tooling directly on the host runner.
+
+Repository automation details such as Dependabot, CODEOWNERS, Release Drafter, docs link checks, and the Flatpak vendor guard are documented in [REPOSITORY_AUTOMATION.md](/home/nick/Documents/Github/immich_sync_app/docs/REPOSITORY_AUTOMATION.md).
 
 ## Contributing Workflow
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -109,7 +109,7 @@ GitHub Actions currently mirrors the same native quality gate with:
 
 The published Flatpak repository is built in a containerized Flatpak workflow rather than by installing Flatpak tooling directly on the host runner.
 
-Repository automation details such as Dependabot, CODEOWNERS, Release Drafter, docs link checks, and the Flatpak vendor guard are documented in [REPOSITORY_AUTOMATION.md](/home/nick/Documents/Github/immich_sync_app/docs/REPOSITORY_AUTOMATION.md).
+Repository automation details such as Dependabot, CODEOWNERS, Release Drafter, docs link checks, and the Flatpak vendor guard are documented in [REPOSITORY_AUTOMATION.md](REPOSITORY_AUTOMATION.md).
 
 ## Contributing Workflow
 

--- a/docs/REPOSITORY_AUTOMATION.md
+++ b/docs/REPOSITORY_AUTOMATION.md
@@ -18,7 +18,7 @@ This setup aims to improve release safety and repo hygiene without turning the p
 
 ## Dependabot
 
-Dependabot configuration lives in [`.github/dependabot.yml`](/home/nick/Documents/Github/immich_sync_app/.github/dependabot.yml).
+Dependabot configuration lives in [`.github/dependabot.yml`](../.github/dependabot.yml).
 
 It currently updates:
 
@@ -33,7 +33,7 @@ Expected repository labels:
 
 ## CODEOWNERS
 
-Ownership rules live in [`.github/CODEOWNERS`](/home/nick/Documents/Github/immich_sync_app/.github/CODEOWNERS).
+Ownership rules live in [`.github/CODEOWNERS`](../.github/CODEOWNERS).
 
 The default owner is:
 
@@ -55,13 +55,13 @@ This is most useful when combined with branch protection or rulesets that requir
 - required conversation resolution
 - admins are not enforced
 
-Because [`.github/CODEOWNERS`](/home/nick/Documents/Github/immich_sync_app/.github/CODEOWNERS) assigns the repo to `@nicx17`, pull requests opened by other people need your approval before merging.
+Because [`.github/CODEOWNERS`](../.github/CODEOWNERS) assigns the repo to `@nicx17`, pull requests opened by other people need your approval before merging.
 
 Your own pull requests are still practical to merge because admin enforcement is left off.
 
 ## Maintainer Approval Gate
 
-Approval enforcement for pull requests opened by other people is handled by [`.github/workflows/maintainer-approval.yml`](/home/nick/Documents/Github/immich_sync_app/.github/workflows/maintainer-approval.yml).
+Approval enforcement for pull requests opened by other people is handled by [`.github/workflows/maintainer-approval.yml`](../.github/workflows/maintainer-approval.yml).
 
 Behavior:
 
@@ -74,9 +74,9 @@ This workflow is now a defense-in-depth signal. The authoritative merge policy o
 
 ## Cargo Vendor Guard
 
-The Flatpak manifests depend on [cargo-sources.json](/home/nick/Documents/Github/immich_sync_app/cargo-sources.json), so dependency updates are not complete unless the vendored source list stays in sync.
+The Flatpak manifests depend on [cargo-sources.json](../cargo-sources.json), so dependency updates are not complete unless the vendored source list stays in sync.
 
-The guard workflow is [`.github/workflows/cargo-sources-guard.yml`](/home/nick/Documents/Github/immich_sync_app/.github/workflows/cargo-sources-guard.yml).
+The guard workflow is [`.github/workflows/cargo-sources-guard.yml`](../.github/workflows/cargo-sources-guard.yml).
 
 It runs on every pull request to `main`, and it fails when:
 
@@ -93,7 +93,7 @@ The workflow allows a root package version-only `Cargo.lock` change for release 
 
 ## Docs Link Check
 
-Documentation link checks run from [`.github/workflows/docs-links.yml`](/home/nick/Documents/Github/immich_sync_app/.github/workflows/docs-links.yml).
+Documentation link checks run from [`.github/workflows/docs-links.yml`](../.github/workflows/docs-links.yml).
 
 It validates links in:
 
@@ -107,16 +107,16 @@ The workflow excludes `img.shields.io` badge URLs because those are noisy and no
 
 Release Drafter is configured by:
 
-- [`.github/release-drafter.yml`](/home/nick/Documents/Github/immich_sync_app/.github/release-drafter.yml)
-- [`.github/workflows/release-drafter.yml`](/home/nick/Documents/Github/immich_sync_app/.github/workflows/release-drafter.yml)
+- [`.github/release-drafter.yml`](../.github/release-drafter.yml)
+- [`.github/workflows/release-drafter.yml`](../.github/workflows/release-drafter.yml)
 
 It helps maintain a draft GitHub release based on merged PR labels and categories.
 
-This does not replace the manual changelog. Mimick still uses [CHANGELOG.md](/home/nick/Documents/Github/immich_sync_app/CHANGELOG.md) as the canonical release notes source for tagged releases.
+This does not replace the manual changelog. Mimick still uses [CHANGELOG.md](../CHANGELOG.md) as the canonical release notes source for tagged releases.
 
 ## Dependabot Auto Merge
 
-Approved dependency PRs can be armed for native GitHub auto-merge by [`.github/workflows/dependabot-auto-merge.yml`](/home/nick/Documents/Github/immich_sync_app/.github/workflows/dependabot-auto-merge.yml).
+Approved dependency PRs can be armed for native GitHub auto-merge by [`.github/workflows/dependabot-auto-merge.yml`](../.github/workflows/dependabot-auto-merge.yml).
 
 The workflow only targets pull requests that are:
 

--- a/docs/REPOSITORY_AUTOMATION.md
+++ b/docs/REPOSITORY_AUTOMATION.md
@@ -1,0 +1,151 @@
+# Repository Automation
+
+This document describes the automation stack used by the Mimick repository.
+
+## Overview
+
+The repo currently uses GitHub-native automation plus a small number of focused workflows:
+
+- `Dependabot` for Cargo and GitHub Actions dependency updates
+- `CODEOWNERS` for ownership and review guidance
+- `Maintainer Approval Gate` to require `@nicx17` approval on PRs opened by other people
+- `Cargo Vendor Guard` to catch missing `cargo-sources.json` refreshes
+- `Docs Link Check` to validate README, docs, and wiki links
+- `Release Drafter` to keep a draft release page up to date
+- `Dependabot Auto Merge` to enable native auto-merge for approved dependency PRs
+
+This setup aims to improve release safety and repo hygiene without turning the project into bot soup.
+
+## Dependabot
+
+Dependabot configuration lives in [`.github/dependabot.yml`](/home/nick/Documents/Github/immich_sync_app/.github/dependabot.yml).
+
+It currently updates:
+
+- Cargo dependencies
+- GitHub Actions workflow actions
+
+Expected repository labels:
+
+- `dependencies`
+- `rust`
+- `github-actions`
+
+## CODEOWNERS
+
+Ownership rules live in [`.github/CODEOWNERS`](/home/nick/Documents/Github/immich_sync_app/.github/CODEOWNERS).
+
+The default owner is:
+
+- `@nicx17`
+
+This is most useful when combined with branch protection or rulesets that require code-owner review.
+
+## Branch Protection On `main`
+
+`main` is now protected in GitHub with these native rules:
+
+- required status checks:
+  - `Format, Lint, and Test`
+  - `Dependency Audit`
+  - `Verify cargo-sources.json`
+- 1 required approving review
+- required code-owner review
+- stale approvals dismissed on new commits
+- required conversation resolution
+- admins are not enforced
+
+Because [`.github/CODEOWNERS`](/home/nick/Documents/Github/immich_sync_app/.github/CODEOWNERS) assigns the repo to `@nicx17`, pull requests opened by other people need your approval before merging.
+
+Your own pull requests are still practical to merge because admin enforcement is left off.
+
+## Maintainer Approval Gate
+
+Approval enforcement for pull requests opened by other people is handled by [`.github/workflows/maintainer-approval.yml`](/home/nick/Documents/Github/immich_sync_app/.github/workflows/maintainer-approval.yml).
+
+Behavior:
+
+- PRs opened by `@nicx17` pass automatically
+- PRs opened by anyone else require the latest review from `@nicx17` to be `APPROVED`
+
+This avoids forcing you to find a second reviewer for your own pull requests while still preventing other contributors from merging without your sign-off.
+
+This workflow is now a defense-in-depth signal. The authoritative merge policy on `main` is the native branch protection described above.
+
+## Cargo Vendor Guard
+
+The Flatpak manifests depend on [cargo-sources.json](/home/nick/Documents/Github/immich_sync_app/cargo-sources.json), so dependency updates are not complete unless the vendored source list stays in sync.
+
+The guard workflow is [`.github/workflows/cargo-sources-guard.yml`](/home/nick/Documents/Github/immich_sync_app/.github/workflows/cargo-sources-guard.yml).
+
+It runs on every pull request to `main`, and it fails when:
+
+- `Cargo.lock` changes
+- `cargo-sources.json` does not change
+
+Expected fix:
+
+```bash
+uv run flatpak-cargo-generator.py Cargo.lock -o cargo-sources.json
+```
+
+The workflow allows a root package version-only `Cargo.lock` change for release prep.
+
+## Docs Link Check
+
+Documentation link checks run from [`.github/workflows/docs-links.yml`](/home/nick/Documents/Github/immich_sync_app/.github/workflows/docs-links.yml).
+
+It validates links in:
+
+- `README.md`
+- `docs/**/*.md`
+- `wiki/**/*.md`
+
+The workflow excludes `img.shields.io` badge URLs because those are noisy and not useful as a release blocker.
+
+## Release Drafter
+
+Release Drafter is configured by:
+
+- [`.github/release-drafter.yml`](/home/nick/Documents/Github/immich_sync_app/.github/release-drafter.yml)
+- [`.github/workflows/release-drafter.yml`](/home/nick/Documents/Github/immich_sync_app/.github/workflows/release-drafter.yml)
+
+It helps maintain a draft GitHub release based on merged PR labels and categories.
+
+This does not replace the manual changelog. Mimick still uses [CHANGELOG.md](/home/nick/Documents/Github/immich_sync_app/CHANGELOG.md) as the canonical release notes source for tagged releases.
+
+## Dependabot Auto Merge
+
+Approved dependency PRs can be armed for native GitHub auto-merge by [`.github/workflows/dependabot-auto-merge.yml`](/home/nick/Documents/Github/immich_sync_app/.github/workflows/dependabot-auto-merge.yml).
+
+The workflow only targets pull requests that are:
+
+- opened by `dependabot[bot]`
+- labeled `dependencies`
+- approved by `@nicx17`
+- not drafts
+
+Important:
+
+- this workflow only enables GitHub's native auto-merge
+- the repository must have **Allow auto-merge** enabled in GitHub settings
+- branch protection or rulesets should require approval if you want "approved dependency PRs" to mean something enforceable
+
+## Recommended GitHub Settings
+
+These GitHub settings are already the intended baseline for this repo:
+
+1. **Allow auto-merge** is enabled.
+2. `main` is protected with required CI checks and review rules.
+3. Code-owner review is required for outside pull requests.
+
+Optional extras you may still want later:
+
+1. enforce admin rules too, if you ever want your own PRs to need the same review path
+2. add more required checks if additional always-on workflows become important enough to gate merges
+
+## Practical Notes
+
+- Public repositories can use GitHub-hosted Actions without the same billing pressure as private repos.
+- Dependabot dependency PRs still need human judgment for larger dependency jumps.
+- Release Drafter is a convenience layer, not the source of truth for Mimick release notes.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -61,15 +61,15 @@ tail -f ~/.cache/mimick/mimick.log
 Each log line includes a timestamp, level, and source module.
 
 ### Export a Diagnostics Bundle
-If you need to file a bug or inspect the app state in one place, use **Export Diagnostics** from the settings window. The export creates a `mimick-diagnostics-*` folder containing:
+If you need to file a bug or inspect the app state in one place, use **Export Diagnostics** from the settings window. The export creates a redacted `mimick-diagnostics-*` folder containing:
 - `summary.txt`
-- `config.json`
-- `status.json`
-- `retries.json`
-- `synced_index.json`
-- `mimick.log`
+- `config.redacted.json`
+- `status.redacted.json`
+- `retries.redacted.json`
+- `synced_index.redacted.json`
+- `privacy-note.txt`
 
-The generated summary omits the API key on purpose.
+The bundle intentionally omits API keys, raw logs, full local paths, and raw server URLs.
 
 ### Manual Debugging
 Run the application directly in a terminal to see `stdout` logs:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -113,16 +113,16 @@ This is useful when a server outage, permission issue, or bad file temporarily b
 
 Use **Export Diagnostics** in the settings window when you need a support snapshot.
 
-The export creates a timestamped `mimick-diagnostics-*` folder containing:
+The export creates a timestamped `mimick-diagnostics-*` folder containing redacted support files:
 
 * `summary.txt`
-* `config.json`
-* `status.json`
-* `retries.json`
-* `synced_index.json`
-* `mimick.log`
+* `config.redacted.json`
+* `status.redacted.json`
+* `retries.redacted.json`
+* `synced_index.redacted.json`
+* `privacy-note.txt`
 
-The summary intentionally omits your API key.
+API keys, raw logs, full local paths, and raw server URLs are intentionally omitted.
 
 ---
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -102,7 +102,9 @@ fn build_summary(config: &Config, state: &AppState) -> String {
         "Pause on battery power: {}",
         config.data.pause_on_battery_power
     ));
-    lines.push("Sensitive data policy: URLs, API key, logs, and full local paths omitted".to_string());
+    lines.push(
+        "Sensitive data policy: URLs, API key, logs, and full local paths omitted".to_string(),
+    );
     lines.push(String::new());
     lines.push("Recent queue events:".to_string());
     for event in &state.recent_events {
@@ -349,7 +351,11 @@ mod tests {
         let summary = build_summary(&config, &state);
         assert!(summary.contains("App status: paused"));
         assert!(summary.contains("Configured watch paths: 1"));
-        assert!(summary.contains("Sensitive data policy: URLs, API key, logs, and full local paths omitted"));
+        assert!(
+            summary.contains(
+                "Sensitive data policy: URLs, API key, logs, and full local paths omitted"
+            )
+        );
         assert!(summary.contains("a.jpg [failed] attempts=2"));
         assert!(!summary.contains("/photos/a.jpg [failed] attempts=2"));
     }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,7 +1,9 @@
-//! Export a support-friendly diagnostics bundle without including secrets.
+//! Export a support-friendly diagnostics bundle with sensitive local data redacted.
 
 use crate::config::Config;
+use crate::queue_manager::FileTask;
 use crate::state_manager::AppState;
+use serde::Serialize;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -30,23 +32,26 @@ fn export_bundle_with_paths(
 
     let summary_path = bundle_dir.join("summary.txt");
     fs::write(summary_path, build_summary(config, state))?;
+    fs::write(
+        bundle_dir.join("privacy-note.txt"),
+        "This bundle intentionally omits API keys, raw logs, server URLs, and full local paths.\n",
+    )?;
 
-    copy_if_exists(&config.config_file, &bundle_dir.join("config.json"))?;
-    copy_if_exists(
-        &cache_path(cache_root, "status.json"),
-        &bundle_dir.join("status.json"),
+    write_json_pretty(
+        &bundle_dir.join("config.redacted.json"),
+        &build_config_export(config),
     )?;
-    copy_if_exists(
-        &cache_path(cache_root, "retries.json"),
-        &bundle_dir.join("retries.json"),
+    write_json_pretty(
+        &bundle_dir.join("status.redacted.json"),
+        &build_state_export(state),
     )?;
-    copy_if_exists(
-        &cache_path(cache_root, "synced_index.json"),
-        &bundle_dir.join("synced_index.json"),
+    write_json_pretty(
+        &bundle_dir.join("retries.redacted.json"),
+        &build_retry_export(&cache_path(cache_root, "retries.json"))?,
     )?;
-    copy_if_exists(
-        &cache_path(cache_root, "mimick.log"),
-        &bundle_dir.join("mimick.log"),
+    write_json_pretty(
+        &bundle_dir.join("synced_index.redacted.json"),
+        &build_sync_index_export(&cache_path(cache_root, "synced_index.json"))?,
     )?;
 
     Ok(bundle_dir)
@@ -67,11 +72,19 @@ fn build_summary(config: &Config, state: &AppState) -> String {
     lines.push(format!("Failed count: {}", state.failed_count));
     lines.push(format!(
         "Current file: {}",
-        state.current_file.as_deref().unwrap_or("none")
+        state
+            .current_file
+            .as_deref()
+            .map(redact_path_hint)
+            .unwrap_or_else(|| "none".to_string())
     ));
     lines.push(format!(
         "Last completed file: {}",
-        state.last_completed_file.as_deref().unwrap_or("none")
+        state
+            .last_completed_file
+            .as_deref()
+            .map(redact_path_hint)
+            .unwrap_or_else(|| "none".to_string())
     ));
     lines.push(format!(
         "Last error: {}",
@@ -89,13 +102,13 @@ fn build_summary(config: &Config, state: &AppState) -> String {
         "Pause on battery power: {}",
         config.data.pause_on_battery_power
     ));
-    lines.push("API key: omitted".to_string());
+    lines.push("Sensitive data policy: URLs, API key, logs, and full local paths omitted".to_string());
     lines.push(String::new());
     lines.push("Recent queue events:".to_string());
     for event in &state.recent_events {
         lines.push(format!(
             "- {} [{}] attempts={} detail={}",
-            event.path,
+            redact_path_hint(&event.path),
             event.status,
             event.attempts,
             event.detail.as_deref().unwrap_or("none")
@@ -105,15 +118,198 @@ fn build_summary(config: &Config, state: &AppState) -> String {
     lines.join("\n")
 }
 
-fn copy_if_exists(from: &Path, to: &Path) -> io::Result<()> {
-    if from.exists() {
-        fs::copy(from, to)?;
-    }
-    Ok(())
-}
-
 fn cache_path(cache_root: &Path, name: &str) -> PathBuf {
     cache_root.join(name)
+}
+
+#[derive(Serialize)]
+struct RedactedConfigExport {
+    internal_url_enabled: bool,
+    external_url_enabled: bool,
+    watch_path_count: usize,
+    watch_paths_with_custom_album: usize,
+    watch_paths_with_rules: usize,
+    run_on_startup: bool,
+    album_sync: bool,
+    delete_after_sync: bool,
+    pause_on_metered_network: bool,
+    pause_on_battery_power: bool,
+}
+
+#[derive(Serialize)]
+struct RedactedQueueEvent {
+    path_hint: String,
+    status: String,
+    detail: Option<String>,
+    attempts: u32,
+    timestamp: f64,
+}
+
+#[derive(Serialize)]
+struct RedactedStateExport {
+    status: String,
+    paused: bool,
+    pause_reason: Option<String>,
+    queue_size: usize,
+    total_queued: usize,
+    processed_count: usize,
+    failed_count: usize,
+    progress: u8,
+    current_file: Option<String>,
+    last_completed_file: Option<String>,
+    last_error: Option<String>,
+    diagnostics_exports: usize,
+    recent_events: Vec<RedactedQueueEvent>,
+}
+
+#[derive(Serialize)]
+struct RedactedRetryExport {
+    total_retry_items: usize,
+    reassociate_only_items: usize,
+    album_targeted_items: usize,
+}
+
+#[derive(Serialize)]
+struct RedactedSyncIndexExport {
+    total_entries: usize,
+    album_named_entries: usize,
+    album_id_entries: usize,
+}
+
+fn build_config_export(config: &Config) -> RedactedConfigExport {
+    let watch_paths_with_custom_album = config
+        .data
+        .watch_paths
+        .iter()
+        .filter(|entry| entry.album_name().is_some_and(|name| !name.is_empty()))
+        .count();
+    let watch_paths_with_rules = config
+        .data
+        .watch_paths
+        .iter()
+        .filter(|entry| {
+            let rules = entry.rules();
+            rules.ignore_hidden
+                || rules.max_file_size_mb.is_some()
+                || !rules.allowed_extensions.is_empty()
+        })
+        .count();
+
+    RedactedConfigExport {
+        internal_url_enabled: config.data.internal_url_enabled,
+        external_url_enabled: config.data.external_url_enabled,
+        watch_path_count: config.data.watch_paths.len(),
+        watch_paths_with_custom_album,
+        watch_paths_with_rules,
+        run_on_startup: config.data.run_on_startup,
+        album_sync: config.data.album_sync,
+        delete_after_sync: config.data.delete_after_sync,
+        pause_on_metered_network: config.data.pause_on_metered_network,
+        pause_on_battery_power: config.data.pause_on_battery_power,
+    }
+}
+
+fn build_state_export(state: &AppState) -> RedactedStateExport {
+    RedactedStateExport {
+        status: state.status.clone(),
+        paused: state.paused,
+        pause_reason: state.pause_reason.clone(),
+        queue_size: state.queue_size,
+        total_queued: state.total_queued,
+        processed_count: state.processed_count,
+        failed_count: state.failed_count,
+        progress: state.progress,
+        current_file: state.current_file.as_deref().map(redact_path_hint),
+        last_completed_file: state.last_completed_file.as_deref().map(redact_path_hint),
+        last_error: state.last_error.clone(),
+        diagnostics_exports: state.diagnostics_exports,
+        recent_events: state
+            .recent_events
+            .iter()
+            .map(|event| RedactedQueueEvent {
+                path_hint: redact_path_hint(&event.path),
+                status: event.status.clone(),
+                detail: event.detail.clone(),
+                attempts: event.attempts,
+                timestamp: event.timestamp,
+            })
+            .collect(),
+    }
+}
+
+fn build_retry_export(retry_path: &Path) -> io::Result<RedactedRetryExport> {
+    let tasks = if retry_path.exists() {
+        let content = fs::read_to_string(retry_path)?;
+        serde_json::from_str::<Vec<FileTask>>(&content).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    Ok(RedactedRetryExport {
+        total_retry_items: tasks.len(),
+        reassociate_only_items: tasks.iter().filter(|task| task.reassociate_only).count(),
+        album_targeted_items: tasks
+            .iter()
+            .filter(|task| task.album_id.is_some() || task.album_name.is_some())
+            .count(),
+    })
+}
+
+fn build_sync_index_export(sync_index_path: &Path) -> io::Result<RedactedSyncIndexExport> {
+    if !sync_index_path.exists() {
+        return Ok(RedactedSyncIndexExport {
+            total_entries: 0,
+            album_named_entries: 0,
+            album_id_entries: 0,
+        });
+    }
+
+    let content = fs::read_to_string(sync_index_path)?;
+    let json = serde_json::from_str::<serde_json::Value>(&content).unwrap_or_default();
+    let files = json
+        .get("files")
+        .and_then(|files| files.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut album_named_entries = 0usize;
+    let mut album_id_entries = 0usize;
+    for record in files.values() {
+        if record
+            .get("album_name")
+            .and_then(|value| value.as_str())
+            .is_some_and(|name| !name.is_empty())
+        {
+            album_named_entries += 1;
+        }
+        if record
+            .get("album_id")
+            .and_then(|value| value.as_str())
+            .is_some_and(|id| !id.is_empty())
+        {
+            album_id_entries += 1;
+        }
+    }
+
+    Ok(RedactedSyncIndexExport {
+        total_entries: files.len(),
+        album_named_entries,
+        album_id_entries,
+    })
+}
+
+fn write_json_pretty<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+    let content = serde_json::to_string_pretty(value)?;
+    fs::write(path, content)
+}
+
+fn redact_path_hint(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(|name| name.to_string())
+        .unwrap_or_else(|| "[path hidden]".to_string())
 }
 
 #[cfg(test)]
@@ -153,12 +349,13 @@ mod tests {
         let summary = build_summary(&config, &state);
         assert!(summary.contains("App status: paused"));
         assert!(summary.contains("Configured watch paths: 1"));
-        assert!(summary.contains("API key: omitted"));
-        assert!(summary.contains("/photos/a.jpg [failed] attempts=2"));
+        assert!(summary.contains("Sensitive data policy: URLs, API key, logs, and full local paths omitted"));
+        assert!(summary.contains("a.jpg [failed] attempts=2"));
+        assert!(!summary.contains("/photos/a.jpg [failed] attempts=2"));
     }
 
     #[test]
-    fn test_export_bundle_writes_summary_and_cache_files() {
+    fn test_export_bundle_writes_redacted_files_only() {
         let dir = tempdir().unwrap();
         let dest_root = dir.path().join("exports");
         let cache_root = dir.path().join("cache");
@@ -182,10 +379,22 @@ mod tests {
         let bundle_dir =
             export_bundle_with_paths(&dest_root, &state, &config, &cache_root).unwrap();
         assert!(bundle_dir.join("summary.txt").exists());
-        assert!(bundle_dir.join("config.json").exists());
-        assert!(bundle_dir.join("status.json").exists());
-        assert!(bundle_dir.join("retries.json").exists());
-        assert!(bundle_dir.join("synced_index.json").exists());
-        assert!(bundle_dir.join("mimick.log").exists());
+        assert!(bundle_dir.join("privacy-note.txt").exists());
+        assert!(bundle_dir.join("config.redacted.json").exists());
+        assert!(bundle_dir.join("status.redacted.json").exists());
+        assert!(bundle_dir.join("retries.redacted.json").exists());
+        assert!(bundle_dir.join("synced_index.redacted.json").exists());
+        assert!(!bundle_dir.join("config.json").exists());
+        assert!(!bundle_dir.join("status.json").exists());
+        assert!(!bundle_dir.join("retries.json").exists());
+        assert!(!bundle_dir.join("synced_index.json").exists());
+        assert!(!bundle_dir.join("mimick.log").exists());
+
+        let config_export = fs::read_to_string(bundle_dir.join("config.redacted.json")).unwrap();
+        assert!(config_export.contains("\"watch_path_count\": 0"));
+        assert!(!config_export.contains("http://localhost"));
+
+        let retry_export = fs::read_to_string(bundle_dir.join("retries.redacted.json")).unwrap();
+        assert!(retry_export.contains("\"total_retry_items\": 0"));
     }
 }

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -6,18 +6,19 @@ Mimick is a Linux background app that watches selected folders and syncs photos 
 
 ## Start Here
 
-- [Installation](Installation)
-- [Configuration and First Run](Configuration-and-First-Run)
-- [Sync Behavior](Sync-Behavior)
-- [Flatpak and Permissions](Flatpak-and-Permissions)
-- [Troubleshooting](Troubleshooting)
+- [Installation](https://github.com/nicx17/mimick/wiki/Installation)
+- [Configuration and First Run](https://github.com/nicx17/mimick/wiki/Configuration-and-First-Run)
+- [Sync Behavior](https://github.com/nicx17/mimick/wiki/Sync-Behavior)
+- [Flatpak and Permissions](https://github.com/nicx17/mimick/wiki/Flatpak-and-Permissions)
+- [Troubleshooting](https://github.com/nicx17/mimick/wiki/Troubleshooting)
 
 ## Maintainers and Contributors
 
-- [Architecture](Architecture)
-- [Development](Development)
-- [Testing](Testing)
-- [Release Operations](Release-Operations)
+- [Architecture](https://github.com/nicx17/mimick/wiki/Architecture)
+- [Development](https://github.com/nicx17/mimick/wiki/Development)
+- [Testing](https://github.com/nicx17/mimick/wiki/Testing)
+- [Repository Automation](https://github.com/nicx17/mimick/wiki/Repository-Automation)
+- [Release Operations](https://github.com/nicx17/mimick/wiki/Release-Operations)
 
 ## Project Notes
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -6,19 +6,19 @@ Mimick is a Linux background app that watches selected folders and syncs photos 
 
 ## Start Here
 
-- [Installation](https://github.com/nicx17/mimick/wiki/Installation)
-- [Configuration and First Run](https://github.com/nicx17/mimick/wiki/Configuration-and-First-Run)
-- [Sync Behavior](https://github.com/nicx17/mimick/wiki/Sync-Behavior)
-- [Flatpak and Permissions](https://github.com/nicx17/mimick/wiki/Flatpak-and-Permissions)
-- [Troubleshooting](https://github.com/nicx17/mimick/wiki/Troubleshooting)
+- [Installation](Installation.md)
+- [Configuration and First Run](Configuration-and-First-Run.md)
+- [Sync Behavior](Sync-Behavior.md)
+- [Flatpak and Permissions](Flatpak-and-Permissions.md)
+- [Troubleshooting](Troubleshooting.md)
 
 ## Maintainers and Contributors
 
-- [Architecture](https://github.com/nicx17/mimick/wiki/Architecture)
-- [Development](https://github.com/nicx17/mimick/wiki/Development)
-- [Testing](https://github.com/nicx17/mimick/wiki/Testing)
-- [Repository Automation](https://github.com/nicx17/mimick/wiki/Repository-Automation)
-- [Release Operations](https://github.com/nicx17/mimick/wiki/Release-Operations)
+- [Architecture](Architecture.md)
+- [Development](Development.md)
+- [Testing](Testing.md)
+- [Repository Automation](Repository-Automation.md)
+- [Release Operations](Release-Operations.md)
 
 ## Project Notes
 

--- a/wiki/Repository-Automation.md
+++ b/wiki/Repository-Automation.md
@@ -1,0 +1,45 @@
+# Repository Automation
+
+Mimick uses a small, focused automation stack for repository hygiene and release safety.
+
+## Current Automation
+
+- Dependabot for Cargo and GitHub Actions updates
+- CODEOWNERS for default repository ownership
+- Maintainer approval gate for PRs opened by other contributors
+- Cargo vendor guard for `cargo-sources.json`
+- Docs link checking for README, docs, and wiki pages
+- Release Drafter for a rolling draft release page
+- Dependabot auto-merge workflow for approved dependency PRs
+
+## Why It Exists
+
+This repo ships a Flatpak build that depends on vendored Cargo metadata, maintains a manual changelog, and relies on workflow-driven releases. A few guardrails go a long way here.
+
+## Important Manual Settings
+
+The important GitHub-side settings are now in place on `main`:
+
+1. `Allow auto-merge`
+2. required status checks:
+   `Format, Lint, and Test`, `Dependency Audit`, and `Verify cargo-sources.json`
+3. 1 required approving review
+4. required code-owner review
+5. stale approvals are dismissed on new commits
+6. conversation resolution is required
+
+Because the repo-wide CODEOWNERS entry points to `@nicx17`, PRs from other contributors now need your approval before merging.
+
+Admins are not enforced, so your own PRs remain practical to merge when needed.
+
+## Key Files
+
+- [`.github/dependabot.yml`](https://github.com/nicx17/mimick/blob/main/.github/dependabot.yml)
+- [`.github/CODEOWNERS`](https://github.com/nicx17/mimick/blob/main/.github/CODEOWNERS)
+- [`.github/workflows/maintainer-approval.yml`](https://github.com/nicx17/mimick/blob/main/.github/workflows/maintainer-approval.yml)
+- [`.github/workflows/cargo-sources-guard.yml`](https://github.com/nicx17/mimick/blob/main/.github/workflows/cargo-sources-guard.yml)
+- [`.github/workflows/docs-links.yml`](https://github.com/nicx17/mimick/blob/main/.github/workflows/docs-links.yml)
+- [`.github/workflows/release-drafter.yml`](https://github.com/nicx17/mimick/blob/main/.github/workflows/release-drafter.yml)
+- [`.github/workflows/dependabot-auto-merge.yml`](https://github.com/nicx17/mimick/blob/main/.github/workflows/dependabot-auto-merge.yml)
+
+For the fuller maintainer-facing explanation, see [`docs/REPOSITORY_AUTOMATION.md`](https://github.com/nicx17/mimick/blob/main/docs/REPOSITORY_AUTOMATION.md).

--- a/wiki/Repository-Automation.md
+++ b/wiki/Repository-Automation.md
@@ -34,12 +34,12 @@ Admins are not enforced, so your own PRs remain practical to merge when needed.
 
 ## Key Files
 
-- [`.github/dependabot.yml`](https://github.com/nicx17/mimick/blob/main/.github/dependabot.yml)
-- [`.github/CODEOWNERS`](https://github.com/nicx17/mimick/blob/main/.github/CODEOWNERS)
-- [`.github/workflows/maintainer-approval.yml`](https://github.com/nicx17/mimick/blob/main/.github/workflows/maintainer-approval.yml)
-- [`.github/workflows/cargo-sources-guard.yml`](https://github.com/nicx17/mimick/blob/main/.github/workflows/cargo-sources-guard.yml)
-- [`.github/workflows/docs-links.yml`](https://github.com/nicx17/mimick/blob/main/.github/workflows/docs-links.yml)
-- [`.github/workflows/release-drafter.yml`](https://github.com/nicx17/mimick/blob/main/.github/workflows/release-drafter.yml)
-- [`.github/workflows/dependabot-auto-merge.yml`](https://github.com/nicx17/mimick/blob/main/.github/workflows/dependabot-auto-merge.yml)
+- [`.github/dependabot.yml`](../.github/dependabot.yml)
+- [`.github/CODEOWNERS`](../.github/CODEOWNERS)
+- [`.github/workflows/maintainer-approval.yml`](../.github/workflows/maintainer-approval.yml)
+- [`.github/workflows/cargo-sources-guard.yml`](../.github/workflows/cargo-sources-guard.yml)
+- [`.github/workflows/docs-links.yml`](../.github/workflows/docs-links.yml)
+- [`.github/workflows/release-drafter.yml`](../.github/workflows/release-drafter.yml)
+- [`.github/workflows/dependabot-auto-merge.yml`](../.github/workflows/dependabot-auto-merge.yml)
 
-For the fuller maintainer-facing explanation, see [`docs/REPOSITORY_AUTOMATION.md`](https://github.com/nicx17/mimick/blob/main/docs/REPOSITORY_AUTOMATION.md).
+For the fuller maintainer-facing explanation, see [`docs/REPOSITORY_AUTOMATION.md`](../docs/REPOSITORY_AUTOMATION.md).

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,19 +1,20 @@
-[Home](Home)
+[Home](https://github.com/nicx17/mimick/wiki)
 
 ### Using Mimick
 
-- [Installation](Installation)
-- [Configuration and First Run](Configuration-and-First-Run)
-- [Sync Behavior](Sync-Behavior)
-- [Flatpak and Permissions](Flatpak-and-Permissions)
-- [Troubleshooting](Troubleshooting)
+- [Installation](https://github.com/nicx17/mimick/wiki/Installation)
+- [Configuration and First Run](https://github.com/nicx17/mimick/wiki/Configuration-and-First-Run)
+- [Sync Behavior](https://github.com/nicx17/mimick/wiki/Sync-Behavior)
+- [Flatpak and Permissions](https://github.com/nicx17/mimick/wiki/Flatpak-and-Permissions)
+- [Troubleshooting](https://github.com/nicx17/mimick/wiki/Troubleshooting)
 
 ### Building Mimick
 
-- [Architecture](Architecture)
-- [Development](Development)
-- [Testing](Testing)
+- [Architecture](https://github.com/nicx17/mimick/wiki/Architecture)
+- [Development](https://github.com/nicx17/mimick/wiki/Development)
+- [Testing](https://github.com/nicx17/mimick/wiki/Testing)
 
 ### Maintaining Mimick
 
-- [Release Operations](Release-Operations)
+- [Repository Automation](https://github.com/nicx17/mimick/wiki/Repository-Automation)
+- [Release Operations](https://github.com/nicx17/mimick/wiki/Release-Operations)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,20 +1,20 @@
-[Home](https://github.com/nicx17/mimick/wiki)
+[Home](Home.md)
 
 ### Using Mimick
 
-- [Installation](https://github.com/nicx17/mimick/wiki/Installation)
-- [Configuration and First Run](https://github.com/nicx17/mimick/wiki/Configuration-and-First-Run)
-- [Sync Behavior](https://github.com/nicx17/mimick/wiki/Sync-Behavior)
-- [Flatpak and Permissions](https://github.com/nicx17/mimick/wiki/Flatpak-and-Permissions)
-- [Troubleshooting](https://github.com/nicx17/mimick/wiki/Troubleshooting)
+- [Installation](Installation.md)
+- [Configuration and First Run](Configuration-and-First-Run.md)
+- [Sync Behavior](Sync-Behavior.md)
+- [Flatpak and Permissions](Flatpak-and-Permissions.md)
+- [Troubleshooting](Troubleshooting.md)
 
 ### Building Mimick
 
-- [Architecture](https://github.com/nicx17/mimick/wiki/Architecture)
-- [Development](https://github.com/nicx17/mimick/wiki/Development)
-- [Testing](https://github.com/nicx17/mimick/wiki/Testing)
+- [Architecture](Architecture.md)
+- [Development](Development.md)
+- [Testing](Testing.md)
 
 ### Maintaining Mimick
 
-- [Repository Automation](https://github.com/nicx17/mimick/wiki/Repository-Automation)
-- [Release Operations](https://github.com/nicx17/mimick/wiki/Release-Operations)
+- [Repository Automation](Repository-Automation.md)
+- [Release Operations](Release-Operations.md)


### PR DESCRIPTION
## Summary
- redact diagnostics exports so support bundles omit raw config, logs, URLs, and full local paths
- harden repository automation by pinning sensitive GitHub Actions and tightening Dependabot auto-merge
- make the Cargo vendor guard enforceable by running it on every PR and requiring it in branch protection
- update docs to reflect the new diagnostics privacy model and repository automation rules

## Why
This closes the main issues found in the review pass:
- diagnostics export exposed more private operational data than intended
- the Cargo vendor guard existed but was not actually merge-blocking
- some write-scoped workflows relied on floating action tags instead of pinned SHAs
- Dependabot auto-merge was broader than necessary

## Validation
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- YAML parse validation for .github/*.yml and .github/workflows/*.yml
- git diff --check

## GitHub Settings
- updated `main` branch protection to require `Verify cargo-sources.json` alongside the existing CI checks
