### PR TITLE
Fix status page icon and follow system appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Expanded supported media formats to match latest Immich server: AVIF, BMP, HEIF, JPEG 2000, JPEG XL, PSD, SVG, 3GPP, AVI, FLV, M4V, Matroska (MKV), MP2T, MXF, and more. The app now recognizes and uploads all Immich-compatible image and video extensions.
 
+### Changed
+- The settings window now explicitly follows the desktop light/dark appearance preference at startup, allowing light mode when the system theme is light.
+- The `Status` page now uses a standard symbolic page icon for more consistent rendering across icon themes.
+
 
 ## [9.0.0] - 2026-03-29
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Mimick is a desktop Immich client for Linux, combining a persistent background d
 - **Live Settings Apply**: `Save Changes` updates the running configuration in place, including watched folders, server URLs, upload concurrency, and pause policies, without restarting the app.
 - **Clear Window Controls**: `Close` hides the settings window, while `Quit` stops the app completely.
 - **Desktop Integration**:
-  - GTK4 / Libadwaita settings UI that follows the desktop theme.
+  - GTK4 / Libadwaita settings UI that follows the desktop light/dark appearance preference.
   - StatusNotifierItem system tray icon (requires AppIndicator support on GNOME)
 - **Media Format Support**: Recognizes and uploads all Immich-compatible image and video formats, including AVIF, BMP, HEIF, JPEG 2000, JPEG XL, PSD, SVG, 3GPP, AVI, FLV, M4V, MKV, MP2T, MXF, and more.  
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -8,7 +8,7 @@ Welcome to Mimick for Linux! This guide provides detailed instructions on how to
 
 ### The System Tray Icon
 
-Once the application is running, a blue "Immich" icon will appear in your system tray (usually at the top right on GNOME/KDE).
+Once the application is running, the Mimick tray icon will appear in your system tray (usually at the top right on GNOME/KDE).
 
 *If you are using GNOME and don't see system tray icons, ensure you have the "AppIndicator and KStatusNotifierItem Support" GNOME extension enabled. Stock GNOME does not support StatusNotifier tray icons out of the box.*
 
@@ -33,6 +33,8 @@ The settings window is split into two pages:
 
 * **Settings**: server details, behavior switches, watch folders, and folder rules
 * **Status**: sync status, queue tools, pause/resume, manual sync, and diagnostics export
+
+The window follows your desktop appearance preference, so it can render in either light mode or dark mode depending on the system theme.
 
 ### Connectivity & Server Details
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,8 @@ async fn main() {
         is_primary_instance_clone.store(true, Ordering::SeqCst);
 
         log::info!("Mimick primary instance initializing");
+        // Always follow the desktop's light/dark preference.
+        adw::StyleManager::default().set_color_scheme(adw::ColorScheme::Default);
 
         // Keep the process alive when the settings window is hidden.
         Box::leak(Box::new(app.hold()));

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -80,7 +80,7 @@ pub fn build_settings_window(
 
     let status_page = adw::PreferencesPage::builder()
         .title("Status")
-        .icon_name("view-dashboard-symbolic")
+        .icon_name("dialog-information-symbolic")
         .build();
     window.add(&status_page);
 


### PR DESCRIPTION

## Summary

This PR improves the settings UI appearance and updates the docs to match.

- Switches the `Status` page to a standard symbolic icon for more consistent rendering across icon themes.
- Explicitly sets Libadwaita to follow the desktop appearance preference at startup, so Mimick can use light mode when the system is light.
- Updates the changelog, README, and user guide to reflect the UI and appearance behavior.

## Files Changed

- [`src/settings_window.rs`](src/settings_window.rs)
- [`src/main.rs`](src/main.rs)
- [`CHANGELOG.md`](CHANGELOG.md)
- [`README.md`](README.md)
- [`docs/USER_GUIDE.md`](docs/USER_GUIDE.md)

## Testing

- Ran `cargo check`

## Notes

- This is a small UI/docs follow-up with no behavior changes outside icon selection and appearance handling.