### PR TITLE
docs: sync all documentation with current v9.3.0 codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Open an Issue on GitHub. Include:
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # Install GTK system dependencies (Ubuntu/Debian)
-sudo apt install libgtk-4-dev libadwaita-1-dev libglib2.0-dev pkg-config build-essential libsecret-1-dev
+sudo apt install libgtk-4-dev libadwaita-1-dev libglib2.0-dev pkg-config build-essential
 
 # Build and run
 cargo run -- --settings

--- a/README.md
+++ b/README.md
@@ -199,21 +199,21 @@ If you prefer to compile Mimick yourself, you can build it natively or package i
 **Ubuntu / Debian:**
 
 ```bash
-sudo apt install libgtk-4-dev libadwaita-1-dev libglib2.0-dev pkg-config build-essential libsecret-1-dev
+sudo apt install libgtk-4-dev libadwaita-1-dev libglib2.0-dev pkg-config build-essential
 
 ```
 
 **Fedora:**
 
 ```bash
-sudo dnf install gtk4-devel libadwaita-devel libsecret-devel pkg-config
+sudo dnf install gtk4-devel libadwaita-devel pkg-config
 
 ```
 
 **Arch Linux:**
 
 ```bash
-sudo pacman -S gtk4 libadwaita libsecret pkgconf base-devel
+sudo pacman -S gtk4 libadwaita pkgconf base-devel
 
 ```
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -8,7 +8,7 @@
 - [x] SHA-1 checksumming per file for Immich deduplication (64KB chunked, low RAM).
 - [x] One-way sync — never delete local files or download from server.
 - [x] File type whitelist (JPG, PNG, HEIC, MP4, MOV, GIF, WEBP, TIFF, RAW, ARW, DNG). Sidecars ignored.
-- [x] 10 concurrent streaming upload workers (constant RAM use regardless of file size).
+- [x] Configurable streaming upload workers (1-10, default 3) with constant RAM use regardless of file size.
 - [x] Persistent retry queue (`~/.cache/mimick/retries.json`) — failed uploads survive reboots.
 - [x] **Offline Sync Stability** — Prevented already-synced files from being re-queued for reassociation when the application is offline or unable to reach the server.
 - [x] **Accurate Progress Tracking** — Fixed the processed file counter to only increment on successful uploads, preventing "ghost" progress during network outages.
@@ -24,7 +24,7 @@
 
 ### Configuration & Security
 - [x] Config file at `~/.config/mimick/config.json` (serde_json).
-- [x] API key stored via `secret-tool` (libsecret) — never written to disk in plain text.
+- [x] API key stored via `oo7` keyring crate (encrypted portal file in Flatpak, D-Bus Secret Service native) -- never written to disk in plain text.
 - [x] Multiple watch directories with per-folder album config.
 - [x] `WatchPathEntry` supports both plain path strings and per-folder album configs.
 
@@ -45,16 +45,13 @@
 - [x] Graceful fallback when `org.kde.StatusNotifierWatcher` is unavailable (GNOME without extension).
 
 ### Desktop Integration
-- [x] `systemd` user service (`setup/mimick.service`) with journal logging.
-- [x] `.desktop` file with Settings action (`setup/mimick.desktop`).
-- [x] Native desktop notifications (`libnotify`).
-- [x] PKGBUILD for Arch Linux / AUR.
-- [x] AppImage packaging (`build_test_appimage.sh`).
+- [x] `.desktop` file with Settings and Quit actions (`setup/io.github.nicx17.mimick.desktop`).
+- [x] Native desktop notifications (`gio::Notification` via XDG notification portal).
 
 ### Rust Port (v2.0)
 - [x] Full rewrite from Python to Rust (Tokio + GTK4-rs + Libadwaita-rs).
 - [x] No Python runtime dependency — single statically-linked binary.
-- [x] 11 unit tests across `api_client`, `config`, `monitor`, `queue_manager`, `state_manager`.
+- [x] 47 unit tests across 13 modules (`api_client`, `autostart`, `config`, `diagnostics`, `main`, `monitor`, `queue_manager`, `runtime_env`, `settings_window`, `startup_scan`, `state_manager`, `sync_index`, `watch_path_display`).
 - [x] All GTK4 widgets updated to 4.10+ standards (no deprecated `ComboBoxText`, `MessageDialog`).
 
 ---

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -16,9 +16,11 @@ graph TD
         Main --> QueueManager[Queue Manager]
         Main --> SharedState["Arc<Mutex<AppState>> - in memory"]
         Main --> RuntimeEnv[Runtime Environment Checks]
+        Main --> StartupScan[Startup Catch-Up Scan]
 
         Monitor -->|File Events + SHA-1| QueueManager
-        QueueManager -->|3 async workers| API[Immich API Client - shared]
+        StartupScan -->|Unsynced files| QueueManager
+        QueueManager -->|1-10 async workers| API[Immich API Client - shared]
         QueueManager -->|Update directly| SharedState
         QueueManager -->|Pause policy checks| RuntimeEnv
 
@@ -56,47 +58,50 @@ Initializes the GTK4 `adw::Application` with ID `io.github.nicx17.mimick`. Only 
 
 - `connect_command_line` opens the settings window when `--settings` is passed **or** when `cmdline.is_remote()` is true (user clicks the app icon while the daemon is already running)
 - Shared `Arc<Mutex<AppState>>` is created before all closures and threaded into both `connect_startup` (workers) and `connect_command_line` (settings window)
-- Shared `Arc<ImmichApiClient>` is stored in a `OnceLock` and reused by the settings window — only one reqwest connection pool is ever allocated
+- Shared `Arc<ImmichApiClient>` is stored in a `OnceLock` and reused by the settings window -- only one reqwest connection pool is ever allocated
 
 ### 2. File Monitor (`src/monitor.rs`)
 
-Uses the `notify` crate for inotify-based filesystem events.
+Uses the `notify` crate for inotify-based filesystem events. Inside Flatpak, falls back to a polling watcher so portal-backed directories continue to sync reliably.
 
 - Filters to media extensions only
 - Applies per-folder rules before queueing files
 - Ignores temporary files until the final media filename exists
 - 2-second debounce per path
-- Per-file `wait_for_file_completion` (async, Tokio task — no OS thread per file)
+- Per-file `wait_for_file_completion` (async, Tokio task -- no OS thread per file)
 - SHA-1 checksum via 64KB chunked `spawn_blocking` (no load into RAM)
+- Supports live watch-path replacement via `MonitorHandle` without restarting the daemon
 
 ### 3. Queue Manager (`src/queue_manager.rs`)
 
 Thread-safe upload orchestrator using a single `Arc<Mutex<AppState>>` for all counters and status.
 
-- **3 async workers** sharing one `mpsc::Receiver` via `Arc<tokio::sync::Mutex>`
-- Workers update `AppState` directly in memory — no disk writes during uploads
+- **Configurable async workers** (1-10, default 3) sharing one `mpsc::Receiver` via `Arc<tokio::sync::Mutex>`
+- Workers update `AppState` directly in memory -- no disk writes during uploads
 - **In-memory retry list** (`Arc<std::sync::Mutex<Vec<FileTask>>>`): retries on next successful upload (network recovery), flushed to disk only on graceful shutdown via `QueueManager::flush_retries()`
 - Reads persisted retries from disk on startup (crash recovery); re-queues after 5s delay
 - Supports manual `Pause / Resume`, `Sync Now`, queue inspection, per-item retry, retry-all, and failed-queue clearing
 - Records recent queue events and pause reasons in shared state for UI visibility and diagnostics
 - `QM_HANDLE: OnceLock<Arc<QueueManager>>` allows `main()` to call `flush_retries()` after `app.run()` returns
+- Environment-aware pause policy: metered network, battery power, and quiet-hours window deferral
 
 ### 4. API Client (`src/api_client.rs`)
 
 - LAN-first, WAN fallback connectivity check
 - Active URL cached in `Mutex<Option<String>>`; cleared on network error to force re-check
-- Files streamed with `reqwest::multipart::Part::stream_with_length` — zero RAM buffering
+- Files streamed with `reqwest::multipart::Part::stream_with_length` -- zero RAM buffering
 - Full 40-char SHA-1 hex used as `device_asset_id` for reliable Immich server-side deduplication
 - Connection pool: max 1 idle connection per host, 30s idle timeout
-- Single shared instance via `API_CLIENT_HANDLE: OnceLock<Arc<ImmichApiClient>>` — no new pool per settings window open
+- Single shared instance via `API_CLIENT_HANDLE: OnceLock<Arc<ImmichApiClient>>` -- no new pool per settings window open
+- Structured error diagnostics with actionable guidance for common failure modes
 
 ### 5. Settings UI (`src/settings_window.rs`)
 
-- **Built once per process**, then hidden on close (`window.connect_close_request` → `set_visible(false)` + `Propagation::Stop`)  
-- Subsequent opens call `win.present()` on the existing hidden window — zero new GTK allocations per open/close cycle
+- **Built once per process**, then hidden on close (`window.connect_close_request` -> `set_visible(false)` + `Propagation::Stop`)  
+- Subsequent opens call `win.present()` on the existing hidden window -- zero new GTK allocations per open/close cycle
 - `Arc<Mutex<AppState>>` passed in directly; the 500ms `glib::timeout_add_local` timer reads it without any disk I/O
 - Album list fetched via the shared `Arc<ImmichApiClient>` on first show; a `glib::WeakRef` guard on the window ensures the async task returns early if the window is closed before the API responds
-- Test Connection button uses the shared client — no new reqwest pool per click
+- Test Connection button uses the shared client -- no new reqwest pool per click
 - Uses a two-page `Settings` / `Status` layout with a persistent footer for `Close`, `Quit`, and live `Save Changes`
 - Saving applies updated API settings, queue policy, worker limit, and watched folders to the running process without a restart
 - Includes queue inspector, diagnostics export, per-folder rule editing, and manual sync controls
@@ -104,7 +109,7 @@ Thread-safe upload orchestrator using a single `Arc<Mutex<AppState>>` for all co
 ### 6. System Tray (`src/tray_icon.rs`)
 
 - Uses `ksni` (D-Bus StatusNotifierItem)
-- Clicking tray actions sends signals back to the GTK main loop — **no child process spawned**
+- Clicking tray actions sends signals back to the GTK main loop -- **no child process spawned**
 - A `glib::timeout_add_local(250ms)` in the GTK main loop polls an `Arc<Mutex<bool>>` flag set by the Tokio watch-forward task; on trigger, calls `open_settings_if_needed` in-process
 
 ### 7. Runtime Environment (`src/runtime_env.rs`)
@@ -116,11 +121,61 @@ Best-effort helpers used by queue policy:
 
 These checks are advisory and only affect uploads when the corresponding behavior switches are enabled.
 
-### 8. State & Persistence
+### 8. Startup Scan (`src/startup_scan.rs`)
+
+Walks all configured watch folders on launch and queues media files that are not yet recorded in the sync index.
+
+- Respects the user's configured startup catch-up mode (`Full`, `RecentOnly`, `NewFilesOnly`)
+- Applies the same per-folder rules and media-extension filter used by the live monitor
+- Detects album-target changes and queues reassociation-only tasks for unchanged files that have moved albums
+- Also used by the manual `Sync Now` action from the tray and settings window
+
+### 9. Sync Index (`src/sync_index.rs`)
+
+Maintains a persistent map of previously synced files at `~/.cache/mimick/synced_index.json`.
+
+- Keyed by file path, stores SHA-1 checksum, album name, and album ID
+- Used during startup scans to skip unchanged files and avoid redundant uploads
+- Detects when a file's content has changed (checksum mismatch) and re-queues it
+- Detects album-target changes and triggers reassociation without re-uploading the file data
+
+### 10. Notifications (`src/notifications.rs`)
+
+Provides desktop notification helpers using `gio::Notification` and the XDG notification portal.
+
+- Global enable/disable toggle controlled by the user-facing "Enable Notifications" switch
+- Batch sync-complete summary notification (fired once when the queue drains, not per file)
+- Connectivity-lost notification (fired once per session after consecutive upload failures)
+- All dispatches route through `glib::idle_add_once` to stay on the GTK main thread
+
+### 11. Diagnostics (`src/diagnostics.rs`)
+
+Exports a redacted support bundle for troubleshooting.
+
+- Writes `summary.txt`, `privacy-note.txt`, `config.redacted.json`, `status.redacted.json`, `retries.redacted.json`, and `synced_index.redacted.json`
+- All local paths are redacted to filename-only hints
+- API keys, raw logs, server URLs, and full local paths are intentionally omitted
+
+### 12. Autostart (`src/autostart.rs`)
+
+Handles autostart integration for both native and Flatpak contexts.
+
+- Inside Flatpak: requests background permission via the `ashpd` Background portal
+- Outside Flatpak: writes a standard autostart desktop entry to `~/.config/autostart/io.github.nicx17.mimick.desktop`
+- Disabling autostart removes the entry (or revokes the portal request)
+
+### 13. Watch Path Display (`src/watch_path_display.rs`)
+
+Utility module for displaying user-friendly labels for watch paths, especially portal-backed Flatpak folders.
+
+- Detects document-portal paths (`/run/user/.../doc/...`) and shows the folder name instead
+- Provides subtitle hints for portal-selected folders in the UI
+
+### 14. State & Persistence
 
 - **`AppState`**: in-memory struct shared by workers and UI via `Arc<Mutex<AppState>>`; includes pause state, pause reason, last completed file, diagnostics export count, and recent queue events
 - **`StateManager`** (`src/state_manager.rs`): reads saved state on startup for crash recovery; writes on graceful shutdown only
 - **Retry queue**: in-memory during session; disk path `~/.cache/mimick/retries.json` written only on exit
 - **Sync index**: persisted at `~/.cache/mimick/synced_index.json` to skip unchanged files across restarts and to detect album-target changes
 - **Notifications**: natively handled via `gio::Notification` and the XDG notification portal; ensures safe delivery without `notify-send` sub-processes when sandboxed
-- **Keyring**: API keys are securely persisted through the `oo7` crate — natively talking D-Bus Secret Service, or reading an encrypted sandbox file when running across the Flatpak boundary
+- **Keyring**: API keys are securely persisted through the `oo7` crate -- natively talking D-Bus Secret Service, or reading an encrypted sandbox file when running across the Flatpak boundary

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -31,7 +31,7 @@ Mimick is a Linux background app that watches selected folders and syncs photos 
 
 ## Current App Highlights
 
-- Two-page `Setup` / `Controls` settings window
+- Two-page `Settings` / `Status` settings window
 - Queue inspector with retry actions
 - Per-folder rules for hidden paths, size limits, and extension filters
 - Diagnostics bundle export for support and bug reports

--- a/wiki/Sync-Behavior.md
+++ b/wiki/Sync-Behavior.md
@@ -36,4 +36,4 @@ If the old album was deleted or the stored album ID is stale, Mimick refreshes a
 - Failed uploads are stored in `~/.cache/mimick/retries.json` and retried on the next run.
 - Duplicate detection uses SHA-1 checksums and Immich's upload-check behavior.
 - Existing assets can be looked up and reused instead of uploading the file bytes again.
-- The Controls page can pause/resume syncing, trigger `Sync Now`, and expose queue recovery actions while Mimick is already running.
+- The Status page can pause/resume syncing, trigger `Sync Now`, and expose queue recovery actions while Mimick is already running.

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -46,13 +46,19 @@ Tests in Rust are written inline within identical files to the logic they test, 
 
 | Source File | Test Location | Description |
 | :--- | :--- | :--- |
+| `src/api_client.rs` | `mod tests` | Tests upload-check response parsing, album resolution helpers, and endpoint URL selection. |
+| `src/autostart.rs` | `mod tests` | Tests desktop-exec escaping and Flatpak host config path mapping. |
 | `src/config.rs` | `mod tests` | Tests JSON serde behavior, folder-rule matching, hidden-path filtering, extension normalization, and best-match watch-path selection. |
+| `src/diagnostics.rs` | `mod tests` | Tests support-summary generation and diagnostics bundle export contents. |
 | `src/main.rs` | `mod tests` | Tests live-queue watch-path selection so nested folders use the most specific configured target. |
-| `src/monitor.rs` | `mod tests` | Tests monitor-side filtering such as temporary-file detection before queueing. |
+| `src/monitor.rs` | `mod tests` | Tests monitor-side filtering such as temporary-file detection, media extension matching, and SHA-1 checksum computation. |
 | `src/queue_manager.rs` | `mod tests` | Tests duplicate queue prevention, retry persistence, failed-queue clearing, and manual retry requeueing. |
 | `src/runtime_env.rs` | `mod tests` | Tests metered-network parsing and battery-power decision logic without depending on the host system. |
-| `src/diagnostics.rs` | `mod tests` | Tests support-summary generation and diagnostics bundle export contents. |
-| `src/state_manager.rs` | `mod tests` | Tests queue-event updates and event-history truncation rules. |
+| `src/settings_window.rs` | `mod tests` | Tests pure-logic helpers used by the settings UI such as config field validation. |
+| `src/startup_scan.rs` | `mod tests` | Tests startup-scan file filtering and sync-index interaction for catch-up logic. |
+| `src/state_manager.rs` | `mod tests` | Tests queue-event updates, event-history truncation rules, and health dashboard field persistence. |
+| `src/sync_index.rs` | `mod tests` | Tests sync record creation, album-change detection, and index persistence round-trips. |
+| `src/watch_path_display.rs` | `mod tests` | Tests document-portal path detection and user-friendly folder label generation. |
 
 ---
 
@@ -60,8 +66,8 @@ Tests in Rust are written inline within identical files to the logic they test, 
 
 While core data structures and support logic are tested, the following areas still have **limited coverage** and rely heavily on manual UI or integration testing during development:
 
-1. **`src/settings_window.rs`**: GTK4/libadwaita UI interactions such as dialogs, queue inspector rendering, and per-folder rules editing.
-2. **`src/api_client.rs`**: Network endpoints still need deeper mocked or sandboxed Immich coverage.
+1. **`src/settings_window.rs`**: GTK4/libadwaita UI interactions such as dialogs, queue inspector rendering, and per-folder rules editing. Some pure-logic helpers are covered, but widget behavior is not.
+2. **`src/api_client.rs`**: Basic response parsing is tested, but network endpoints still need deeper mocked or sandboxed Immich coverage.
 3. **`src/main.rs` / `src/tray_icon.rs`**: Full daemon lifecycle, tray signaling, and application-instance behavior remain mostly manual/integration tested.
 4. **Async worker integration**: Queue manager helpers are covered more directly now, but end-to-end worker behavior against a mocked API is still a worthwhile next step.
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -87,15 +87,15 @@ rm -f ~/.cache/mimick/retries.json
 *(In Flatpak, use `~/.var/app/io.github.nicx17.mimick/cache/mimick/retries.json`)*
 
 ### Export a Diagnostics Bundle
-Use `Export Diagnostics` from the Controls page to collect:
+Use `Export Diagnostics` from the Status page to collect:
 - `summary.txt`
-- `config.json`
-- `status.json`
-- `retries.json`
-- `synced_index.json`
-- `mimick.log`
+- `privacy-note.txt`
+- `config.redacted.json`
+- `status.redacted.json`
+- `retries.redacted.json`
+- `synced_index.redacted.json`
 
-This is the easiest way to gather support details without exposing the API key, raw logs, full local paths, or raw server URLs. This is generated securely to a timestamped `mimick-diagnostics-*` folder.
+API keys, raw logs, full local paths, and raw server URLs are intentionally omitted. The bundle is written to a timestamped `mimick-diagnostics-*` folder.
 
 ### Useful Logs
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -13,3 +13,8 @@
 - [Architecture](Architecture)
 - [Development](Development)
 - [Testing](Testing)
+
+### Maintainer
+
+- [Release Operations](Release-Operations)
+- [Repository Automation](Repository-Automation)


### PR DESCRIPTION
## Summary

Full documentation audit against the current source code.
## Changes

### Build prerequisites (3 files)
- Removed `libsecret-1-dev` / `libsecret-devel` / `libsecret` from README, CONTRIBUTING, and wiki/Development — the `oo7` crate is pure Rust and needs no system keyring library at build time.

### wiki/Architecture.md
- Added 6 missing component sections: Startup Scan, Sync Index, Notifications, Diagnostics, Autostart, Watch Path Display.
- Updated mermaid diagram to include startup scan flow.
- Changed hardcoded "3 async workers" to "Configurable async workers (1-10, default 3)".

### wiki/Testing.md
- Expanded test file table from 7 to 13 modules.
- Updated coverage gaps to reflect that `api_client.rs` and `settings_window.rs` now have `#[cfg(test)]` blocks.

### wiki/Troubleshooting.md
- Fixed diagnostics bundle file list to match actual output (`*.redacted.json` files, no `mimick.log`).

### Terminology fixes
- "Setup / Controls" to "Settings / Status" in wiki/Home.md, wiki/Sync-Behavior.md, and wiki/Troubleshooting.md.

### wiki/_Sidebar.md
- Added Release-Operations and Repository-Automation under a new Maintainer heading.

### roadmap.md
- `secret-tool (libsecret)` -> `oo7` keyring crate.
- `libnotify` -> `gio::Notification`.
- `10 concurrent workers` -> configurable 1-10, default 3.
- `11 tests across 5 modules` -> 47 tests across 13 modules.
- Removed stale references to `mimick.service`, `PKGBUILD`, and `build_test_appimage.sh`.
