### PR TITLE
 refactor: migrate desktop notifications to GIO, enforce single-window mode, and clean up Flatpak configuration

### DIFF
--- a/io.github.nicx17.mimick.local.yml
+++ b/io.github.nicx17.mimick.local.yml
@@ -1,5 +1,4 @@
 app-id: io.github.nicx17.mimick
-default-branch: stable
 branch: stable
 runtime: org.gnome.Platform
 runtime-version: '50'

--- a/io.github.nicx17.mimick.yml
+++ b/io.github.nicx17.mimick.yml
@@ -1,5 +1,4 @@
 app-id: io.github.nicx17.mimick
-default-branch: stable
 branch: stable
 runtime: org.gnome.Platform
 runtime-version: '50'

--- a/setup/io.github.nicx17.mimick.desktop
+++ b/setup/io.github.nicx17.mimick.desktop
@@ -11,6 +11,7 @@ Keywords=Photo;Sync;Backup;Immich;
 StartupNotify=false
 X-GNOME-Autostart-enabled=true
 StartupWMClass=io.github.nicx17.mimick
+SingleMainWindow=true
 
 [Desktop Action Settings]
 Name=Open Settings

--- a/setup/metainfo/io.github.nicx17.mimick.metainfo.xml
+++ b/setup/metainfo/io.github.nicx17.mimick.metainfo.xml
@@ -84,26 +84,26 @@
         </ul>
       </description>
     </release>
-        <release version="9.1.0" date="2026-04-08">
-          <description>
-            <ul>
-              <li>Expanded supported media formats to match the latest Immich server compatibility list, including AVIF, BMP, HEIF, JPEG 2000, JPEG XL, PSD, SVG, 3GPP, AVI, FLV, M4V, Matroska (MKV), MP2T, MXF, and more.</li>
-              <li>The settings window now follows the desktop light and dark appearance preference at startup, and the status page uses a standard symbolic icon for more consistent rendering across icon themes.</li>
-              <li>Flatpak packaging now targets the GNOME 50 runtime for current desktop compatibility.</li>
-            </ul>
-          </description>
-        </release>
-        <release version="9.0.0" date="2026-03-29">
-          <description>
-            <ul>
-              <li>Fixed an Immich asset timestamp regression where newly uploaded files could land at the wrong timeline time or lose their intended timezone after server-side metadata processing.</li>
-              <li>Upload metadata handling now preserves filesystem-based creation times more reliably and reapplies the local timezone after upload so Immich keeps the correct asset date placement.</li>
-              <li>The settings window now uses <code>Status</code> and <code>Settings</code> pages, shows the first-run API-key guidance at the top of the configuration flow, and no longer forces dark mode.</li>
-              <li><code>Save &amp; Restart</code> has been replaced with live <code>Save Changes</code> behavior that updates the running API client, queue policy, upload worker count, and watched folders without relaunching Mimick.</li>
-              <li>Watch-folder changes now reconfigure the live filesystem monitor in place, so adding or removing folders takes effect immediately after saving.</li>
-            </ul>
-          </description>
-        </release>
+    <release version="9.1.0" date="2026-04-08">
+      <description>
+        <ul>
+          <li>Expanded supported media formats to match the latest Immich server compatibility list, including AVIF, BMP, HEIF, JPEG 2000, JPEG XL, PSD, SVG, 3GPP, AVI, FLV, M4V, Matroska (MKV), MP2T, MXF, and more.</li>
+          <li>The settings window now follows the desktop light and dark appearance preference at startup, and the status page uses a standard symbolic icon for more consistent rendering across icon themes.</li>
+          <li>Flatpak packaging now targets the GNOME 50 runtime for current desktop compatibility.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="9.0.0" date="2026-03-29">
+      <description>
+        <ul>
+          <li>Fixed an Immich asset timestamp regression where newly uploaded files could land at the wrong timeline time or lose their intended timezone after server-side metadata processing.</li>
+          <li>Upload metadata handling now preserves filesystem-based creation times more reliably and reapplies the local timezone after upload so Immich keeps the correct asset date placement.</li>
+          <li>The settings window now uses <code>Status</code> and <code>Settings</code> pages, shows the first-run API-key guidance at the top of the configuration flow, and no longer forces dark mode.</li>
+          <li><code>Save &amp; Restart</code> has been replaced with live <code>Save Changes</code> behavior that updates the running API client, queue policy, upload worker count, and watched folders without relaunching Mimick.</li>
+          <li>Watch-folder changes now reconfigure the live filesystem monitor in place, so adding or removing folders takes effect immediately after saving.</li>
+        </ul>
+      </description>
+    </release>
     <release version="8.0.0" date="2026-03-25">
       <description>
         <ul>

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,32 +1,8 @@
-//! Provides desktop notification helpers.
+//! Provides desktop notification helpers using the GIO notification portal.
 //!
-//! All functions are best-effort: if `notify-send` is not installed, the call is
-//! silently ignored. No notification is fired more than once per concept per
-//! session — callers are responsible for the guard logic.
-
-use std::process::Command;
-
-// ── Internal primitive ───────────────────────────────────────────────────────
-
-fn send_raw(title: &str, message: &str) {
-    let mut cmd = Command::new("notify-send");
-    cmd.arg("--app-name").arg("Mimick");
-    cmd.arg(title);
-    cmd.arg(message);
-
-    match cmd.spawn() {
-        Ok(mut child) => {
-            let _ = child.wait();
-            log::debug!("Notification sent: {} - {}", title, message);
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // notify-send is optional.
-        }
-        Err(e) => log::error!("Failed to send notification: {}", e),
-    }
-}
-
-// ── Public API ──────────────────────────────────────────────────────────────
+//! All functions are best-effort: if no running `gio::Application` is available,
+//! the call is silently ignored. No notification is fired more than once per
+//! concept per session -- callers are responsible for the guard logic.
 
 /// Fired once when the upload queue drains after an active sync cycle.
 ///
@@ -48,13 +24,45 @@ pub fn send_sync_summary(succeeded: usize, failed: usize) {
             succeeded, failed
         )
     };
-    send_raw(&title, &body);
+    send_gio(&title, &body, "sync-complete");
 }
 
 /// Fired once per session when consecutive uploads all fail due to connectivity issues.
 pub fn send_connectivity_lost() {
-    send_raw(
+    send_gio(
         "Mimick: Connection lost",
         "Could not reach the Immich server. Uploads will resume automatically when connectivity is restored.",
+        "connectivity-lost",
     );
+}
+
+// ── Internal primitive ───────────────────────────────────────────────────────
+
+/// Send a desktop notification via `gio::Notification`.
+///
+/// This uses the XDG notification portal under Flatpak and the native
+/// desktop notification daemon on bare-metal installs. The themed icon
+/// ensures the app icon renders correctly in both scenarios.
+fn send_gio(title: &str, body: &str, notification_id: &str) {
+    let title = title.to_string();
+    let body = body.to_string();
+    let id = notification_id.to_string();
+
+    glib::idle_add_once(move || {
+        use gtk::prelude::ApplicationExt;
+
+        let Some(app) = gtk::gio::Application::default() else {
+            log::debug!("No default GIO application; skipping notification.");
+            return;
+        };
+
+        let notification = gtk::gio::Notification::new(&title);
+        notification.set_body(Some(&body));
+
+        let icon = gtk::gio::ThemedIcon::new("io.github.nicx17.mimick");
+        notification.set_icon(&icon);
+
+        app.send_notification(Some(&id), &notification);
+        log::debug!("Notification sent via GIO: {} - {}", title, body);
+    });
 }

--- a/src/queue_manager.rs
+++ b/src/queue_manager.rs
@@ -295,9 +295,7 @@ impl QueueManager {
                                     let mut notified = connectivity_notified_ref.lock().unwrap();
                                     if !*notified {
                                         *notified = true;
-                                        tokio::task::spawn_blocking(|| {
-                                            notifications::send_connectivity_lost();
-                                        });
+                                        notifications::send_connectivity_lost();
                                     }
                                 }
                             }
@@ -342,9 +340,7 @@ impl QueueManager {
                             };
 
                             if let Some((succeeded, failed)) = summary {
-                                tokio::task::spawn_blocking(move || {
-                                    notifications::send_sync_summary(succeeded, failed);
-                                });
+                                notifications::send_sync_summary(succeeded, failed);
                             }
                         }
                         None => {

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -396,11 +396,7 @@ pub fn build_settings_window(
         .build();
     behavior_group.add(&battery_row);
 
-    let catchup_model = gtk::StringList::new(&[
-        "Full Scan",
-        "Recent Changed Only (7 days)",
-        "New Files Only",
-    ]);
+    let catchup_model = gtk::StringList::new(&["Full Scan", "Recent Only (7d)", "New Files Only"]);
     let catchup_row = adw::ComboRow::builder()
         .title("Startup Catch-up Mode")
         .subtitle("Limits how aggressively Mimick scans for changes when launching.")


### PR DESCRIPTION
# Harden Flatpak manifest and migrate notifications to GIO portal

- Removed redundant `default-branch` key from both Flatpak manifests (`branch: stable` already handles this)
- Migrated desktop notifications from `notify-send` (silently failing in sandbox) to `gio::Notification` via the XDG notification portal
- App icon now renders correctly in notifications using `gio::ThemedIcon`
- Removed `tokio::task::spawn_blocking` wrappers from notification callsites in `queue_manager.rs` (no longer needed with `glib::idle_add_once` dispatch)
- Added `SingleMainWindow=true` to the desktop entry for GNOME 50+ shell integration
- Normalized inconsistent indentation in metainfo release notes (9.1.0, 9.0.0)
- Shortened catch-up mode dropdown label to prevent text clipping in `adw::ComboRow`
- Confirmed `secret-tool` works correctly without `--talk-name=org.freedesktop.secrets` (libsecret uses the portal backend automatically in GNOME 50)
- All checks pass: fmt, clippy, 50/50 tests, flatpak-builder, live runtime
