### PR TITLE
feat: add support for all Immich-compatible media formats in MIME type handling, filtering, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ tree.txt
 sstool.py
 aur.md
 .codex
+formats.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Save & Restart` has been replaced with live `Save Changes` behavior that updates the running API client, queue policy, upload worker count, and watched folders without relaunching Mimick.
 - Watch-folder changes now reconfigure the live filesystem monitor in place, so adding or removing folders takes effect immediately after saving.
 
+
 ## [Unreleased]
+
+### Added
+- Expanded supported media formats to match latest Immich server: AVIF, BMP, HEIF, JPEG 2000, JPEG XL, PSD, SVG, 3GPP, AVI, FLV, M4V, Matroska (MKV), MP2T, MXF, and more. The app now recognizes and uploads all Immich-compatible image and video extensions.
 
 ## [8.0.0] - 2026-03-25
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ Mimick is a desktop Immich client for Linux, combining a persistent background d
 | **Ping Test Dialog** | **Tray Icon** |
 | ![Ping Test Dialog](docs/screenshots/ping_test_screenshot.png) | ![Tray Icon](docs/screenshots/tray_icon_screenshot.png) |
 
+
 ## Features
+
+- **Expanded Media Format Support**: Now recognizes and uploads all Immich-compatible image and video formats, including AVIF, BMP, HEIF, JPEG 2000, JPEG XL, PSD, SVG, 3GPP, AVI, FLV, M4V, MKV, MP2T, MXF, and more.
 
 - **File Monitoring**: Watches selected folders for new files and waits for stable size before uploading.
 - **SHA-1 Checksumming**: Deduplication via checksum before upload — exact same logic as the Immich mobile apps.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -38,6 +38,7 @@ If a file seems to be ignored completely:
 - Large files can be skipped by the max-size rule.
 - Extension allowlists only accept matching file extensions after normalization.
 - Temporary files are ignored until the final media filename appears.
+- **New:** Only Immich-compatible image and video formats are recognized. See `formats.md` for the full list of supported extensions. Unsupported formats will be skipped automatically.
 
 ## Logs & Diagnostics
 

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -817,14 +817,29 @@ fn mime_for_path(path: &Path) -> &'static str {
         .map(|e| e.to_string_lossy().to_lowercase())
         .as_deref()
     {
-        Some("jpg") | Some("jpeg") => "image/jpeg",
-        Some("png") => "image/png",
-        Some("mp4") => "video/mp4",
-        Some("mov") => "video/quicktime",
+        Some("avif") => "image/avif",
+        Some("bmp") => "image/bmp",
         Some("gif") => "image/gif",
-        Some("webp") => "image/webp",
         Some("heic") => "image/heic",
-        Some("tiff") | Some("tif") => "image/tiff",
+        Some("heif") => "image/heif",
+        Some("insp") | Some("jpe") | Some("jpeg") | Some("jpg") => "image/jpeg",
+        Some("jp2") => "image/jp2",
+        Some("jxl") => "image/jxl",
+        Some("png") => "image/png",
+        Some("psd") => "image/vnd.adobe.photoshop",
+        Some("svg") => "image/svg+xml",
+        Some("tif") | Some("tiff") => "image/tiff",
+        Some("webp") => "image/webp",
+        Some("3gp") | Some("3gpp") => "video/3gpp",
+        Some("avi") => "video/x-msvideo",
+        Some("flv") => "video/x-flv",
+        Some("insv") | Some("mp4") => "video/mp4",
+        Some("m2t") | Some("m2ts") | Some("mts") => "video/mp2t",
+        Some("m4v") => "video/x-m4v",
+        Some("mkv") => "video/x-matroska",
+        Some("mpe") | Some("mpeg") | Some("mpg") => "video/mpeg",
+        Some("mov") => "video/quicktime",
+        Some("mxf") => "application/mxf",
         _ => "application/octet-stream",
     }
 }
@@ -956,9 +971,22 @@ mod tests {
 
     #[test]
     fn test_mime_for_path() {
+        assert_eq!(mime_for_path(Path::new("test.avif")), "image/avif");
         assert_eq!(mime_for_path(Path::new("test.jpg")), "image/jpeg");
+        assert_eq!(mime_for_path(Path::new("test.jpe")), "image/jpeg");
+        assert_eq!(mime_for_path(Path::new("test.heif")), "image/heif");
+        assert_eq!(mime_for_path(Path::new("test.jp2")), "image/jp2");
+        assert_eq!(mime_for_path(Path::new("test.jxl")), "image/jxl");
         assert_eq!(mime_for_path(Path::new("test.PNG")), "image/png");
+        assert_eq!(
+            mime_for_path(Path::new("test.psd")),
+            "image/vnd.adobe.photoshop"
+        );
+        assert_eq!(mime_for_path(Path::new("test.svg")), "image/svg+xml");
         assert_eq!(mime_for_path(Path::new("test.mp4")), "video/mp4");
+        assert_eq!(mime_for_path(Path::new("test.insv")), "video/mp4");
+        assert_eq!(mime_for_path(Path::new("test.mkv")), "video/x-matroska");
+        assert_eq!(mime_for_path(Path::new("test.mxf")), "application/mxf");
         assert_eq!(
             mime_for_path(Path::new("test.unknown")),
             "application/octet-stream"

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -13,7 +13,9 @@ use tokio::sync::mpsc;
 
 /// List of allowed media file extensions accepted for upload.
 pub(crate) const MEDIA_EXTENSIONS: &[&str] = &[
-    "jpg", "jpeg", "png", "heic", "mp4", "mov", "gif", "webp", "tiff", "tif", "raw", "arw", "dng",
+    "3gp", "3gpp", "arw", "avif", "avi", "bmp", "dng", "flv", "gif", "heic", "heif", "insp",
+    "insv", "jp2", "jpe", "jpeg", "jpg", "jxl", "m2t", "m2ts", "m4v", "mkv", "mov", "mp4", "mpe",
+    "mpeg", "mpg", "mts", "mxf", "png", "psd", "raw", "rw2", "svg", "tif", "tiff", "webp",
 ];
 
 /// Number of consecutive stable size checks required before a file is considered complete.
@@ -336,7 +338,9 @@ pub(crate) fn is_temporary_file(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{compute_sha1_chunked, is_flatpak_sandbox, is_temporary_file};
+    use super::{
+        compute_sha1_chunked, is_flatpak_sandbox, is_supported_media_path, is_temporary_file,
+    };
     use std::io::Write;
     use std::path::Path;
     use tempfile::NamedTempFile;
@@ -362,5 +366,19 @@ mod tests {
         assert!(is_temporary_file(Path::new("/tmp/upload.jpg.tmp")));
         assert!(is_temporary_file(Path::new("/tmp/image.png~")));
         assert!(!is_temporary_file(Path::new("/tmp/final.jpg")));
+    }
+
+    #[test]
+    fn test_supported_media_extensions_include_new_immich_formats() {
+        assert!(is_supported_media_path(Path::new("photo.avif")));
+        assert!(is_supported_media_path(Path::new("photo.heif")));
+        assert!(is_supported_media_path(Path::new("photo.jp2")));
+        assert!(is_supported_media_path(Path::new("photo.jxl")));
+        assert!(is_supported_media_path(Path::new("photo.psd")));
+        assert!(is_supported_media_path(Path::new("photo.svg")));
+        assert!(is_supported_media_path(Path::new("video.3gp")));
+        assert!(is_supported_media_path(Path::new("video.avi")));
+        assert!(is_supported_media_path(Path::new("video.mkv")));
+        assert!(is_supported_media_path(Path::new("video.mxf")));
     }
 }

--- a/src/startup_scan.rs
+++ b/src/startup_scan.rs
@@ -291,7 +291,9 @@ mod tests {
 
     #[test]
     fn test_supported_media_path_filter() {
+        assert!(is_supported_media_path(&PathBuf::from("image.avif")));
         assert!(is_supported_media_path(&PathBuf::from("image.jpg")));
+        assert!(is_supported_media_path(&PathBuf::from("movie.mkv")));
         assert!(is_supported_media_path(&PathBuf::from("movie.mp4")));
         assert!(!is_supported_media_path(&PathBuf::from("notes.txt")));
     }


### PR DESCRIPTION

## Changes

- Expanded MIME type detection to include all Immich-supported image and video formats:
  - AVIF, BMP, HEIF, JPEG 2000, JPEG XL, PSD, SVG, 3GPP, AVI, FLV, M4V, MKV, MP2T, MXF, and more.
- Updated the media extension allowlist to match the latest Immich compatibility.
- Added and extended unit tests for new formats and extensions.
- Improved file filtering logic to ensure only Immich-compatible media files are recognized and queued.
- Updated documentation and troubleshooting guides to reflect expanded format support.