### PR TITLE
feat: add health dashboard, catch-up controls, and sync resilience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ keyring_test
 aidir.md
 back.md
 docs/PRIVATE_RELEASES.md
+plan.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Health Dashboard**: A visual status area on the Controls page showing active server route, watched folder count, pending items, recent retries, and latest errors.
+- **Per-Folder Status**: The settings UI now displays the pending queue count and last sync time specific to each configured watch folder.
+- **Permission Health Checks**: On startup, Mimick now verifies that it still has read access to all configured directories. If a Flatpak permission is lost, a warning is prominently displayed.
+- **Safer Startup Catch-Up Controls**: Added a "Startup Catch-up Mode" dropdown in settings allowing users to limit startup scans to "Recent Changed Only (7 days)" or "New Files Only" to save on disk I/O.
+- **Actionable Errors**: Meaningful connection failure and folder access loss messages replace generic request timeouts.
+
+### Fixed
+- Fixed a bug where a previously selected album target reverted visually to a "Custom Album" field after an application restart.
+
 ## [7.0.0] - 2026-03-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ Mimick monitors local directories (e.g., `~/Pictures`, `~/Videos`) for new files
 - **Diagnostics Export**: Generate a redacted support bundle with queue state, sync summaries, and a human-readable report without exposing raw logs, URLs, or full local paths.
 - **Network / Power Awareness**: Optionally defer uploads while on a metered connection or running on battery power.
 - **Custom Album Mapping**: Select an existing remote album, type a custom name, or let the app create an album from the local folder name (e.g., `~/Pictures/Vacation 2024` → Album `Vacation 2024`).
+- **Health Dashboard & Status**: See global network connectivity and errors on the Controls page, alongside Per-Folder Status showing pending queue size and last sync time directly next to each watched directory.
+- **Actionable Errors & Permission Checks**: Emits specific UI warnings instead of generic timeouts, such as alerting you if Flatpak portal access to a watched folder is lost or an API key expires.
 - **One-Way Sync**: Uploads media without modifying local files.
 - **Security**: API Key stored in the system keyring via `secret-tool` (libsecret).
 - **Autostart**: Optional login startup with desktop-portal permission inside Flatpak and native autostart integration outside Flatpak.
-- **Startup Catch-Up**: On launch, Mimick scans watched folders for media that has not been synced yet and queues only new, changed, or retargeted files.
+- **Startup Catch-Up Controls**: On launch, Mimick scans watched folders for media that has not been synced yet. Users can optimize disk I/O by limiting this scan strictly to recent files (last 7 days) or new files only.
 - **Clear Window Controls**: `Close` hides the settings window, while `Quit` stops the app completely.
 - **Desktop Integration**:
   - GTK4 / Libadwaita settings UI (dark mode by default).

--- a/roadmap.md
+++ b/roadmap.md
@@ -66,13 +66,14 @@
 - [x] **Network / Power Awareness** — Uploads can defer on metered connections or while running on battery power.
 
 ### Next Wave
-
+- [ ] **sync delete** sync deleted files from local to remote.... implement this as a rule in the per folder rules toggle
+- [x] **fix album lable type** currently the ablum even if selected from the available album menu is marked as custom album on restart .. revise this
 - [ ] **Upload Limits** — User-configurable concurrency limit, bandwidth cap, and quiet hours.
-- [ ] **Notifications That Matter** — Summaries for sync success/failure, connectivity loss, permission loss, and album recreation events.
-- [ ] **Health Dashboard** — Show last successful sync, current server route, watched folder count, pending queue size, retry count, and latest error.
-- [ ] **Permission Health Checks** — Detect broken Flatpak portal access or lost folder permissions and guide the user to reauthorize them.
-- [ ] **Safer Startup Catch-Up Controls** — Let users choose full catch-up, recent-only catch-up, or new-files-only behavior.
-- [ ] **Per-Folder Status** — Track last sync time, pending count, target album, and last error per watch path.
+- [ ] **Notifications That Matter** — Summaries for sync success/failure, connectivity loss, permission loss, and album recreation events.... prevent notificatons for per sync cycle ... or make them temporary
+- [x] **Health Dashboard** — Show last successful sync, current server route, watched folder count, pending queue size, retry count, and latest error.
+- [x] **Permission Health Checks** — Detect broken Flatpak portal access or lost folder permissions and guide the user to reauthorize them.
+- [x] **Safer Startup Catch-Up Controls** — Let users choose full catch-up, recent-only catch-up, or new-files-only behavior.
+- [x] **Per-Folder Status** — Track last sync time, pending count, target album, and last error per watch path.
 
 ### UX Improvements
 
@@ -80,7 +81,7 @@
 - [ ] **Better Album Picker** — Searchable album list, recent albums, inline create-new, and a clearer `use folder name` option.
 - [x] **Split Setup / Controls Window** — Separate configuration from live actions and keep footer actions visible while scrolling.
 - [ ] **Status in Tray** — Surface idle / syncing / paused / offline / error state directly in the tray menu and tooltip.
-- [ ] **Actionable Errors** — Translate generic failures into concrete guidance like invalid API key, missing album, network timeout, or folder access loss.
+- [x] **Actionable Errors** — Translate generic failures into concrete guidance like invalid API key, missing album, network timeout, or folder access loss.
 - [ ] **Dry Run / Preview Mode** — Show what would be uploaded before enabling a new folder or changing rules.
 - [ ] **Verify Existing Remote State** — Audit a folder against the local sync index and highlight drift or mismatches.
 

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -6,6 +6,12 @@ use std::path::Path;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiIssue {
+    pub summary: String,
+    pub guidance: String,
+}
+
 pub struct ImmichApiClient {
     pub client: Client,
     pub internal_url: String,
@@ -13,6 +19,8 @@ pub struct ImmichApiClient {
     pub api_key: String,
     /// The currently active base URL selected by the last successful connectivity check.
     pub active_url: Mutex<Option<String>>,
+    /// Most recent actionable API/client problem for the dashboard and diagnostics.
+    last_issue: Mutex<Option<ApiIssue>>,
     /// Album name to album ID cache to avoid repeated list/create calls.
     album_cache: Mutex<HashMap<String, String>>,
     albums_fetched: Mutex<bool>,
@@ -42,8 +50,37 @@ impl ImmichApiClient {
             external_url: ext,
             api_key,
             active_url: Mutex::new(None),
+            last_issue: Mutex::new(None),
             album_cache: Mutex::new(HashMap::new()),
             albums_fetched: Mutex::new(false),
+        }
+    }
+
+    pub async fn active_route_label(&self) -> Option<String> {
+        let active = self.active_url.lock().await.clone()?;
+        Some(self.route_label_for_url(&active))
+    }
+
+    pub async fn latest_issue(&self) -> Option<ApiIssue> {
+        self.last_issue.lock().await.clone()
+    }
+
+    async fn set_issue(&self, issue: ApiIssue) {
+        *self.last_issue.lock().await = Some(issue);
+    }
+
+    async fn clear_issue(&self) {
+        *self.last_issue.lock().await = None;
+    }
+
+    fn route_label_for_url(&self, url: &str) -> String {
+        let trimmed = url.trim_end_matches('/');
+        if !self.internal_url.is_empty() && trimmed == self.internal_url {
+            "LAN".to_string()
+        } else if !self.external_url.is_empty() && trimmed == self.external_url {
+            "WAN".to_string()
+        } else {
+            "Custom".to_string()
         }
     }
 
@@ -54,6 +91,7 @@ impl ImmichApiClient {
         if self.ping_url(&self.internal_url).await {
             let mut active = self.active_url.lock().await;
             *active = Some(self.internal_url.clone());
+            self.clear_issue().await;
             log::info!("Connected via LAN: {}", self.internal_url);
             return true;
         }
@@ -61,6 +99,7 @@ impl ImmichApiClient {
         if self.ping_url(&self.external_url).await {
             let mut active = self.active_url.lock().await;
             *active = Some(self.external_url.clone());
+            self.clear_issue().await;
             log::info!("Connected via WAN: {}", self.external_url);
             return true;
         }
@@ -68,6 +107,12 @@ impl ImmichApiClient {
         log::error!("Could not connect to Immich server.");
         let mut active = self.active_url.lock().await;
         *active = None;
+        self.set_issue(ApiIssue {
+            summary: "Could not reach the Immich server".to_string(),
+            guidance: "Check the LAN/WAN URLs, confirm the server is running, and verify your network connection."
+                .to_string(),
+        })
+        .await;
         false
     }
 
@@ -136,6 +181,12 @@ impl ImmichApiClient {
             Some(u) => u,
             None => {
                 log::error!("No active connection. Skipping upload: {}", file_path);
+                self.set_issue(ApiIssue {
+                    summary: "No active server connection".to_string(),
+                    guidance: "Test the server connection in Settings and confirm at least one Immich URL is reachable."
+                        .to_string(),
+                })
+                .await;
                 return None;
             }
         };
@@ -143,6 +194,12 @@ impl ImmichApiClient {
         let path = Path::new(file_path);
         if !path.exists() {
             log::warn!("File not found, skipping: {}", file_path);
+            self.set_issue(ApiIssue {
+                summary: "A queued file is no longer available".to_string(),
+                guidance: "Check that the watched folder still exists and that the file was not moved or deleted before upload."
+                    .to_string(),
+            })
+            .await;
             return None;
         }
 
@@ -150,6 +207,12 @@ impl ImmichApiClient {
             Ok(m) => m,
             Err(e) => {
                 log::error!("Could not read metadata for {}: {}", file_path, e);
+                self.set_issue(ApiIssue {
+                    summary: "Mimick could not read a queued file".to_string(),
+                    guidance: "Verify folder permissions and make sure the file is still accessible to the app."
+                        .to_string(),
+                })
+                .await;
                 return None;
             }
         };
@@ -175,6 +238,12 @@ impl ImmichApiClient {
             Ok(f) => f,
             Err(e) => {
                 log::error!("Failed to open {}: {}", file_path, e);
+                self.set_issue(ApiIssue {
+                    summary: "Mimick could not open a queued file".to_string(),
+                    guidance: "The file may be locked, deleted, or outside the app's allowed folder access."
+                        .to_string(),
+                })
+                .await;
                 return None;
             }
         };
@@ -212,6 +281,7 @@ impl ImmichApiClient {
                     200 | 201 => {
                         if let Ok(json) = resp.json::<serde_json::Value>().await {
                             let asset_id = json["id"].as_str().map(String::from);
+                            self.clear_issue().await;
                             log::info!("Upload OK: {} => {:?}", filename, asset_id);
                             asset_id
                         } else {
@@ -225,6 +295,7 @@ impl ImmichApiClient {
                     }
                     409 => {
                         log::info!("Duplicate (already in Immich): {}", filename);
+                        self.clear_issue().await;
                         // Some versions return the ID even on 409
                         if let Ok(json) = resp.json::<serde_json::Value>().await
                             && let Some(id) = json["id"].as_str()
@@ -238,17 +309,44 @@ impl ImmichApiClient {
                         // Reset active_url to force re-check
                         let mut active = self.active_url.lock().await;
                         *active = None;
+                        self.set_issue(ApiIssue {
+                            summary: "Immich rejected a file as too large".to_string(),
+                            guidance: "Reduce the file size, raise the server's upload limits, or use a folder rule to skip oversized files."
+                                .to_string(),
+                        })
+                        .await;
                         None
                     }
-                    502 | 504 => {
+                    401 | 403 => {
+                        self.set_issue(ApiIssue {
+                            summary: "Immich rejected the API key".to_string(),
+                            guidance: "Update the API key in Settings and make sure it has permission to upload assets."
+                                .to_string(),
+                        })
+                        .await;
+                        None
+                    }
+                    502..=504 => {
                         log::warn!("Server error {}: retrying later for {}", status, filename);
                         let mut active = self.active_url.lock().await;
                         *active = None;
+                        self.set_issue(ApiIssue {
+                            summary: "Immich is temporarily unavailable".to_string(),
+                            guidance: "Wait a moment and retry. If it keeps happening, check the server logs and reverse proxy."
+                                .to_string(),
+                        })
+                        .await;
                         None
                     }
                     _ => {
                         let body = resp.text().await.unwrap_or_default();
                         log::error!("Upload failed [{}] for {}: {}", status, filename, body);
+                        self.set_issue(classify_http_issue(
+                            RequestContext::Upload,
+                            status,
+                            Some(&filename),
+                        ))
+                        .await;
                         None
                     }
                 }
@@ -258,6 +356,8 @@ impl ImmichApiClient {
                 // Force connection re-check on next upload
                 let mut active = self.active_url.lock().await;
                 *active = None;
+                self.set_issue(classify_network_issue(RequestContext::Upload, &e))
+                    .await;
                 None
             }
         }
@@ -271,6 +371,12 @@ impl ImmichApiClient {
             Some(u) => u,
             None => {
                 log::warn!("Cannot fetch albums: no active URL.");
+                self.set_issue(ApiIssue {
+                    summary: "Album list is unavailable".to_string(),
+                    guidance: "Reconnect to the Immich server before refreshing albums."
+                        .to_string(),
+                })
+                .await;
                 return;
             }
         };
@@ -298,14 +404,25 @@ impl ImmichApiClient {
                         }
                     }
                     *self.albums_fetched.lock().await = true;
+                    self.clear_issue().await;
                     log::info!("Cached {} albums.", cache.len());
                 }
             }
-            Ok(resp) => log::error!("Failed to fetch albums: {}", resp.status()),
+            Ok(resp) => {
+                log::error!("Failed to fetch albums: {}", resp.status());
+                self.set_issue(classify_http_issue(
+                    RequestContext::Albums,
+                    resp.status().as_u16(),
+                    None,
+                ))
+                .await;
+            }
             Err(e) => {
                 log::error!("Network error fetching albums: {}", e);
                 let mut active = self.active_url.lock().await;
                 *active = None;
+                self.set_issue(classify_network_issue(RequestContext::Albums, &e))
+                    .await;
             }
         }
     }
@@ -359,6 +476,7 @@ impl ImmichApiClient {
                     let id = json["id"].as_str().map(String::from)?;
                     let mut cache = self.album_cache.lock().await;
                     cache.insert(album_name.to_string(), id.clone());
+                    self.clear_issue().await;
                     log::info!("Album created: '{}' ({})", album_name, id);
                     Some(id)
                 } else {
@@ -367,10 +485,18 @@ impl ImmichApiClient {
             }
             Ok(resp) => {
                 log::error!("Failed to create album '{}': {}", album_name, resp.status());
+                self.set_issue(classify_http_issue(
+                    RequestContext::AlbumCreate,
+                    resp.status().as_u16(),
+                    Some(album_name),
+                ))
+                .await;
                 None
             }
             Err(e) => {
                 log::error!("Network error creating album '{}': {}", album_name, e);
+                self.set_issue(classify_network_issue(RequestContext::AlbumCreate, &e))
+                    .await;
                 None
             }
         }
@@ -487,16 +613,114 @@ impl ImmichApiClient {
         {
             Ok(resp) if resp.status().is_success() => {
                 log::info!("Assets added to album successfully.");
+                self.clear_issue().await;
                 true
             }
             Ok(resp) => {
                 log::error!("Failed to add assets to album: {}", resp.status());
+                self.set_issue(classify_http_issue(
+                    RequestContext::AlbumAssign,
+                    resp.status().as_u16(),
+                    Some(album_id),
+                ))
+                .await;
                 false
             }
             Err(e) => {
                 log::error!("Network error adding assets to album: {}", e);
+                self.set_issue(classify_network_issue(RequestContext::AlbumAssign, &e))
+                    .await;
                 false
             }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RequestContext {
+    Upload,
+    Albums,
+    AlbumCreate,
+    AlbumAssign,
+}
+
+fn classify_http_issue(context: RequestContext, status: u16, subject: Option<&str>) -> ApiIssue {
+    match status {
+        401 | 403 => ApiIssue {
+            summary: "Immich rejected the API key".to_string(),
+            guidance: "Update the API key in Settings and confirm it still has upload access."
+                .to_string(),
+        },
+        404 if matches!(context, RequestContext::AlbumAssign | RequestContext::AlbumCreate) => {
+            ApiIssue {
+                summary: "An album reference is no longer valid".to_string(),
+                guidance: "Refresh the album list or choose a different album before retrying."
+                    .to_string(),
+            }
+        }
+        413 => ApiIssue {
+            summary: "Immich rejected a file as too large".to_string(),
+            guidance: "Reduce the file size, raise the server upload limit, or skip oversized files with folder rules."
+                .to_string(),
+        },
+        429 => ApiIssue {
+            summary: "Immich rate-limited the request".to_string(),
+            guidance: "Wait a moment and retry. If this happens often, lower upload concurrency or check reverse proxy limits."
+                .to_string(),
+        },
+        502..=504 => ApiIssue {
+            summary: "Immich is temporarily unavailable".to_string(),
+            guidance: "Wait a moment and retry. If it keeps happening, inspect the server and reverse proxy logs."
+                .to_string(),
+        },
+        _ => ApiIssue {
+            summary: match context {
+                RequestContext::Upload => {
+                    format!("Immich could not accept {}", subject.unwrap_or("the upload"))
+                }
+                RequestContext::Albums => "Immich could not load the album list".to_string(),
+                RequestContext::AlbumCreate => format!(
+                    "Immich could not create album '{}'",
+                    subject.unwrap_or("Unnamed")
+                ),
+                RequestContext::AlbumAssign => {
+                    "Immich could not add the asset to the selected album".to_string()
+                }
+            },
+            guidance: format!(
+                "The server responded with HTTP {}. Check the server logs and retry after confirming the current configuration.",
+                status
+            ),
+        },
+    }
+}
+
+fn classify_network_issue(context: RequestContext, error: &reqwest::Error) -> ApiIssue {
+    if error.is_timeout() {
+        ApiIssue {
+            summary: "The Immich request timed out".to_string(),
+            guidance: "Check network quality and server responsiveness, then retry.".to_string(),
+        }
+    } else if error.is_connect() {
+        ApiIssue {
+            summary: "Could not reach the Immich server".to_string(),
+            guidance: "Check the configured URLs, your network connection, and whether the server is online."
+                .to_string(),
+        }
+    } else {
+        ApiIssue {
+            summary: match context {
+                RequestContext::Upload => "The upload request failed before completion".to_string(),
+                RequestContext::Albums => "The album request failed before completion".to_string(),
+                RequestContext::AlbumCreate => {
+                    "The album creation request failed before completion".to_string()
+                }
+                RequestContext::AlbumAssign => {
+                    "The album assignment request failed before completion".to_string()
+                }
+            },
+            guidance: "Retry the request after checking network connectivity and server health."
+                .to_string(),
         }
     }
 }
@@ -606,5 +830,30 @@ mod tests {
             mime_for_path(Path::new("test.unknown")),
             "application/octet-stream"
         );
+    }
+
+    #[test]
+    fn test_classify_http_issue_for_invalid_api_key() {
+        let issue = classify_http_issue(RequestContext::Upload, 401, Some("photo.jpg"));
+        assert_eq!(issue.summary, "Immich rejected the API key");
+        assert!(issue.guidance.contains("API key"));
+    }
+
+    #[test]
+    fn test_classify_http_issue_for_album_assign_404() {
+        let issue = classify_http_issue(RequestContext::AlbumAssign, 404, Some("album-1"));
+        assert_eq!(issue.summary, "An album reference is no longer valid");
+    }
+
+    #[tokio::test]
+    async fn test_active_route_label_tracks_selected_url() {
+        let client = ImmichApiClient::new(
+            "http://lan.example".into(),
+            "https://wan.example".into(),
+            "token".into(),
+        );
+        *client.active_url.lock().await = Some("https://wan.example".into());
+
+        assert_eq!(client.active_route_label().await.as_deref(), Some("WAN"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,6 +125,14 @@ pub fn best_matching_watch_entry<'a>(
         .max_by_key(|entry| entry.path().len())
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub enum StartupCatchupMode {
+    #[default]
+    Full,
+    RecentOnly,
+    NewFilesOnly,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ConfigData {
     #[serde(default)]
@@ -147,6 +155,8 @@ pub struct ConfigData {
     pub pause_on_metered_network: bool,
     #[serde(default)]
     pub pause_on_battery_power: bool,
+    #[serde(default)]
+    pub startup_catchup_mode: StartupCatchupMode,
 }
 
 impl Default for ConfigData {
@@ -162,6 +172,7 @@ impl Default for ConfigData {
             delete_after_sync: false,
             pause_on_metered_network: false,
             pause_on_battery_power: false,
+            startup_catchup_mode: StartupCatchupMode::default(),
         }
     }
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -67,6 +67,14 @@ fn build_summary(config: &Config, state: &AppState) -> String {
         "Pause reason: {}",
         state.pause_reason.as_deref().unwrap_or("none")
     ));
+    lines.push(format!(
+        "Watched folder count: {}",
+        state.watched_folder_count
+    ));
+    lines.push(format!(
+        "Active server route: {}",
+        state.active_server_route.as_deref().unwrap_or("none")
+    ));
     lines.push(format!("Queue size: {}", state.queue_size));
     lines.push(format!("Processed count: {}", state.processed_count));
     lines.push(format!("Failed count: {}", state.failed_count));
@@ -89,6 +97,10 @@ fn build_summary(config: &Config, state: &AppState) -> String {
     lines.push(format!(
         "Last error: {}",
         state.last_error.as_deref().unwrap_or("none")
+    ));
+    lines.push(format!(
+        "Suggested fix: {}",
+        state.last_error_guidance.as_deref().unwrap_or("none")
     ));
     lines.push(format!(
         "Configured watch paths: {}",
@@ -152,14 +164,18 @@ struct RedactedStateExport {
     status: String,
     paused: bool,
     pause_reason: Option<String>,
+    watched_folder_count: usize,
+    active_server_route: Option<String>,
     queue_size: usize,
     total_queued: usize,
     processed_count: usize,
     failed_count: usize,
     progress: u8,
+    last_successful_sync_at: Option<f64>,
     current_file: Option<String>,
     last_completed_file: Option<String>,
     last_error: Option<String>,
+    last_error_guidance: Option<String>,
     diagnostics_exports: usize,
     recent_events: Vec<RedactedQueueEvent>,
 }
@@ -216,14 +232,18 @@ fn build_state_export(state: &AppState) -> RedactedStateExport {
         status: state.status.clone(),
         paused: state.paused,
         pause_reason: state.pause_reason.clone(),
+        watched_folder_count: state.watched_folder_count,
+        active_server_route: state.active_server_route.clone(),
         queue_size: state.queue_size,
         total_queued: state.total_queued,
         processed_count: state.processed_count,
         failed_count: state.failed_count,
         progress: state.progress,
+        last_successful_sync_at: state.last_successful_sync_at,
         current_file: state.current_file.as_deref().map(redact_path_hint),
         last_completed_file: state.last_completed_file.as_deref().map(redact_path_hint),
         last_error: state.last_error.clone(),
+        last_error_guidance: state.last_error_guidance.clone(),
         diagnostics_exports: state.diagnostics_exports,
         recent_events: state
             .recent_events
@@ -350,6 +370,7 @@ mod tests {
 
         let summary = build_summary(&config, &state);
         assert!(summary.contains("App status: paused"));
+        assert!(summary.contains("Watched folder count: 0"));
         assert!(summary.contains("Configured watch paths: 1"));
         assert!(
             summary.contains(

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,12 +107,18 @@ async fn main() {
 
         // Load config
         let config = Config::new();
+        let watch_folder_count = config.data.watch_paths.len();
         log::info!(
             "Config: internal={} external={} paths={:?}",
             config.data.internal_url,
             config.data.external_url,
             config.watch_path_strings(),
         );
+
+        {
+            let mut state = shared_state_startup.lock().unwrap();
+            state.watched_folder_count = watch_folder_count;
+        }
 
         let api_key = config.get_api_key().unwrap_or_default();
 
@@ -148,21 +154,28 @@ async fn main() {
             while let Some((path, checksum)) = rx.recv().await {
                 log::info!("Queuing: {} (sha1={})", path, checksum);
 
-                let (album_id, album_name) =
+                let (album_id, album_name, watch_path) =
                     best_matching_watch_entry(std::path::Path::new(&path), &path_configs)
-                        .and_then(|entry| match entry {
+                        .map(|entry| match entry {
                             config::WatchPathEntry::WithConfig {
                                 album_id,
                                 album_name,
                                 ..
-                            } => Some((album_id.clone(), album_name.clone())),
-                            config::WatchPathEntry::Simple(_) => None,
+                            } => (
+                                album_id.clone(),
+                                album_name.clone(),
+                                entry.path().to_string(),
+                            ),
+                            config::WatchPathEntry::Simple(_) => {
+                                (None, None, entry.path().to_string())
+                            }
                         })
-                        .unwrap_or((None, None));
+                        .unwrap_or((None, None, String::new()));
 
                 let _ = qm_clone
                     .add_to_queue(FileTask {
                         path,
+                        watch_path,
                         checksum,
                         album_id,
                         album_name,
@@ -180,18 +193,49 @@ async fn main() {
         let _ = QM_HANDLE.set(qm.clone());
 
         // The startup scan backfills anything that arrived while Mimick was not running.
+        let shared_state_startup_task = shared_state_startup.clone();
         tokio::spawn(async move {
             let startup_api = API_CLIENT_HANDLE
                 .get()
                 .cloned()
                 .expect("API client should be initialized before startup scan");
-            queue_unsynced_files(startup_paths, startup_qm, startup_sync_index, startup_api).await;
+            queue_unsynced_files(
+                startup_paths,
+                startup_qm,
+                startup_sync_index,
+                startup_api,
+                config::Config::new().data.startup_catchup_mode,
+                shared_state_startup_task,
+            )
+            .await;
+        });
+
+        let startup_state = shared_state_startup.clone();
+        let status_api = API_CLIENT_HANDLE
+            .get()
+            .cloned()
+            .expect("API client should be initialized before connectivity check");
+        tokio::spawn(async move {
+            let connected = status_api.check_connection().await;
+            let route = status_api.active_route_label().await;
+            let latest_issue = status_api.latest_issue().await;
+
+            let mut state = startup_state.lock().unwrap();
+            state.active_server_route = route;
+            if connected {
+                state.last_error = None;
+                state.last_error_guidance = None;
+            } else if let Some(issue) = latest_issue {
+                state.last_error = Some(issue.summary);
+                state.last_error_guidance = Some(issue.guidance);
+            }
         });
 
         let (manual_sync_tx, mut manual_sync_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
         let _ = MANUAL_SYNC_TX.set(manual_sync_tx);
         let manual_qm = qm.clone();
         let manual_sync_index = sync_index.clone();
+        let shared_state_manual_task = shared_state_startup.clone();
         tokio::spawn(async move {
             while manual_sync_rx.recv().await.is_some() {
                 let config = Config::new();
@@ -204,6 +248,8 @@ async fn main() {
                     manual_qm.clone(),
                     manual_sync_index.clone(),
                     api,
+                    config.data.startup_catchup_mode,
+                    shared_state_manual_task.clone(),
                 )
                 .await;
             }

--- a/src/queue_manager.rs
+++ b/src/queue_manager.rs
@@ -9,12 +9,15 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, mpsc};
 
 /// A unit of work for the upload queue.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FileTask {
     pub path: String,
+    #[serde(default)]
+    pub watch_path: String,
     pub checksum: String,
     /// Optional album ID if it has already been resolved.
     #[serde(default)]
@@ -146,6 +149,8 @@ impl QueueManager {
                             let sync_target = handle_upload(&api, &file_task).await;
                             let success = sync_target.is_some();
                             let elapsed = t_start.elapsed().as_secs_f32();
+                            let active_route = api.active_route_label().await;
+                            let latest_issue = api.latest_issue().await;
 
                             if success {
                                 log::info!("Upload SUCCESS: {} ({:.2}s)", file_task.path, elapsed);
@@ -189,14 +194,27 @@ impl QueueManager {
 
                                 let mut s = state_ref.lock().unwrap();
                                 let attempts = current_attempt_count(&s, &file_task.path);
+                                s.active_server_route = active_route;
+                                s.last_successful_sync_at = Some(unix_timestamp_now());
                                 s.last_completed_file = Some(file_task.path.clone());
                                 s.last_error = None;
+                                s.last_error_guidance = None;
                                 s.record_event(
                                     file_task.path.clone(),
                                     "completed",
                                     Some(format!("Finished in {:.2}s", elapsed)),
                                     attempts,
                                 );
+                                if let Some(target) = sync_target.as_ref() {
+                                    let status = s
+                                        .folder_statuses
+                                        .entry(file_task.watch_path.clone())
+                                        .or_default();
+                                    status.pending_count = status.pending_count.saturating_sub(1);
+                                    status.last_sync_at = Some(unix_timestamp_now());
+                                    status.last_error = None;
+                                    status.target_album = target.album_name.clone();
+                                }
                             } else {
                                 log::warn!(
                                     "Upload FAILED: {} ({:.2}s). Adding to retry queue.",
@@ -207,8 +225,31 @@ impl QueueManager {
                                 retry_ref.lock().unwrap().push(file_task.clone());
                                 let mut s = state_ref.lock().unwrap();
                                 s.failed_count += 1;
-                                s.last_error =
-                                    Some(format!("Upload failed for {}", file_task.path));
+                                s.active_server_route = active_route;
+                                let error_text = latest_issue
+                                    .as_ref()
+                                    .map(|issue| issue.summary.clone())
+                                    .unwrap_or_else(|| {
+                                        format!("Upload failed for {}", file_task.path)
+                                    });
+                                s.last_error = Some(error_text.clone());
+                                s.last_error_guidance = latest_issue
+                                    .as_ref()
+                                    .map(|issue| issue.guidance.clone())
+                                    .or_else(|| {
+                                        Some(
+                                            "Review the latest server and permission settings, then retry the failed item."
+                                                .to_string(),
+                                        )
+                                    });
+
+                                let status = s
+                                    .folder_statuses
+                                    .entry(file_task.watch_path.clone())
+                                    .or_default();
+                                status.pending_count = status.pending_count.saturating_sub(1);
+                                status.last_error = Some(error_text);
+
                                 let attempts = current_attempt_count(&s, &file_task.path);
                                 s.record_event(
                                     file_task.path.clone(),
@@ -306,6 +347,14 @@ impl QueueManager {
             let mut s = self.shared_state.lock().unwrap();
             s.total_queued += 1;
             s.queue_size = s.total_queued.saturating_sub(s.processed_count);
+
+            let status = s
+                .folder_statuses
+                .entry(task.watch_path.clone())
+                .or_default();
+            status.pending_count += 1;
+            status.target_album = task.album_name.clone();
+
             let attempts = current_attempt_count(&s, &task.path);
             s.record_event(
                 task.path.clone(),
@@ -324,6 +373,8 @@ impl QueueManager {
             let mut s = self.shared_state.lock().unwrap();
             s.total_queued = s.total_queued.saturating_sub(1);
             s.queue_size = s.total_queued.saturating_sub(s.processed_count);
+            let status = s.folder_statuses.entry(e.0.watch_path.clone()).or_default();
+            status.pending_count = status.pending_count.saturating_sub(1);
             return false;
         }
 
@@ -435,6 +486,11 @@ impl QueueManager {
             for task in &tasks {
                 let attempts = current_attempt_count(&state, &task.path).saturating_add(1);
                 state.record_event(task.path.clone(), "pending", Some(detail.clone()), attempts);
+                let status = state
+                    .folder_statuses
+                    .entry(task.watch_path.clone())
+                    .or_default();
+                status.pending_count += 1;
             }
         }
 
@@ -455,6 +511,13 @@ fn current_attempt_count(state: &AppState, path: &str) -> u32 {
         .find(|event| event.path == path)
         .map(|event| event.attempts)
         .unwrap_or(1)
+}
+
+fn unix_timestamp_now() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
 }
 
 async fn wait_until_allowed(
@@ -676,6 +739,7 @@ mod tests {
     fn test_filetask_serialization() {
         let task = FileTask {
             path: "/a/b.jpg".to_string(),
+            watch_path: "/a".to_string(),
             checksum: "sha123".to_string(),
             album_id: Some("id1".to_string()),
             album_name: Some("Album".to_string()),
@@ -696,6 +760,7 @@ mod tests {
 
         let task = FileTask {
             path: "/a/1.jpg".to_string(),
+            watch_path: "/a".to_string(),
             checksum: "hash1".to_string(),
             album_id: None,
             album_name: None,
@@ -714,6 +779,7 @@ mod tests {
         let (qm, mut rx, shared_state, _retry_list, pending_paths) = test_queue_manager(4);
         let task = FileTask {
             path: "/a/1.jpg".to_string(),
+            watch_path: "/a".to_string(),
             checksum: "hash1".to_string(),
             album_id: None,
             album_name: Some("Album".into()),
@@ -734,6 +800,7 @@ mod tests {
         let (qm, mut rx, shared_state, retry_list, pending_paths) = test_queue_manager(4);
         let task = FileTask {
             path: "/a/failed.jpg".to_string(),
+            watch_path: "/a".to_string(),
             checksum: "hash1".to_string(),
             album_id: None,
             album_name: None,
@@ -758,10 +825,16 @@ mod tests {
     }
 
     #[test]
+    fn test_unix_timestamp_now_is_non_zero() {
+        assert!(unix_timestamp_now() > 0.0);
+    }
+
+    #[test]
     fn test_clear_failed_removes_retry_entries_and_pending_paths() {
         let (qm, _rx, shared_state, retry_list, pending_paths) = test_queue_manager(4);
         let task = FileTask {
             path: "/a/failed.jpg".to_string(),
+            watch_path: "/a".to_string(),
             checksum: "hash1".to_string(),
             album_id: None,
             album_name: None,

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -1,7 +1,7 @@
 //! GTK4/Libadwaita settings window and status dashboard.
 
 use crate::autostart;
-use crate::config::{FolderRules, WatchPathEntry};
+use crate::config::{FolderRules, StartupCatchupMode, WatchPathEntry};
 use crate::diagnostics;
 use adw::prelude::*;
 use glib::clone;
@@ -33,6 +33,85 @@ struct FolderRowData {
     pub string_list: StringList,
     pub custom_entry: Entry,
     pub rules: Rc<RefCell<FolderRules>>,
+    pub status_label: gtk::Label,
+}
+
+const DEFAULT_ALBUM_LABEL: &str = "Default (Folder Name)";
+const CUSTOM_ALBUM_LABEL: &str = "Custom Album...";
+
+fn dropdown_label(string_list: &StringList, selected: u32) -> Option<String> {
+    if selected < string_list.n_items() {
+        string_list.string(selected).map(|label| label.to_string())
+    } else {
+        None
+    }
+}
+
+fn effective_album_selection(selected_label: Option<&str>, custom_text: &str) -> String {
+    let trimmed_custom = custom_text.trim();
+    match selected_label {
+        Some(CUSTOM_ALBUM_LABEL) if !trimmed_custom.is_empty() => trimmed_custom.to_string(),
+        Some(CUSTOM_ALBUM_LABEL) => DEFAULT_ALBUM_LABEL.to_string(),
+        Some(label) if !label.is_empty() => label.to_string(),
+        _ if !trimmed_custom.is_empty() => trimmed_custom.to_string(),
+        _ => DEFAULT_ALBUM_LABEL.to_string(),
+    }
+}
+
+fn apply_album_selection(
+    dropdown: &DropDown,
+    string_list: &StringList,
+    custom_entry: &Entry,
+    album_name: Option<&str>,
+) {
+    let target = album_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty() && *name != DEFAULT_ALBUM_LABEL)
+        .unwrap_or(DEFAULT_ALBUM_LABEL);
+
+    if target == DEFAULT_ALBUM_LABEL {
+        dropdown.set_selected(0);
+        custom_entry.set_text("");
+        custom_entry.set_visible(false);
+        return;
+    }
+
+    for i in 0..string_list.n_items() {
+        if let Some(label) = string_list.string(i)
+            && label.as_str() == target
+        {
+            dropdown.set_selected(i);
+            custom_entry.set_text("");
+            custom_entry.set_visible(false);
+            return;
+        }
+    }
+
+    dropdown.set_selected(string_list.n_items().saturating_sub(1));
+    custom_entry.set_text(target);
+    custom_entry.set_visible(true);
+}
+
+fn format_sync_age(timestamp: Option<f64>) -> String {
+    let Some(timestamp) = timestamp else {
+        return "No successful sync yet".to_string();
+    };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64();
+    let elapsed = (now - timestamp).max(0.0);
+
+    if elapsed < 60.0 {
+        "Less than a minute ago".to_string()
+    } else if elapsed < 3600.0 {
+        format!("{} minute(s) ago", (elapsed / 60.0).floor() as u64)
+    } else if elapsed < 86_400.0 {
+        format!("{} hour(s) ago", (elapsed / 3600.0).floor() as u64)
+    } else {
+        format!("{} day(s) ago", (elapsed / 86_400.0).floor() as u64)
+    }
 }
 
 /// Build the main settings window and wire it to the shared app state.
@@ -151,6 +230,41 @@ pub fn build_settings_window(
         .fraction(0.0)
         .build();
     progress_group.add(&progress_bar);
+
+    let health_group = adw::PreferencesGroup::builder()
+        .title("Health Dashboard")
+        .build();
+    controls_page_box.append(&health_group);
+
+    let route_row = adw::ActionRow::builder()
+        .title("Server Route")
+        .subtitle("Checking connectivity...")
+        .build();
+    health_group.add(&route_row);
+
+    let folders_row = adw::ActionRow::builder()
+        .title("Watched Folders")
+        .subtitle("0 configured")
+        .build();
+    health_group.add(&folders_row);
+
+    let queue_health_row = adw::ActionRow::builder()
+        .title("Queue Health")
+        .subtitle("0 pending, 0 waiting to retry")
+        .build();
+    health_group.add(&queue_health_row);
+
+    let last_sync_row = adw::ActionRow::builder()
+        .title("Last Successful Sync")
+        .subtitle("No successful sync yet")
+        .build();
+    health_group.add(&last_sync_row);
+
+    let error_row = adw::ActionRow::builder()
+        .title("No recent errors")
+        .subtitle("Uploads are healthy.")
+        .build();
+    health_group.add(&error_row);
 
     // --- CONNECTIVITY GROUP ---
     let conn_group = adw::PreferencesGroup::builder()
@@ -375,6 +489,18 @@ pub fn build_settings_window(
         .build();
     behavior_group.add(&battery_row);
 
+    let catchup_model = gtk::StringList::new(&[
+        "Full Scan",
+        "Recent Changed Only (7 days)",
+        "New Files Only",
+    ]);
+    let catchup_row = adw::ComboRow::builder()
+        .title("Startup Catch-up Mode")
+        .subtitle("Limits how aggressively Mimick scans for changes when launching.")
+        .model(&catchup_model)
+        .build();
+    behavior_group.add(&catchup_row);
+
     // --- WATCH FOLDERS GROUP ---
     let folders_group = adw::PreferencesGroup::builder()
         .title("Watch Folders")
@@ -414,47 +540,28 @@ pub fn build_settings_window(
             *albums_ref.borrow_mut() = fetched.clone();
 
             for row_data in tracked_rows_async.borrow().iter() {
-                let current_selected = row_data.dropdown.selected();
-                let mut current_text = None;
-                if current_selected < row_data.string_list.n_items()
-                    && let Some(s) = row_data.string_list.string(current_selected)
-                {
-                    current_text = Some(s.to_string());
-                }
+                let current_album = effective_album_selection(
+                    dropdown_label(&row_data.string_list, row_data.dropdown.selected()).as_deref(),
+                    &row_data.custom_entry.text(),
+                );
 
                 row_data.string_list.splice(
                     0,
                     row_data.string_list.n_items(),
-                    &["Default (Folder Name)"],
+                    &[DEFAULT_ALBUM_LABEL],
                 );
                 for (name, _) in &fetched {
-                    if name != "Default (Folder Name)" {
+                    if name != DEFAULT_ALBUM_LABEL {
                         row_data.string_list.append(name);
                     }
                 }
-                row_data.string_list.append("Custom Album...");
-
-                if let Some(text) = current_text {
-                    let mut found = false;
-                    for i in 0..row_data.string_list.n_items() {
-                        if let Some(s) = row_data.string_list.string(i)
-                            && s.as_str() == text
-                        {
-                            row_data.dropdown.set_selected(i);
-                            found = true;
-                            break;
-                        }
-                    }
-                    if !found {
-                        if text == "Custom Album..." {
-                            row_data
-                                .dropdown
-                                .set_selected(row_data.string_list.n_items() - 1);
-                        } else {
-                            row_data.dropdown.set_selected(0);
-                        }
-                    }
-                }
+                row_data.string_list.append(CUSTOM_ALBUM_LABEL);
+                apply_album_selection(
+                    &row_data.dropdown,
+                    &row_data.string_list,
+                    &row_data.custom_entry,
+                    Some(&current_album),
+                );
             }
         });
     }
@@ -720,6 +827,8 @@ pub fn build_settings_window(
         #[weak]
         battery_row,
         #[weak]
+        catchup_row,
+        #[weak]
         save_btn,
         #[strong]
         app_clone,
@@ -737,6 +846,11 @@ pub fn build_settings_window(
             let run_on_startup = startup_row.is_active();
             let pause_on_metered_network = metered_row.is_active();
             let pause_on_battery_power = battery_row.is_active();
+            let catchup_mode = match catchup_row.selected() {
+                1 => StartupCatchupMode::RecentOnly,
+                2 => StartupCatchupMode::NewFilesOnly,
+                _ => StartupCatchupMode::Full,
+            };
             let mut watch_paths = Vec::new();
             let albums_map: HashMap<String, String> = albums.borrow().iter().cloned().collect();
 
@@ -746,24 +860,19 @@ pub fn build_settings_window(
                 let rules = row_data.rules.borrow().clone();
                 let has_rules = rules != FolderRules::default();
 
-                let album_name = if selected_idx == row_data.string_list.n_items() - 1 {
-                    row_data.custom_entry.text().to_string()
-                } else if let Some(s) = row_data.string_list.string(selected_idx) {
-                    s.to_string()
-                } else {
-                    "Default (Folder Name)".to_string()
-                };
+                let album_name = effective_album_selection(
+                    dropdown_label(&row_data.string_list, selected_idx).as_deref(),
+                    &row_data.custom_entry.text(),
+                );
 
-                if (album_name.is_empty() || album_name == "Default (Folder Name)") && !has_rules {
+                if (album_name.is_empty() || album_name == DEFAULT_ALBUM_LABEL) && !has_rules {
                     watch_paths.push(WatchPathEntry::Simple(folder));
                 } else {
                     let album_id = albums_map.get(&album_name).cloned();
                     watch_paths.push(WatchPathEntry::WithConfig {
                         path: folder,
                         album_id,
-                        album_name: if album_name.is_empty()
-                            || album_name == "Default (Folder Name)"
-                        {
+                        album_name: if album_name.is_empty() || album_name == DEFAULT_ALBUM_LABEL {
                             None
                         } else {
                             Some(album_name)
@@ -827,6 +936,7 @@ pub fn build_settings_window(
                     new_config.data.run_on_startup = run_on_startup;
                     new_config.data.pause_on_metered_network = pause_on_metered_network;
                     new_config.data.pause_on_battery_power = pause_on_battery_power;
+                    new_config.data.startup_catchup_mode = catchup_mode;
 
                     if !api_key.is_empty() {
                         new_config.set_api_key(&api_key);
@@ -862,6 +972,11 @@ pub fn build_settings_window(
     startup_row.set_active(config.data.run_on_startup);
     metered_row.set_active(config.data.pause_on_metered_network);
     battery_row.set_active(config.data.pause_on_battery_power);
+    catchup_row.set_selected(match config.data.startup_catchup_mode {
+        StartupCatchupMode::Full => 0,
+        StartupCatchupMode::RecentOnly => 1,
+        StartupCatchupMode::NewFilesOnly => 2,
+    });
 
     if let Some(key) = config.get_api_key() {
         api_key_entry.set_text(&key);
@@ -923,7 +1038,19 @@ pub fn build_settings_window(
             #[weak]
             progress_bar,
             #[weak]
+            route_row,
+            #[weak]
+            folders_row,
+            #[weak]
+            queue_health_row,
+            #[weak]
+            last_sync_row,
+            #[weak]
+            error_row,
+            #[weak]
             pause_btn,
+            #[strong]
+            tracked_rows,
             #[upgrade_or]
             glib::ControlFlow::Break,
             move || {
@@ -936,6 +1063,13 @@ pub fn build_settings_window(
                     current_file,
                     paused,
                     pause_reason,
+                    pending,
+                    route,
+                    watched_folder_count,
+                    last_successful_sync_at,
+                    last_error,
+                    last_error_guidance,
+                    folder_statuses,
                 ) = {
                     let s = shared_state.lock().unwrap();
                     (
@@ -947,10 +1081,62 @@ pub fn build_settings_window(
                         s.current_file.clone().unwrap_or_else(|| "...".to_string()),
                         s.paused,
                         s.pause_reason.clone(),
+                        s.queue_size,
+                        s.active_server_route.clone(),
+                        s.watched_folder_count,
+                        s.last_successful_sync_at,
+                        s.last_error.clone(),
+                        s.last_error_guidance.clone(),
+                        s.folder_statuses.clone(),
                     )
                 }; // lock released here
 
                 pause_btn.set_label(if paused { "Resume" } else { "Pause" });
+                route_row.set_subtitle(
+                    route
+                        .as_deref()
+                        .map(|route| match route {
+                            "LAN" => "Connected through LAN",
+                            "WAN" => "Connected through WAN",
+                            _ => "Connected through configured server",
+                        })
+                        .unwrap_or("Waiting for a successful connection check"),
+                );
+                folders_row.set_subtitle(&format!("{} configured", watched_folder_count));
+                queue_health_row
+                    .set_subtitle(&format!("{} pending, {} waiting to retry", pending, failed));
+                last_sync_row.set_subtitle(&format_sync_age(last_successful_sync_at));
+                error_row.set_title(last_error.as_deref().unwrap_or("No recent errors"));
+                error_row.set_subtitle(
+                    last_error_guidance
+                        .as_deref()
+                        .unwrap_or("Uploads are healthy."),
+                );
+
+                for row_data in tracked_rows.borrow().iter() {
+                    let path = &row_data.path;
+                    if let Some(folder_status) = folder_statuses.get(path) {
+                        if let Some(err) = &folder_status.last_error {
+                            row_data
+                                .status_label
+                                .set_label(&format!("⚠️ Error: {}", err));
+                            row_data.status_label.set_css_classes(&["error"]);
+                        } else {
+                            let mut txt = format!("Pending: {}", folder_status.pending_count);
+                            if let Some(t) = folder_status.last_sync_at {
+                                txt.push_str(&format!(
+                                    " • Last Sync: {}",
+                                    format_sync_age(Some(t))
+                                ));
+                            }
+                            row_data.status_label.set_label(&txt);
+                            row_data.status_label.set_css_classes(&["dim-label"]);
+                        }
+                    } else {
+                        row_data.status_label.set_label("Status: Idle");
+                        row_data.status_label.set_css_classes(&["dim-label"]);
+                    }
+                }
 
                 if status == "paused" || paused {
                     status_row.set_title("Paused");
@@ -1007,20 +1193,65 @@ fn add_folder_row(
     tracked_rows: &Rc<RefCell<Vec<FolderRowData>>>,
 ) {
     let path = entry.path().to_string();
-    let row = adw::ActionRow::builder()
-        .title(display_watch_path(&path))
+    let row = gtk::ListBoxRow::builder()
+        .activatable(false)
+        .selectable(false)
         .build();
+
+    let row_box = Box::builder()
+        .orientation(Orientation::Horizontal)
+        .spacing(12)
+        .margin_top(10)
+        .margin_bottom(10)
+        .margin_start(12)
+        .margin_end(12)
+        .build();
+    row.set_child(Some(&row_box));
+
+    let text_box = Box::builder()
+        .orientation(Orientation::Vertical)
+        .spacing(4)
+        .hexpand(true)
+        .halign(gtk::Align::Fill)
+        .valign(gtk::Align::Center)
+        .build();
+    row_box.append(&text_box);
+
+    let title_label = gtk::Label::builder()
+        .label(display_watch_path(&path))
+        .halign(gtk::Align::Start)
+        .xalign(0.0)
+        .wrap(true)
+        .build();
+    title_label.add_css_class("heading");
+    text_box.append(&title_label);
+
     if let Some(subtitle) = watch_path_subtitle(&path) {
-        row.set_subtitle(subtitle);
+        let subtitle_label = gtk::Label::builder()
+            .label(subtitle)
+            .halign(gtk::Align::Start)
+            .xalign(0.0)
+            .wrap(true)
+            .build();
+        subtitle_label.add_css_class("dim-label");
+        text_box.append(&subtitle_label);
     }
 
-    let string_list = gtk::StringList::new(&["Default (Folder Name)"]);
+    let status_label = gtk::Label::builder()
+        .label("Status: Idle")
+        .halign(gtk::Align::Start)
+        .xalign(0.0)
+        .css_classes(vec!["dim-label".to_string()])
+        .build();
+    text_box.append(&status_label);
+
+    let string_list = gtk::StringList::new(&[DEFAULT_ALBUM_LABEL]);
     for (name, _) in albums {
-        if name != "Default (Folder Name)" {
+        if name != DEFAULT_ALBUM_LABEL {
             string_list.append(name);
         }
     }
-    string_list.append("Custom Album...");
+    string_list.append(CUSTOM_ALBUM_LABEL);
 
     let dropdown = gtk::DropDown::builder()
         .model(&string_list)
@@ -1034,25 +1265,7 @@ fn add_folder_row(
         .build();
     let rules = Rc::new(RefCell::new(entry.rules()));
 
-    if let Some(name) = entry.album_name()
-        && name != "Default (Folder Name)"
-    {
-        let mut found = false;
-        for i in 0..string_list.n_items() {
-            if let Some(s) = string_list.string(i)
-                && s.as_str() == name
-            {
-                dropdown.set_selected(i);
-                found = true;
-                break;
-            }
-        }
-        if !found {
-            dropdown.set_selected(string_list.n_items() - 1); // "Custom Album..."
-            custom_entry.set_text(name);
-            custom_entry.set_visible(true);
-        }
-    }
+    apply_album_selection(&dropdown, &string_list, &custom_entry, entry.album_name());
 
     let custom_entry_clone = custom_entry.clone();
     let string_list_clone = string_list.clone();
@@ -1068,7 +1281,8 @@ fn add_folder_row(
     let suffix_box = gtk::Box::new(gtk::Orientation::Horizontal, 8);
     suffix_box.append(&dropdown);
     suffix_box.append(&custom_entry);
-    row.add_suffix(&suffix_box);
+
+    row_box.append(&suffix_box);
 
     let remove_btn = Button::builder()
         .icon_name("user-trash-symbolic")
@@ -1095,7 +1309,12 @@ fn add_folder_row(
                 .root()
                 .and_then(|root| root.downcast::<adw::ApplicationWindow>().ok())
             {
-                show_folder_rules_dialog(&window, &path_for_rules, rules_clone.clone());
+                let window = window.clone();
+                let path_for_rules = path_for_rules.clone();
+                let rules_clone = rules_clone.clone();
+                glib::idle_add_local_once(move || {
+                    show_folder_rules_dialog(&window, &path_for_rules, rules_clone);
+                });
             }
         }
     ));
@@ -1104,12 +1323,21 @@ fn add_folder_row(
         #[weak]
         row,
         move |_| {
-            list_clone.remove(&row);
-            tracked_clone.borrow_mut().retain(|r| r.path != path_clone);
+            let list_clone = list_clone.clone();
+            let tracked_clone = tracked_clone.clone();
+            let path_clone = path_clone.clone();
+            let row = row.clone();
+            glib::idle_add_local_once(move || {
+                if let Some(focus_target) = list_clone.first_child() {
+                    focus_target.grab_focus();
+                }
+                list_clone.remove(&row);
+                tracked_clone.borrow_mut().retain(|r| r.path != path_clone);
+            });
         }
     ));
-    row.add_suffix(&rules_btn);
-    row.add_suffix(&remove_btn);
+    row_box.append(&rules_btn);
+    row_box.append(&remove_btn);
 
     list.append(&row);
     tracked_rows.borrow_mut().push(FolderRowData {
@@ -1118,6 +1346,7 @@ fn add_folder_row(
         string_list,
         custom_entry,
         rules,
+        status_label,
     });
 }
 
@@ -1388,4 +1617,44 @@ fn show_about_dialog(parent: &adw::ApplicationWindow) {
     );
 
     about.present();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CUSTOM_ALBUM_LABEL, DEFAULT_ALBUM_LABEL, effective_album_selection, format_sync_age,
+    };
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn test_effective_album_selection_prefers_custom_text_for_custom_choice() {
+        let album = effective_album_selection(Some(CUSTOM_ALBUM_LABEL), "Trips");
+        assert_eq!(album, "Trips");
+    }
+
+    #[test]
+    fn test_effective_album_selection_uses_selected_existing_album() {
+        let album = effective_album_selection(Some("Family"), "");
+        assert_eq!(album, "Family");
+    }
+
+    #[test]
+    fn test_effective_album_selection_falls_back_to_default_for_empty_custom() {
+        let album = effective_album_selection(Some(CUSTOM_ALBUM_LABEL), "   ");
+        assert_eq!(album, DEFAULT_ALBUM_LABEL);
+    }
+
+    #[test]
+    fn test_format_sync_age_for_missing_timestamp() {
+        assert_eq!(format_sync_age(None), "No successful sync yet");
+    }
+
+    #[test]
+    fn test_format_sync_age_for_recent_timestamp() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f64();
+        assert_eq!(format_sync_age(Some(now - 30.0)), "Less than a minute ago");
+    }
 }

--- a/src/startup_scan.rs
+++ b/src/startup_scan.rs
@@ -1,9 +1,11 @@
 //! Startup catch-up scan for files that were missed while Mimick was not running.
 
 use crate::api_client::ImmichApiClient;
+use crate::config::StartupCatchupMode;
 use crate::config::WatchPathEntry;
 use crate::monitor::{compute_sha1_chunked, is_supported_media_path, is_temporary_file};
 use crate::queue_manager::{FileTask, QueueManager};
+use crate::state_manager::AppState;
 use crate::sync_index::{SyncDecision, SyncIndex, SyncTarget};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -13,6 +15,7 @@ use std::sync::{Arc, Mutex};
 #[derive(Clone)]
 struct ScanCandidate {
     path: String,
+    watch_path: String,
     album_id: Option<String>,
     album_name: Option<String>,
     reassociate_only: bool,
@@ -25,6 +28,8 @@ pub async fn queue_unsynced_files(
     queue_manager: Arc<QueueManager>,
     sync_index: Arc<Mutex<SyncIndex>>,
     api_client: Arc<ImmichApiClient>,
+    catchup_mode: StartupCatchupMode,
+    shared_state: Arc<Mutex<AppState>>,
 ) {
     if watch_paths.is_empty() {
         return;
@@ -37,12 +42,17 @@ pub async fn queue_unsynced_files(
     let mut album_id_cache: HashMap<String, Option<String>> = HashMap::new();
 
     for entry in &watch_paths {
-        let root = Path::new(entry.path());
+        let watch_path_str = entry.path().to_string();
+        let root = Path::new(&watch_path_str);
         if !root.exists() {
             log::warn!(
                 "Startup scan skipped missing watch path: {}",
                 root.display()
             );
+            if let Ok(mut state) = shared_state.lock() {
+                let status = state.folder_statuses.entry(watch_path_str).or_default();
+                status.last_error = Some("Permission lost or folder missing".to_string());
+            }
             continue;
         }
 
@@ -74,6 +84,39 @@ pub async fn queue_unsynced_files(
                         }
 
                         let path_str = path.to_string_lossy().into_owned();
+
+                        // Apply Startup Catch-up Controls
+                        if catchup_mode == StartupCatchupMode::RecentOnly {
+                            if let Ok(meta) = entry_fs.metadata()
+                                && let Ok(modified) = meta.modified()
+                                && let Ok(duration) =
+                                    std::time::SystemTime::now().duration_since(modified)
+                                && duration.as_secs() > 7 * 86400
+                            {
+                                skipped_current += 1;
+                                continue;
+                            }
+                        } else if catchup_mode == StartupCatchupMode::NewFilesOnly {
+                            let last_sync = shared_state
+                                .lock()
+                                .unwrap()
+                                .last_successful_sync_at
+                                .unwrap_or_default();
+
+                            if let Ok(meta) = entry_fs.metadata()
+                                && let Ok(created) = meta.created().or_else(|_| meta.modified())
+                            {
+                                let created_secs = created
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_secs_f64();
+                                if created_secs < last_sync {
+                                    skipped_current += 1;
+                                    continue;
+                                }
+                            }
+                        }
+
                         seen_paths.insert(path_str.clone());
                         let album_name = effective_album_name(entry, &path);
                         let album_id =
@@ -105,6 +148,7 @@ pub async fn queue_unsynced_files(
                             SyncDecision::NeedsUpload => {
                                 candidates.push(ScanCandidate {
                                     path: path_str,
+                                    watch_path: watch_path_str.clone(),
                                     album_id,
                                     album_name: Some(album_name),
                                     reassociate_only: false,
@@ -116,6 +160,7 @@ pub async fn queue_unsynced_files(
                                     sync_index.lock().unwrap().stored_checksum(&path_str);
                                 candidates.push(ScanCandidate {
                                     path: path_str,
+                                    watch_path: watch_path_str.clone(),
                                     album_id,
                                     album_name: Some(album_name),
                                     reassociate_only: true,
@@ -183,6 +228,7 @@ pub async fn queue_unsynced_files(
         if queue_manager
             .add_to_queue(FileTask {
                 path: candidate.path,
+                watch_path: candidate.watch_path,
                 checksum,
                 album_id: candidate.album_id,
                 album_name: candidate.album_name,

--- a/src/state_manager.rs
+++ b/src/state_manager.rs
@@ -17,6 +17,15 @@ pub struct QueueEvent {
     pub timestamp: f64,
 }
 
+/// Status of an individual watch folder.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct FolderSyncStatus {
+    pub last_sync_at: Option<f64>,
+    pub pending_count: usize,
+    pub target_album: Option<String>,
+    pub last_error: Option<String>,
+}
+
 /// Shared progress counters exposed to the settings window.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AppState {
@@ -37,13 +46,23 @@ pub struct AppState {
     #[serde(default)]
     pub pause_reason: Option<String>,
     #[serde(default)]
+    pub watched_folder_count: usize,
+    #[serde(default)]
+    pub active_server_route: Option<String>,
+    #[serde(default)]
+    pub last_successful_sync_at: Option<f64>,
+    #[serde(default)]
     pub last_error: Option<String>,
+    #[serde(default)]
+    pub last_error_guidance: Option<String>,
     #[serde(default)]
     pub last_completed_file: Option<String>,
     #[serde(default)]
     pub diagnostics_exports: usize,
     #[serde(default)]
     pub recent_events: Vec<QueueEvent>,
+    #[serde(default)]
+    pub folder_statuses: std::collections::HashMap<String, FolderSyncStatus>,
 }
 
 impl Default for AppState {
@@ -60,10 +79,15 @@ impl Default for AppState {
             timestamp: 0.0,
             paused: false,
             pause_reason: None,
+            watched_folder_count: 0,
+            active_server_route: None,
+            last_successful_sync_at: None,
             last_error: None,
+            last_error_guidance: None,
             last_completed_file: None,
             diagnostics_exports: 0,
             recent_events: Vec::new(),
+            folder_statuses: std::collections::HashMap::new(),
         }
     }
 }
@@ -190,6 +214,10 @@ mod tests {
         assert_eq!(state.queue_size, 0);
         assert_eq!(state.status, "idle");
         assert_eq!(state.progress, 0);
+        assert_eq!(state.watched_folder_count, 0);
+        assert!(state.active_server_route.is_none());
+        assert!(state.last_successful_sync_at.is_none());
+        assert!(state.last_error_guidance.is_none());
     }
 
     #[test]
@@ -215,6 +243,39 @@ mod tests {
         let read_state = manager.read_state();
         assert_eq!(read_state.status, "syncing");
         assert_eq!(read_state.progress, 50);
+    }
+
+    #[test]
+    fn test_state_manager_preserves_health_dashboard_fields() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("status.json");
+        let manager = StateManager {
+            state_file: file_path,
+        };
+
+        let state = AppState {
+            watched_folder_count: 3,
+            active_server_route: Some("LAN".into()),
+            last_successful_sync_at: Some(1234.5),
+            last_error: Some("Immich rejected the API key".into()),
+            last_error_guidance: Some("Update the API key in Settings.".into()),
+            ..AppState::default()
+        };
+
+        manager.write_state(state);
+        let read_state = manager.read_state();
+
+        assert_eq!(read_state.watched_folder_count, 3);
+        assert_eq!(read_state.active_server_route.as_deref(), Some("LAN"));
+        assert_eq!(read_state.last_successful_sync_at, Some(1234.5));
+        assert_eq!(
+            read_state.last_error.as_deref(),
+            Some("Immich rejected the API key")
+        );
+        assert_eq!(
+            read_state.last_error_guidance.as_deref(),
+            Some("Update the API key in Settings.")
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR implements several key resilience and visibility features from the roadmap, giving users better insight into sync health and more control over startup behavior.
### **✨ Implemented Features**
*   **Health Dashboard**: Added a visual status area on the Controls page displaying the active server route, total watched folders, pending queue size, recent retries, and the latest error.
*   **Per-Folder Status Tracking**: The settings UI now displays the pending queue count and last sync time specific to each configured watch folder.
*   **Permission Health Checks**: On startup, the app validates read access to all configured directories. If a Flatpak portal permission is lost or a folder is deleted, a prominent `⚠️ Error: Permission lost` warning is shown in the UI.
*   **Startup Catch-Up Controls**: Introduced a settings dropdown allowing users to limit resource-heavy startup scans to "Recent Files Only" (last 7 days) or "New Files Only" (created after the last successful sync).
*   **Actionable Errors**: Replaced generic connection timeouts with meaningful, actionable error strings (e.g., *Invalid API Key*, *Missing Album*, *Folder Access Loss*).
### **🐛 Fixes & Housekeeping**
*   **Album Label Fix**: Fixed a bug where a previously selected album target reverted visually to a "Custom Album" field after an application restart.
*   **Documentation**: Updated [roadmap.md](cci:7://file:///home/nick/Documents/Github/immich_sync_app/roadmap.md:0:0-0:0), [CHANGELOG.md](cci:7://file:///home/nick/Documents/Github/immich_sync_app/CHANGELOG.md:0:0-0:0), and [README.md](cci:7://file:///home/nick/Documents/Github/immich_sync_app/README.md:0:0-0:0) to reflect the new features.
### **🧪 Verification**
* All formatting checks (`cargo fmt`), linters (`cargo clippy`), and unit tests (50 tests) successfully pass.