### PR TITLE
fix: reset pending folder status counts on startup to prevent ghost labels after failed uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ formats.md
 workflowfix.md
 docs/REPOSITORY_AUTOMATION.md
 docs/RELEASE_PROCESS.md
+failed_upload_bug.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
 ## [Unreleased]
+
+### Fixed
+- Fixed a bug where a discarded failed-upload task could leave a persistent "Pending: 1" ghost label on the folder configuration UI across application restarts.
 
 
 ## [9.1.0] - 2026-04-08

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,10 @@ async fn main() {
         saved.failed_count = 0; // Will be repopulated from retries.json if any
         saved.current_file = None;
 
+        for status in saved.folder_statuses.values_mut() {
+            status.pending_count = 0;
+        }
+
         // Reset volatile fields that shouldn't survive a restart
         AppState {
             status: "idle".to_string(),


### PR DESCRIPTION
## Description

This PR fixes a state desynchronization bug that causes failed upload tasks to leave a persistent "Pending: 1" ghost label on the folder configuration UI across application restarts.

### Root Cause
When a user clicks "Retry All Failed" or a network-active automatic retry triggers, the failed tasks are un-registered from the `retry_list` and pushed back into the asynchronous `mpsc::channel`. During this action, the folder's `pending_count` is correctly incremented.

However, if the application is gracefully closed or forcefully restarted *before* the upload worker manages to finish processing that channel message, the channel is dropped entirely. 
On the next application launch, `main.rs` successfully clears the `queue_size` and drops unfinished tasks (which prevents infinite looping of invalid items), **but it neglected to reset the `folder_statuses.pending_count`**. Because the file was dropped from the channel, it is absent from `retries.json`, meaning it permanently vanishes from the retry queue but leaves a ghost "Pending" badge on the folder forever. 

### Changes Made
- **`src/main.rs`**: Updated the `AppState` deserialization block during initialization to iterate through `saved.folder_statuses` and explicitly reset `pending_count` back to `0`. 

Since the `startup_scan` seamlessly sweeps monitored directories automatically and re-adds any genuine unattended media to the queue at load, safely zeroing-out UI tokens prevents abandoned state residuals from remaining permanently fixed.

## Testing Strategy
- Verified structural stability via `cargo check` and `cargo test`.
- Forced an immediate exit while items were actively routed through the tokio retry channel.
- Validated that upon the next startup, the phantom `Pending: 1` warning successfully resets, effectively resolving the queue lock.