### PR TITLE
Fix GTK focus assertion crash in folder rules dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fixed an internal GTK critical focus assertion error (`box != NULL`) that occurred when opening the folder rules configuration dialog.
 - Fixed a bug where a discarded failed-upload task could leave a persistent "Pending: 1" ghost label on the folder configuration UI across application restarts.
 
 

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -1398,12 +1398,19 @@ fn show_folder_rules_dialog(
 
     let current = rules_state.borrow().clone();
 
+    let list_box = gtk::ListBox::builder()
+        .selection_mode(gtk::SelectionMode::None)
+        .css_classes(vec![String::from("boxed-list")])
+        .build();
+
     let ignore_hidden = adw::SwitchRow::builder()
         .title("Ignore Hidden Files / Folders")
         .subtitle("Skip paths that contain hidden components such as .cache or .thumbnails.")
         .active(current.ignore_hidden)
         .build();
-    content.append(&ignore_hidden);
+
+    list_box.append(&ignore_hidden);
+    content.append(&list_box);
 
     let max_size_entry = Entry::builder()
         .placeholder_text("Max file size in MB, leave blank for no limit")


### PR DESCRIPTION
## Description
Fixes a `Gtk-CRITICAL **: gtk_list_box_row_grab_focus: assertion 'box != NULL' failed` warning that triggered when opening the "Edit Folder Rules" dialog.

### Root Cause & Fix
The `adw::SwitchRow` widget used for the "Ignore Hidden Files" toggle is structurally a `gtk::ListBoxRow`. When appended directly into a standard GTK `Box`, it triggers internal focus/traversal assertions because GTK expects to find a parent layout `ListBox`.

This PR wraps the standalone `SwitchRow` inside a `gtk::ListBox` (applying the native `.boxed-list` CSS class) before attaching it to the layout, gracefully resolving the focus traversals while keeping the native Libadwaita aesthetic.
