### PR TITLE
chore: update workflows and documentation for maintainer approval

### DIFF
--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -1,5 +1,10 @@
 name: Maintainer Approval Gate
 
+# This workflow is intended to be the approval gate for a solo-maintainer repo.
+# GitHub's native "required approving review" rule cannot be satisfied by the PR
+# author reviewing their own pull request, so this check passes automatically for
+# @nicx17's PRs and requires @nicx17 approval for PRs opened by anyone else.
+
 on:
   pull_request_target:
     branches: ["main"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,35 @@ jobs:
 
           sha256sum dist/mimick.flatpakrepo > dist/SHA256SUMS.txt
 
-      - name: Extract release notes
+      - name: Find latest draft release
+        id: draft_release
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+
+            const drafts = releases
+              .filter((release) => release.draft)
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            const draft = drafts[0];
+            if (!draft) {
+              core.info("No draft release found. Falling back to CHANGELOG.md.");
+              core.setOutput("found", "false");
+              return;
+            }
+
+            core.info(`Using draft release #${draft.id} (${draft.name || draft.tag_name})`);
+            core.setOutput("found", "true");
+            core.setOutput("id", String(draft.id));
+            core.setOutput("body", draft.body || "");
+
+      - name: Extract fallback release notes from changelog
+        if: steps.draft_release.outputs.found != 'true'
         shell: bash
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
@@ -94,10 +122,57 @@ jobs:
             capture { print }
           ' CHANGELOG.md | sed '/./,$!d' > dist/release-notes.md
 
-      - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: dist/release-notes.md
-          files: |
-            dist/mimick.flatpakrepo
-            dist/SHA256SUMS.txt
+      - name: Write draft release notes
+        if: steps.draft_release.outputs.found == 'true'
+        shell: bash
+        run: |
+          cat <<'EOF' > dist/release-notes.md
+          ${{ steps.draft_release.outputs.body }}
+          EOF
+
+      - name: Publish latest draft release
+        if: steps.draft_release.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+
+          jq -n \
+            --arg tag_name "${GITHUB_REF_NAME}" \
+            --arg target_commitish "${GITHUB_SHA}" \
+            --arg name "${TAG_VERSION}" \
+            --rawfile body dist/release-notes.md \
+            '{
+              tag_name: $tag_name,
+              target_commitish: $target_commitish,
+              name: $name,
+              body: $body,
+              draft: false,
+              prerelease: false,
+              make_latest: "true"
+            }' > dist/release-payload.json
+
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/releases/${{ steps.draft_release.outputs.id }}" \
+            --input dist/release-payload.json
+
+          gh release upload "${GITHUB_REF_NAME}" \
+            dist/mimick.flatpakrepo \
+            dist/SHA256SUMS.txt \
+            --clobber
+
+      - name: Publish GitHub release from changelog fallback
+        if: steps.draft_release.outputs.found != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          gh release create "${GITHUB_REF_NAME}" \
+            dist/mimick.flatpakrepo \
+            dist/SHA256SUMS.txt \
+            --title "${TAG_VERSION}" \
+            --notes-file dist/release-notes.md

--- a/docs/REPOSITORY_AUTOMATION.md
+++ b/docs/REPOSITORY_AUTOMATION.md
@@ -43,21 +43,19 @@ This is most useful when combined with branch protection or rulesets that requir
 
 ## Branch Protection On `main`
 
-`main` is now protected in GitHub with these native rules:
+For a solo-maintainer setup, `main` should be protected in GitHub with these native rules:
 
 - required status checks:
   - `Format, Lint, and Test`
   - `Dependency Audit`
   - `Verify cargo-sources.json`
-- 1 required approving review
-- required code-owner review
 - stale approvals dismissed on new commits
 - required conversation resolution
 - admins are not enforced
 
-Because [`.github/CODEOWNERS`](../.github/CODEOWNERS) assigns the repo to `@nicx17`, pull requests opened by other people need your approval before merging.
+Do not rely on GitHub's native `required approving review` rule for a solo-maintainer repository. GitHub does not let the PR author satisfy that rule by approving their own pull request, so enabling it will block your own PRs from ever becoming "approved" in the normal way.
 
-Your own pull requests are still practical to merge because admin enforcement is left off.
+Instead, this repo uses the `Maintainer Approval Gate` status check to require `@nicx17` approval on pull requests opened by other people, while allowing PRs authored by `@nicx17` to pass without a second account.
 
 ## Maintainer Approval Gate
 
@@ -112,7 +110,7 @@ Release Drafter is configured by:
 
 It helps maintain a draft GitHub release based on merged PR labels and categories.
 
-This does not replace the manual changelog. Mimick still uses [CHANGELOG.md](../CHANGELOG.md) as the canonical release notes source for tagged releases.
+Tagged releases now prefer the latest Release Drafter draft body when publishing a GitHub release. If no draft release exists, the release workflow falls back to the matching section in [CHANGELOG.md](../CHANGELOG.md).
 
 ## Dependabot Auto Merge
 
@@ -136,16 +134,18 @@ Important:
 These GitHub settings are already the intended baseline for this repo:
 
 1. **Allow auto-merge** is enabled.
-2. `main` is protected with required CI checks and review rules.
-3. Code-owner review is required for outside pull requests.
+2. `main` is protected with required CI checks and conversation resolution.
+3. `Maintainer Approval Gate` is included in the required status checks if you want outside-contributor PRs to require `@nicx17` approval.
 
 Optional extras you may still want later:
 
-1. enforce admin rules too, if you ever want your own PRs to need the same review path
-2. add more required checks if additional always-on workflows become important enough to gate merges
+1. re-enable native required approving reviews if you add another maintainer who can review your PRs
+2. enforce admin rules too, if you ever want your own PRs to need the same bypass restrictions
+3. add more required checks if additional always-on workflows become important enough to gate merges
 
 ## Practical Notes
 
 - Public repositories can use GitHub-hosted Actions without the same billing pressure as private repos.
 - Dependabot dependency PRs still need human judgment for larger dependency jumps.
-- Release Drafter is a convenience layer, not the source of truth for Mimick release notes.
+- Release Drafter is now the preferred GitHub release-notes source when a draft exists, while [CHANGELOG.md](../CHANGELOG.md) remains the fallback and long-form project history.
+- GitHub Actions cannot override the native "required approving review" rule for self-authored PRs; if you enable that rule, plan on a second reviewer or manual admin bypass.


### PR DESCRIPTION
- Updated `.github/workflows/release.yml`
  - Publishes the latest draft release body when a tag is pushed
  - Falls back to the matching `CHANGELOG.md` section if no draft release exists
  - Continues attaching `mimick.flatpakrepo` and `SHA256SUMS.txt`

- Updated `.github/workflows/maintainer-approval.yml`
  - Added clear workflow-level documentation about the solo-maintainer approval model

- Updated release and automation docs
  - `docs/REPOSITORY_AUTOMATION.md`
  - `docs/PRIVATE_RELEASES.md`
