### PR TITLE
fix: remove duplicate URL toggle handlers and complete diagnostics export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New notification toggle. Allow user to enable or disable the notifications sent through the app
 
+### Fixed
+- Fixed duplicate URL toggle validation handlers that caused two error dialogs to appear when disabling the last enabled URL switch.
+- Added missing config fields (`startup_catchup_mode`, `upload_concurrency`, `quiet_hours_start`, `quiet_hours_end`) to the diagnostics redacted export and plain-text summary.
+
 ## [9.2.0] - 2026-04-14
 
 ### Changed

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -118,6 +118,30 @@ fn build_summary(config: &Config, state: &AppState) -> String {
         "Notifications enabled: {}",
         config.data.notifications_enabled
     ));
+    lines.push(format!(
+        "Startup catchup mode: {:?}",
+        config.data.startup_catchup_mode
+    ));
+    lines.push(format!(
+        "Upload concurrency: {}",
+        config.data.upload_concurrency
+    ));
+    lines.push(format!(
+        "Quiet hours start: {}",
+        config
+            .data
+            .quiet_hours_start
+            .map(|h| h.to_string())
+            .unwrap_or_else(|| "disabled".to_string())
+    ));
+    lines.push(format!(
+        "Quiet hours end: {}",
+        config
+            .data
+            .quiet_hours_end
+            .map(|h| h.to_string())
+            .unwrap_or_else(|| "disabled".to_string())
+    ));
     lines.push(
         "Sensitive data policy: URLs, API key, logs, and full local paths omitted".to_string(),
     );
@@ -153,6 +177,10 @@ struct RedactedConfigExport {
     pause_on_metered_network: bool,
     pause_on_battery_power: bool,
     notifications_enabled: bool,
+    startup_catchup_mode: String,
+    upload_concurrency: u8,
+    quiet_hours_start: Option<u8>,
+    quiet_hours_end: Option<u8>,
 }
 
 #[derive(Serialize)]
@@ -230,6 +258,10 @@ fn build_config_export(config: &Config) -> RedactedConfigExport {
         pause_on_metered_network: config.data.pause_on_metered_network,
         pause_on_battery_power: config.data.pause_on_battery_power,
         notifications_enabled: config.data.notifications_enabled,
+        startup_catchup_mode: format!("{:?}", config.data.startup_catchup_mode),
+        upload_concurrency: config.data.upload_concurrency,
+        quiet_hours_start: config.data.quiet_hours_start,
+        quiet_hours_end: config.data.quiet_hours_end,
     }
 }
 

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -207,44 +207,6 @@ pub fn build_settings_window(
     external_row.add_suffix(&external_entry);
     conn_group.add(&external_row);
 
-    // Toggle validation: prevent both switches being OFF at the same time
-    // Mirrors Python's _validate_toggles logic
-    internal_switch.connect_active_notify(clone!(
-        #[weak]
-        external_switch,
-        #[weak]
-        window,
-        move |sw| {
-            if !sw.is_active() && !external_switch.is_active() {
-                sw.set_active(true);
-                let dialog = gtk::AlertDialog::builder()
-                    .message("At least one URL required")
-                    .detail("You must keep at least one URL switch enabled.")
-                    .buttons(["OK"])
-                    .build();
-                dialog.show(Some(&window));
-            }
-        }
-    ));
-
-    external_switch.connect_active_notify(clone!(
-        #[weak]
-        internal_switch,
-        #[weak]
-        window,
-        move |sw| {
-            if !sw.is_active() && !internal_switch.is_active() {
-                sw.set_active(true);
-                let dialog = gtk::AlertDialog::builder()
-                    .message("At least one URL required")
-                    .detail("You must keep at least one URL switch enabled.")
-                    .buttons(["OK"])
-                    .build();
-                dialog.show(Some(&window));
-            }
-        }
-    ));
-
     // API Key
     let api_key_row = adw::ActionRow::builder().title("API Key").build();
     let api_key_entry = PasswordEntry::builder()


### PR DESCRIPTION
## Summary
- Removed duplicate `connect_active_notify` handlers on the internal/external URL switches that caused two error dialogs to appear when disabling the last enabled URL.
- Added missing config fields (`startup_catchup_mode`, `upload_concurrency`, `quiet_hours_start`, `quiet_hours_end`) to the diagnostics redacted export and plain-text summary.
## Changes
### `src/settings_window.rs`
- Removed the first set of `connect_active_notify` handlers (lines 210–246) that used the older `gtk::AlertDialog` API without `transient_for` or entry sensitivity updates. The correct handlers using `adw::MessageDialog` remain unchanged.
### `src/diagnostics.rs`
- Added 4 fields to `RedactedConfigExport`: `startup_catchup_mode`, `upload_concurrency`, `quiet_hours_start`, `quiet_hours_end`.
- Populated them in `build_config_export()`.
- Added corresponding lines to the `build_summary()` plain-text output.
