### PR TITLE
Fix duplicate Release Drafter drafts

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request_target:
-    types: [opened, reopened, synchronize, labeled, unlabeled, closed]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:
@@ -18,6 +18,9 @@ env:
 jobs:
   update-release-draft:
     runs-on: ubuntu-24.04
+    concurrency:
+      group: release-drafter
+      cancel-in-progress: true
 
     steps:
       - name: Update draft release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,11 +84,13 @@ jobs:
 
           sha256sum dist/mimick.flatpakrepo > dist/SHA256SUMS.txt
 
-      - name: Find latest draft release
+      - name: Find matching draft release
         id: draft_release
         uses: actions/github-script@v8
         with:
           script: |
+            const tagName = process.env.GITHUB_REF_NAME;
+            const releaseName = tagName.replace(/^v/, "");
             const releases = await github.paginate(github.rest.repos.listReleases, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -99,9 +101,11 @@ jobs:
               .filter((release) => release.draft)
               .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
-            const draft = drafts[0];
+            const draft = drafts.find((release) =>
+              release.tag_name === tagName || release.name === releaseName
+            );
             if (!draft) {
-              core.info("No draft release found. Falling back to CHANGELOG.md.");
+              core.info(`No draft release found for ${tagName}. Falling back to CHANGELOG.md.`);
               core.setOutput("found", "false");
               return;
             }
@@ -130,7 +134,7 @@ jobs:
           ${{ steps.draft_release.outputs.body }}
           EOF
 
-      - name: Publish latest draft release
+      - name: Publish matching draft release
         if: steps.draft_release.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/REPOSITORY_AUTOMATION.md
+++ b/docs/REPOSITORY_AUTOMATION.md
@@ -110,7 +110,9 @@ Release Drafter is configured by:
 
 It helps maintain a draft GitHub release based on merged PR labels and categories.
 
-Tagged releases now prefer the latest Release Drafter draft body when publishing a GitHub release. If no draft release exists, the release workflow falls back to the matching section in [CHANGELOG.md](../CHANGELOG.md).
+The workflow now serializes draft updates and avoids running a redundant PR-close pass, which helps prevent duplicate draft releases during merges.
+
+Tagged releases now prefer the Release Drafter draft whose tag or title matches the version being published. If no matching draft release exists, the release workflow falls back to the matching section in [CHANGELOG.md](../CHANGELOG.md).
 
 ## Dependabot Auto Merge
 


### PR DESCRIPTION
Serialize Release Drafter runs to prevent duplicate draft releases and update the workflow to select only the draft that matches the version being published. Update documentation to reflect the new behavior.