### PR TITLE
feat: live settings auto-apply, background sync toggle, batch notifications, and logging improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
----
+## [Unreleased] - 2026-04-21
+
+### Added
+- Settings: Live auto-apply for most preferences (workers, quiet hours, folder rules, per-folder album selection, watch-folders). Connectivity fields (API key and server URLs) are now applied only when explicitly saved from the Connectivity section.
+- Single-batch sync summary notification: multiple concurrent upload workers now aggregate results and emit a single "processed" summary notification when a sync batch completes.
+
+### Changed
+- Logging: Console output is colorized by level and file logs use a plain, machine-friendly formatter with automatic rotation (approx. 2 MB per file, keep 5). See README and wiki for configuration details.
+
 
 ## [9.3.0] - 2026-04-14
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,19 @@ cargo run -- --settings     # open the settings window immediately
 
 ```
 
-Logs written to the terminal and to `~/.cache/mimick/mimick.log` now include timestamps.
+Logs written to the terminal and to `~/.cache/mimick/mimick.log` include timestamps.
+Terminal logs are colorized by level, and file logs rotate automatically.
+
+## Logging & Notifications
+
+- **Logging**: Mimick now uses a colored console formatter for human-friendly terminal output and a plain file formatter for persistent logs. File logs are rotated automatically (approx. 2 MB per file; 5 files kept). Control verbosity with `RUST_LOG` (for example: `RUST_LOG=debug`). See [wiki/Development.md](wiki/Development.md) for details on the logger configuration.
+
+- **Notifications**: To reduce notification spam, Mimick aggregates multiple worker uploads into a single batch summary notification when a sync cycle completes. A separate "Connection Lost" notification is still emitted for connectivity failure events.
+
+### Settings behavior
+
+- Most settings (worker count, quiet hours, folder rules, per-folder album, watch-folder additions/removals) are applied live when changed in the Settings window.
+- Connectivity edits (API key and server URLs) are intentionally save-only and require clicking **Save** within the Connectivity group to take effect. This reduces accidental partial-configuration of server credentials during exploratory edits.
 
 ### Local Flatpak Build
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -100,4 +100,4 @@
 - [ ] **Exponential backoff** — Smarter retry scheduling instead of immediate replay on restart.
 - [ ] **Progress notifications** — Desktop notifications with counts and outcomes, not just logs.
 - [ ] **Tray icon dynamic states** — Distinct icons for idle, syncing, paused, and error conditions.
-- [ ] **Background Sync Toggle** — Make background sync optional by providing a toggle in the control menu... will be on by default.
+- [x] **Background Sync Toggle** — Make background sync optional via a toggle in Settings > Behavior; enabled by default.

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,6 +148,9 @@ pub struct ConfigData {
     pub pause_on_metered_network: bool,
     #[serde(default)]
     pub pause_on_battery_power: bool,
+    /// Whether automatic background monitoring/upload discovery is enabled.
+    #[serde(default = "default_true")]
+    pub background_sync_enabled: bool,
     /// Whether desktop notifications (sync summary, connectivity lost, etc.) are shown.
     #[serde(default = "default_true")]
     pub notifications_enabled: bool,
@@ -177,6 +180,7 @@ impl Default for ConfigData {
             delete_after_sync: false,
             pause_on_metered_network: false,
             pause_on_battery_power: false,
+            background_sync_enabled: true,
             notifications_enabled: true,
             startup_catchup_mode: StartupCatchupMode::default(),
             upload_concurrency: default_upload_concurrency(),
@@ -363,7 +367,14 @@ mod tests {
         let data = ConfigData::default();
         assert!(data.internal_url_enabled);
         assert!(data.external_url_enabled);
+        assert!(data.background_sync_enabled);
         assert!(!data.album_sync); // default is false for bool
+    }
+
+    #[test]
+    fn test_config_data_background_sync_defaults_true_when_missing() {
+        let data: ConfigData = serde_json::from_str("{}").unwrap();
+        assert!(data.background_sync_enabled);
     }
 
     #[test]

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -115,6 +115,10 @@ fn build_summary(config: &Config, state: &AppState) -> String {
         config.data.pause_on_battery_power
     ));
     lines.push(format!(
+        "Background sync enabled: {}",
+        config.data.background_sync_enabled
+    ));
+    lines.push(format!(
         "Notifications enabled: {}",
         config.data.notifications_enabled
     ));
@@ -176,6 +180,7 @@ struct RedactedConfigExport {
     delete_after_sync: bool,
     pause_on_metered_network: bool,
     pause_on_battery_power: bool,
+    background_sync_enabled: bool,
     notifications_enabled: bool,
     startup_catchup_mode: String,
     upload_concurrency: u8,
@@ -257,6 +262,7 @@ fn build_config_export(config: &Config) -> RedactedConfigExport {
         delete_after_sync: config.data.delete_after_sync,
         pause_on_metered_network: config.data.pause_on_metered_network,
         pause_on_battery_power: config.data.pause_on_battery_power,
+        background_sync_enabled: config.data.background_sync_enabled,
         notifications_enabled: config.data.notifications_enabled,
         startup_catchup_mode: format!("{:?}", config.data.startup_catchup_mode),
         upload_concurrency: config.data.upload_concurrency,

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,6 +174,8 @@ async fn main() {
             state.watched_folder_count = watch_folder_count;
         }
 
+        let background_sync_enabled = config.data.background_sync_enabled;
+
         let api_key = config.get_api_key().unwrap_or_default();
         let runtime_internal_url = if config.data.internal_url_enabled {
             config.data.internal_url.clone()
@@ -210,12 +212,21 @@ async fn main() {
         // Apply the user's notification preference before any notification can fire.
         crate::notifications::set_enabled(config.data.notifications_enabled);
 
-        // Start the live filesystem watcher immediately.
+        // Keep the watcher service alive, but optionally disable active folder watches.
         let (tx, mut rx) = mpsc::channel(32);
-        let monitor = Monitor::new(config.data.watch_paths.clone());
+        let monitor_paths = if background_sync_enabled {
+            config.data.watch_paths.clone()
+        } else {
+            Vec::new()
+        };
+        let monitor = Monitor::new(monitor_paths, background_sync_enabled);
         let monitor_handle = Arc::new(monitor.start(tx));
         let _ = MONITOR_HANDLE.set(monitor_handle);
-        log::info!("File monitor started");
+        if background_sync_enabled {
+            log::info!("File monitor started");
+        } else {
+            log::info!("Background sync is disabled; monitor started with no active watches");
+        }
 
         // Feed monitor events into the upload queue, preserving per-path album config
         let qm_clone = qm.clone();
@@ -263,22 +274,26 @@ async fn main() {
         let _ = QM_HANDLE.set(qm.clone());
 
         // The startup scan backfills anything that arrived while Mimick was not running.
-        let shared_state_startup_task = shared_state_startup.clone();
-        tokio::spawn(async move {
-            let startup_api = API_CLIENT_HANDLE
-                .get()
-                .cloned()
-                .expect("API client should be initialized before startup scan");
-            queue_unsynced_files(
-                startup_paths,
-                startup_qm,
-                startup_sync_index,
-                startup_api,
-                config::Config::new().data.startup_catchup_mode,
-                shared_state_startup_task,
-            )
-            .await;
-        });
+        if background_sync_enabled {
+            let shared_state_startup_task = shared_state_startup.clone();
+            tokio::spawn(async move {
+                let startup_api = API_CLIENT_HANDLE
+                    .get()
+                    .cloned()
+                    .expect("API client should be initialized before startup scan");
+                queue_unsynced_files(
+                    startup_paths,
+                    startup_qm,
+                    startup_sync_index,
+                    startup_api,
+                    config::Config::new().data.startup_catchup_mode,
+                    shared_state_startup_task,
+                )
+                .await;
+            });
+        } else {
+            log::info!("Background sync is disabled; skipping startup catch-up scan");
+        }
 
         let startup_state = shared_state_startup.clone();
         let status_api = API_CLIENT_HANDLE

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 use gtk::prelude::*;
 use libadwaita as adw;
+use log::Record;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
@@ -31,7 +32,10 @@ use state_manager::{AppState, StateManager};
 use sync_index::SyncIndex;
 use tray_icon::build_tray;
 
-use flexi_logger::{FileSpec, Logger, WriteMode, colored_detailed_format, detailed_format};
+use flexi_logger::{
+    Cleanup, Criterion, DeferredNow, Duplicate, FileSpec, Logger, Naming, WriteMode, style,
+};
+use std::io::Write;
 
 /// Retains the queue manager handle so the graceful shutdown path can flush pending retries.
 static QM_HANDLE: std::sync::OnceLock<Arc<QueueManager>> = std::sync::OnceLock::new();
@@ -42,6 +46,45 @@ static MONITOR_HANDLE: std::sync::OnceLock<Arc<MonitorHandle>> = std::sync::Once
 /// Used to request an immediate startup-style catch-up scan from the UI or tray controls.
 static MANUAL_SYNC_TX: std::sync::OnceLock<tokio::sync::mpsc::UnboundedSender<()>> =
     std::sync::OnceLock::new();
+
+fn format_log_location(record: &Record) -> String {
+    match (record.file(), record.line()) {
+        (Some(file), Some(line)) => format!(" {}:{}", file, line),
+        _ => String::new(),
+    }
+}
+
+fn detailed_plain_format(
+    w: &mut dyn Write,
+    now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), std::io::Error> {
+    write!(
+        w,
+        "[{}] {:<5} [{}] {}{}",
+        now.format("%Y-%m-%d %H:%M:%S%.6f %:z"),
+        record.level(),
+        record.target(),
+        record.args(),
+        format_log_location(record)
+    )
+}
+
+fn detailed_colored_format(
+    w: &mut dyn Write,
+    now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), std::io::Error> {
+    write!(
+        w,
+        "[{}] {} [{}] {}{}",
+        now.format("%Y-%m-%d %H:%M:%S%.6f %:z"),
+        style(record.level()).paint(format!("{:<5}", record.level())),
+        record.target(),
+        record.args(),
+        format_log_location(record)
+    )
+}
 
 #[tokio::main]
 async fn main() {
@@ -59,10 +102,15 @@ async fn main() {
                 .suppress_timestamp() // "mimick.log" instead of "mimick_2026-03-09_10-33-35.log"
                 .suffix("log"),
         )
-        .format_for_files(detailed_format)
-        .format_for_stdout(colored_detailed_format)
+        .format_for_files(detailed_plain_format)
+        .format_for_stdout(detailed_colored_format)
+        .rotate(
+            Criterion::Size(2_000_000),
+            Naming::Numbers,
+            Cleanup::KeepLogFiles(5),
+        )
         // Also print to stdout for systemd / terminal users
-        .duplicate_to_stdout(flexi_logger::Duplicate::All)
+        .duplicate_to_stdout(Duplicate::All)
         .write_mode(WriteMode::Direct)
         .start()
         .expect("Failed to initialize logger");

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -26,10 +26,14 @@ const FLATPAK_POLL_INTERVAL_MS: u64 = 2000;
 
 pub struct Monitor {
     watch_paths: Vec<WatchPathEntry>,
+    background_sync_enabled: bool,
 }
 
 enum MonitorCommand {
-    ReplaceWatchPaths(Vec<WatchPathEntry>),
+    ReplaceWatchPaths {
+        watch_paths: Vec<WatchPathEntry>,
+        background_sync_enabled: bool,
+    },
 }
 
 #[derive(Clone)]
@@ -38,13 +42,17 @@ pub struct MonitorHandle {
 }
 
 impl Monitor {
-    pub fn new(watch_paths: Vec<WatchPathEntry>) -> Self {
-        Self { watch_paths }
+    pub fn new(watch_paths: Vec<WatchPathEntry>, background_sync_enabled: bool) -> Self {
+        Self {
+            watch_paths,
+            background_sync_enabled,
+        }
     }
 
     /// Start the watcher thread and emit `(path, sha1_hex)` tuples for ready files.
     pub fn start(&self, tx: mpsc::Sender<(String, String)>) -> MonitorHandle {
         let watch_paths = self.watch_paths.clone();
+        let background_sync_enabled = self.background_sync_enabled;
         let handle = tokio::runtime::Handle::current();
         let (command_tx, command_rx) = std::sync::mpsc::channel();
 
@@ -59,8 +67,14 @@ impl Monitor {
             };
 
             let mut watch_paths = watch_paths;
+            let mut background_sync_enabled = background_sync_enabled;
             let mut watched_roots = Vec::<PathBuf>::new();
-            replace_watches(&mut *watcher, &mut watched_roots, &watch_paths);
+            replace_watches(
+                &mut *watcher,
+                &mut watched_roots,
+                &watch_paths,
+                background_sync_enabled,
+            );
 
             // Debounce map: path -> last seen instant
             let mut debounce_map: HashMap<String, Instant> = HashMap::new();
@@ -74,9 +88,18 @@ impl Monitor {
             loop {
                 while let Ok(command) = command_rx.try_recv() {
                     match command {
-                        MonitorCommand::ReplaceWatchPaths(new_paths) => {
+                        MonitorCommand::ReplaceWatchPaths {
+                            watch_paths: new_paths,
+                            background_sync_enabled: new_background_sync_enabled,
+                        } => {
                             watch_paths = new_paths;
-                            replace_watches(&mut *watcher, &mut watched_roots, &watch_paths);
+                            background_sync_enabled = new_background_sync_enabled;
+                            replace_watches(
+                                &mut *watcher,
+                                &mut watched_roots,
+                                &watch_paths,
+                                background_sync_enabled,
+                            );
                         }
                     }
                 }
@@ -192,11 +215,15 @@ impl Monitor {
 }
 
 impl MonitorHandle {
-    pub fn replace_watch_paths(&self, watch_paths: Vec<WatchPathEntry>) {
-        if let Err(err) = self
-            .command_tx
-            .send(MonitorCommand::ReplaceWatchPaths(watch_paths))
-        {
+    pub fn replace_watch_paths(
+        &self,
+        watch_paths: Vec<WatchPathEntry>,
+        background_sync_enabled: bool,
+    ) {
+        if let Err(err) = self.command_tx.send(MonitorCommand::ReplaceWatchPaths {
+            watch_paths,
+            background_sync_enabled,
+        }) {
             log::warn!("Could not update watch paths on the live monitor: {}", err);
         }
     }
@@ -206,6 +233,7 @@ fn replace_watches(
     watcher: &mut dyn Watcher,
     watched_roots: &mut Vec<PathBuf>,
     watch_paths: &[WatchPathEntry],
+    background_sync_enabled: bool,
 ) {
     for path in watched_roots.drain(..) {
         if let Err(err) = watcher.unwatch(&path) {
@@ -231,7 +259,11 @@ fn replace_watches(
     }
 
     if !any_watching {
-        log::warn!("No valid watch paths. File monitoring is idle until a folder is added.");
+        if background_sync_enabled {
+            log::warn!("No valid watch paths. File monitoring is idle until a folder is added.");
+        } else {
+            log::info!("Background sync disabled. File monitoring is idle until it is enabled.");
+        }
     }
 }
 

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -23,17 +23,14 @@ pub fn send_sync_summary(succeeded: usize, failed: usize) {
     if succeeded == 0 && failed == 0 {
         return;
     }
-    let title = if failed == 0 {
-        "Sync complete".to_string()
-    } else {
-        format!("Sync complete ({} failed)", failed)
-    };
+    let title = "Sync complete".to_string();
+    let processed = succeeded.saturating_add(failed);
     let body = if failed == 0 {
-        format!("{} file(s) uploaded successfully.", succeeded)
+        format!("All {} file(s) processed. Idle.", processed)
     } else {
         format!(
-            "{} file(s) uploaded. {} file(s) failed and will be retried.",
-            succeeded, failed
+            "All {} file(s) processed. Idle. {} failed and will be retried.",
+            processed, failed
         )
     };
     send_gio(&title, &body, "sync-complete");

--- a/src/queue_manager.rs
+++ b/src/queue_manager.rs
@@ -45,6 +45,17 @@ pub struct QueueManager {
     retry_path: PathBuf,
     policy: Arc<std::sync::Mutex<EnvironmentPolicy>>,
     worker_limit: Arc<AtomicUsize>,
+    batch_notify_state: Arc<std::sync::Mutex<BatchNotifyState>>,
+}
+
+#[derive(Debug, Default)]
+struct BatchNotifyState {
+    active: bool,
+    notify_scheduled: bool,
+    current_batch_id: u64,
+    last_notified_batch_id: u64,
+    start_processed: usize,
+    start_failed: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -98,8 +109,7 @@ impl QueueManager {
         ));
         let policy_ref = Arc::new(std::sync::Mutex::new(policy));
         let worker_limit = Arc::new(AtomicUsize::new(workers.clamp(1, MAX_WORKERS)));
-
-        let last_notify_completed = Arc::new(std::sync::Mutex::new(0usize));
+        let batch_notify_state = Arc::new(std::sync::Mutex::new(BatchNotifyState::default()));
         let connectivity_lost_notified = Arc::new(std::sync::Mutex::new(false));
         let consecutive_failures = Arc::new(std::sync::Mutex::new(0usize));
 
@@ -111,6 +121,7 @@ impl QueueManager {
             retry_path: retry_path.clone(),
             policy: policy_ref.clone(),
             worker_limit: worker_limit.clone(),
+            batch_notify_state: batch_notify_state.clone(),
         };
 
         for i in 0..MAX_WORKERS {
@@ -121,7 +132,7 @@ impl QueueManager {
             let retry_ref = retry_list.clone();
             let pending_ref = pending_paths.clone();
             let sync_index_ref = sync_index.clone();
-            let last_notify_ref = last_notify_completed.clone();
+            let batch_notify_ref = batch_notify_state.clone();
             let connectivity_notified_ref = connectivity_lost_notified.clone();
             let consec_fail_ref = consecutive_failures.clone();
             let policy_ref = policy_ref.clone();
@@ -207,6 +218,8 @@ impl QueueManager {
                                     );
                                     {
                                         let mut s = state_ref.lock().unwrap();
+                                        let mut batch_state = batch_notify_ref.lock().unwrap();
+                                        activate_batch_if_needed(&mut batch_state, &s);
                                         s.failed_count =
                                             s.failed_count.saturating_sub(retries.len());
                                         s.total_queued += retries.len();
@@ -301,7 +314,7 @@ impl QueueManager {
                             }
 
                             // Update processed count and determine idle state.
-                            let summary = {
+                            let summary_batch = {
                                 let mut s = state_ref.lock().unwrap();
                                 if success {
                                     s.processed_count += 1;
@@ -320,12 +333,17 @@ impl QueueManager {
                                     };
                                     s.progress = 100;
                                     log::info!("All {} file(s) processed. Idle.", s.total_queued);
-                                    let succeeded = s
-                                        .processed_count
-                                        .saturating_sub(*last_notify_ref.lock().unwrap());
-                                    let failed = s.failed_count;
-                                    *last_notify_ref.lock().unwrap() = s.processed_count;
-                                    Some((succeeded, failed))
+                                    let mut batch_state = batch_notify_ref.lock().unwrap();
+                                    if batch_state.active
+                                        && batch_state.current_batch_id
+                                            != batch_state.last_notified_batch_id
+                                        && !batch_state.notify_scheduled
+                                    {
+                                        batch_state.notify_scheduled = true;
+                                        Some(batch_state.current_batch_id)
+                                    } else {
+                                        None
+                                    }
                                 } else {
                                     s.queue_size = s.total_queued.saturating_sub(total_handled);
                                     s.progress = if s.total_queued > 0 {
@@ -339,8 +357,51 @@ impl QueueManager {
                                 }
                             };
 
-                            if let Some((succeeded, failed)) = summary {
-                                notifications::send_sync_summary(succeeded, failed);
+                            if let Some(batch_id) = summary_batch {
+                                let state_ref = state_ref.clone();
+                                let batch_notify_ref = batch_notify_ref.clone();
+                                tokio::spawn(async move {
+                                    // Debounce queue-drain notifications so bursts of single-file
+                                    // arrivals do not emit one desktop notification per upload.
+                                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+                                    let summary = {
+                                        let s = state_ref.lock().unwrap();
+                                        let mut batch_state = batch_notify_ref.lock().unwrap();
+                                        let total_handled = s.processed_count + s.failed_count;
+                                        let queue_idle = total_handled >= s.total_queued
+                                            && s.active_workers == 0;
+
+                                        if batch_state.active
+                                            && batch_state.notify_scheduled
+                                            && batch_state.current_batch_id == batch_id
+                                            && batch_state.current_batch_id
+                                                != batch_state.last_notified_batch_id
+                                            && queue_idle
+                                        {
+                                            let succeeded = s
+                                                .processed_count
+                                                .saturating_sub(batch_state.start_processed);
+                                            let failed = s
+                                                .failed_count
+                                                .saturating_sub(batch_state.start_failed);
+
+                                            batch_state.last_notified_batch_id = batch_id;
+                                            batch_state.notify_scheduled = false;
+                                            batch_state.active = false;
+                                            Some((succeeded, failed))
+                                        } else {
+                                            if batch_state.current_batch_id == batch_id {
+                                                batch_state.notify_scheduled = false;
+                                            }
+                                            None
+                                        }
+                                    };
+
+                                    if let Some((succeeded, failed)) = summary {
+                                        notifications::send_sync_summary(succeeded, failed);
+                                    }
+                                });
                             }
                         }
                         None => {
@@ -360,6 +421,8 @@ impl QueueManager {
             if !loaded_retries.is_empty() {
                 {
                     let mut s = state_ref2.lock().unwrap();
+                    let mut batch_state = batch_notify_state.lock().unwrap();
+                    activate_batch_if_needed(&mut batch_state, &s);
                     // Retry items are now being actively queued — reset failed_count.
                     s.failed_count = 0;
                     s.total_queued += loaded_retries.len();
@@ -388,6 +451,8 @@ impl QueueManager {
 
         {
             let mut s = self.shared_state.lock().unwrap();
+            let mut batch_state = self.batch_notify_state.lock().unwrap();
+            activate_batch_if_needed(&mut batch_state, &s);
             s.total_queued += 1;
             s.queue_size = s.total_queued.saturating_sub(s.processed_count);
 
@@ -532,6 +597,8 @@ impl QueueManager {
 
         {
             let mut state = self.shared_state.lock().unwrap();
+            let mut batch_state = self.batch_notify_state.lock().unwrap();
+            activate_batch_if_needed(&mut batch_state, &state);
             state.failed_count = state.failed_count.saturating_sub(tasks.len());
             state.total_queued += tasks.len();
             state.queue_size = state.total_queued.saturating_sub(state.processed_count);
@@ -563,6 +630,19 @@ fn current_attempt_count(state: &AppState, path: &str) -> u32 {
         .find(|event| event.path == path)
         .map(|event| event.attempts)
         .unwrap_or(1)
+}
+
+fn activate_batch_if_needed(batch_state: &mut BatchNotifyState, state: &AppState) {
+    if batch_state.active {
+        return;
+    }
+
+    // Start a fresh notification batch when work is (re)introduced.
+    batch_state.active = true;
+    batch_state.notify_scheduled = false;
+    batch_state.current_batch_id = batch_state.current_batch_id.saturating_add(1);
+    batch_state.start_processed = state.processed_count;
+    batch_state.start_failed = state.failed_count;
 }
 
 fn unix_timestamp_now() -> f64 {
@@ -840,6 +920,7 @@ mod tests {
                     quiet_hours_end: None,
                 })),
                 worker_limit: Arc::new(AtomicUsize::new(1)),
+                batch_notify_state: Arc::new(Mutex::new(BatchNotifyState::default())),
             },
             rx,
             shared_state,

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -11,6 +11,7 @@ use gtk::{
     ScrolledWindow, Switch,
 };
 use libadwaita as adw;
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::Path;
@@ -223,6 +224,13 @@ pub fn build_settings_window(
         .build();
     conn_group.add(&test_btn);
 
+    let save_btn = Button::builder()
+        .label("Save Connection Settings")
+        .css_classes(vec!["suggested-action".to_string()])
+        .margin_top(6)
+        .build();
+    conn_group.add(&save_btn);
+
     // Clone before moving into test_btn closure so api_client is still available below
     let api_client_for_test = api_client.clone();
     test_btn.connect_clicked(clone!(
@@ -346,6 +354,12 @@ pub fn build_settings_window(
         .build();
     behavior_group.add(&startup_row);
 
+    let background_sync_row = adw::SwitchRow::builder()
+        .title("Background Sync")
+        .subtitle("Automatically watch folders in the background after launch.")
+        .build();
+    behavior_group.add(&background_sync_row);
+
     let metered_row = adw::SwitchRow::builder()
         .title("Pause on Metered Network")
         .subtitle("Defer uploads while the active connection is marked as metered.")
@@ -421,9 +435,312 @@ pub fn build_settings_window(
         .build();
     settings_page.add(&folders_group);
 
-    let startup_initial = config.data.run_on_startup;
+    let startup_state = Rc::new(RefCell::new(config.data.run_on_startup));
+    let background_sync_state = Rc::new(RefCell::new(config.data.background_sync_enabled));
+    let apply_in_flight = Rc::new(Cell::new(false));
     let tracked_rows = Rc::new(RefCell::new(Vec::<FolderRowData>::new()));
     let albums: Rc<RefCell<Vec<(String, String)>>> = Rc::new(RefCell::new(Vec::new()));
+
+    let apply_settings = Rc::new(clone!(
+        #[weak]
+        window,
+        #[weak]
+        startup_row,
+        #[weak]
+        internal_switch,
+        #[weak]
+        external_switch,
+        #[weak]
+        internal_entry,
+        #[weak]
+        external_entry,
+        #[weak]
+        api_key_entry,
+        #[weak]
+        metered_row,
+        #[weak]
+        battery_row,
+        #[weak]
+        notifications_row,
+        #[weak]
+        concurrency_row,
+        #[weak]
+        quiet_hours_row,
+        #[weak]
+        quiet_start_row,
+        #[weak]
+        quiet_end_row,
+        #[weak]
+        catchup_row,
+        #[weak]
+        background_sync_row,
+        #[strong]
+        tracked_rows,
+        #[strong]
+        albums,
+        #[strong]
+        shared_state,
+        #[strong]
+        api_client,
+        #[strong]
+        queue_manager,
+        #[strong]
+        monitor_handle,
+        #[strong]
+        sync_now_tx,
+        #[strong]
+        startup_state,
+        #[strong]
+        background_sync_state,
+        #[strong]
+        apply_in_flight,
+        move |include_connectivity: bool| {
+            if apply_in_flight.get() {
+                return;
+            }
+            apply_in_flight.set(true);
+
+            let existing = Config::new();
+            let mut internal_url_enabled = existing.data.internal_url_enabled;
+            let mut external_url_enabled = existing.data.external_url_enabled;
+            let mut internal_url = existing.data.internal_url.clone();
+            let mut external_url = existing.data.external_url.clone();
+            let mut api_key = existing.get_api_key().unwrap_or_default();
+            if include_connectivity {
+                internal_url_enabled = internal_switch.is_active();
+                external_url_enabled = external_switch.is_active();
+                internal_url = internal_entry.text().to_string();
+                external_url = external_entry.text().to_string();
+                api_key = api_key_entry.text().to_string();
+            }
+            let run_on_startup = startup_row.is_active();
+            let pause_on_metered_network = metered_row.is_active();
+            let pause_on_battery_power = battery_row.is_active();
+            let notifications_enabled = notifications_row.is_active();
+            let upload_concurrency = concurrency_row.value() as u8;
+            let quiet_hours_enabled = quiet_hours_row.is_active();
+            let quiet_hours_start = quiet_hours_enabled.then(|| quiet_start_row.value() as u8);
+            let quiet_hours_end = quiet_hours_enabled.then(|| quiet_end_row.value() as u8);
+            let background_sync_enabled = background_sync_row.is_active();
+            let catchup_mode = match catchup_row.selected() {
+                1 => StartupCatchupMode::RecentOnly,
+                2 => StartupCatchupMode::NewFilesOnly,
+                _ => StartupCatchupMode::Full,
+            };
+
+            let mut watch_paths = Vec::new();
+            let albums_map: HashMap<String, String> = albums.borrow().iter().cloned().collect();
+            for row_data in tracked_rows.borrow().iter() {
+                let folder = row_data.path.clone();
+                let rules = row_data.rules.borrow().clone();
+                let has_rules = rules != FolderRules::default();
+                let album_name = row_data.album_name.borrow().clone();
+
+                if (album_name.is_empty() || album_name == DEFAULT_ALBUM_LABEL) && !has_rules {
+                    watch_paths.push(WatchPathEntry::Simple(folder));
+                } else {
+                    let album_id = albums_map.get(&album_name).cloned();
+                    watch_paths.push(WatchPathEntry::WithConfig {
+                        path: folder,
+                        album_id,
+                        album_name: if album_name.is_empty() || album_name == DEFAULT_ALBUM_LABEL {
+                            None
+                        } else {
+                            Some(album_name)
+                        },
+                        rules,
+                    });
+                }
+            }
+
+            let runtime_internal_url = if internal_url_enabled {
+                internal_url.clone()
+            } else {
+                String::new()
+            };
+            let runtime_external_url = if external_url_enabled {
+                external_url.clone()
+            } else {
+                String::new()
+            };
+
+            let previous_startup = *startup_state.borrow();
+            let previous_background_sync = *background_sync_state.borrow();
+
+            glib::MainContext::default().spawn_local(clone!(
+                #[weak]
+                window,
+                #[weak]
+                startup_row,
+                #[strong]
+                shared_state,
+                #[strong]
+                api_client,
+                #[strong]
+                queue_manager,
+                #[strong]
+                monitor_handle,
+                #[strong]
+                sync_now_tx,
+                #[strong]
+                startup_state,
+                #[strong]
+                background_sync_state,
+                #[strong]
+                apply_in_flight,
+                async move {
+                    if run_on_startup != previous_startup {
+                        match autostart::apply(&window, run_on_startup).await {
+                            Ok(granted) if granted == run_on_startup => {}
+                            Ok(_) => {
+                                startup_row.set_active(previous_startup);
+                                apply_in_flight.set(false);
+
+                                let dialog = adw::MessageDialog::builder()
+                                    .transient_for(&window)
+                                    .heading("Startup Permission Needed")
+                                    .body("Mimick was not allowed to start automatically at login.")
+                                    .build();
+                                dialog.add_response("ok", "OK");
+                                dialog.present();
+                                return;
+                            }
+                            Err(err) => {
+                                startup_row.set_active(previous_startup);
+                                apply_in_flight.set(false);
+
+                                let dialog = adw::MessageDialog::builder()
+                                    .transient_for(&window)
+                                    .heading("Could Not Update Startup Setting")
+                                    .body(&err)
+                                    .build();
+                                dialog.add_response("ok", "OK");
+                                dialog.present();
+                                return;
+                            }
+                        }
+                    }
+
+                    let mut new_config = Config::new();
+                    new_config.data.internal_url_enabled = internal_url_enabled;
+                    new_config.data.external_url_enabled = external_url_enabled;
+                    new_config.data.internal_url = internal_url;
+                    new_config.data.external_url = external_url;
+                    new_config.data.watch_paths = watch_paths.clone();
+                    new_config.data.run_on_startup = run_on_startup;
+                    new_config.data.background_sync_enabled = background_sync_enabled;
+                    new_config.data.pause_on_metered_network = pause_on_metered_network;
+                    new_config.data.pause_on_battery_power = pause_on_battery_power;
+                    new_config.data.notifications_enabled = notifications_enabled;
+                    new_config.data.startup_catchup_mode = catchup_mode;
+                    new_config.data.upload_concurrency = upload_concurrency;
+                    new_config.data.quiet_hours_start = quiet_hours_start;
+                    new_config.data.quiet_hours_end = quiet_hours_end;
+
+                    if include_connectivity
+                        && !api_key.is_empty()
+                        && !new_config.set_api_key(&api_key)
+                    {
+                        apply_in_flight.set(false);
+
+                        let dialog = adw::MessageDialog::builder()
+                            .transient_for(&window)
+                            .heading("Could Not Save API Key")
+                            .body("Mimick could not store the API key in your desktop keyring.")
+                            .build();
+                        dialog.add_response("ok", "OK");
+                        dialog.present();
+                        return;
+                    }
+
+                    if !new_config.save() {
+                        apply_in_flight.set(false);
+
+                        let dialog = adw::MessageDialog::builder()
+                            .transient_for(&window)
+                            .heading("Could Not Save Settings")
+                            .body("Mimick could not write the updated configuration to disk.")
+                            .build();
+                        dialog.add_response("ok", "OK");
+                        dialog.present();
+                        return;
+                    }
+
+                    *startup_state.borrow_mut() = run_on_startup;
+                    *background_sync_state.borrow_mut() = background_sync_enabled;
+
+                    if let Some(client) = api_client.clone() {
+                        client
+                            .update_settings(
+                                runtime_internal_url.clone(),
+                                runtime_external_url.clone(),
+                                api_key.clone(),
+                            )
+                            .await;
+                    }
+
+                    if let Some(qm) = queue_manager.clone() {
+                        qm.set_worker_limit(upload_concurrency);
+                        qm.update_environment_policy(crate::queue_manager::EnvironmentPolicy {
+                            pause_on_metered_network,
+                            pause_on_battery_power,
+                            quiet_hours_start,
+                            quiet_hours_end,
+                        });
+                    }
+
+                    crate::notifications::set_enabled(notifications_enabled);
+
+                    if previous_background_sync != background_sync_enabled {
+                        let mut state = shared_state.lock().unwrap();
+                        if !background_sync_enabled && state.status != "uploading" && !state.paused
+                        {
+                            state.status = "idle".to_string();
+                            state.pause_reason = None;
+                        }
+                    }
+
+                    if let Some(monitor) = monitor_handle.clone() {
+                        let monitor_paths = if background_sync_enabled {
+                            watch_paths.clone()
+                        } else {
+                            Vec::new()
+                        };
+                        monitor.replace_watch_paths(monitor_paths, background_sync_enabled);
+                    }
+
+                    if background_sync_enabled
+                        && previous_background_sync != background_sync_enabled
+                        && let Some(tx) = sync_now_tx.as_ref()
+                    {
+                        let _ = tx.send(());
+                    }
+
+                    {
+                        let mut state = shared_state.lock().unwrap();
+                        state.watched_folder_count = watch_paths.len();
+                        let current_paths = watch_paths
+                            .iter()
+                            .map(|entry| entry.path().to_string())
+                            .collect::<std::collections::HashSet<_>>();
+                        state
+                            .folder_statuses
+                            .retain(|path, _| current_paths.contains(path));
+                    }
+
+                    apply_in_flight.set(false);
+                }
+            ));
+        }
+    ));
+
+    let auto_apply_settings: Rc<dyn Fn()> = Rc::new(clone!(
+        #[strong]
+        apply_settings,
+        move || {
+            (apply_settings)(false);
+        }
+    ));
 
     // Reuse the application-wide API client — do NOT create a new one here.
     // Creating a new reqwest Client per window open allocates a new connection pool
@@ -469,19 +786,27 @@ pub fn build_settings_window(
     // Add existing paths to listbox with album dropdown
     for entry in &config.data.watch_paths {
         #[allow(deprecated)]
-        add_folder_row(&folders_list, entry, albums.clone(), &tracked_rows);
+        add_folder_row(
+            &folders_list,
+            entry,
+            albums.clone(),
+            &tracked_rows,
+            auto_apply_settings.clone(),
+        );
     }
 
     let folders_list_clone = folders_list.clone();
     let window_clone = window.clone();
     let tracked_rows_clone = tracked_rows.clone();
     let albums_clone = albums.clone();
+    let apply_settings_for_add = auto_apply_settings.clone();
 
     add_folder_btn.connect_clicked(move |_| {
         let dialog = FileDialog::builder().title("Select Watch Folder").build();
         let list_clone = folders_list_clone.clone();
         let tracked_clone = tracked_rows_clone.clone();
         let albums_ref = albums_clone.clone();
+        let apply_settings_for_add = apply_settings_for_add.clone();
 
         dialog.select_folder(
             Some(&window_clone),
@@ -500,7 +825,9 @@ pub fn build_settings_window(
                         &WatchPathEntry::Simple(path_str),
                         albums_ref.clone(),
                         &tracked_clone,
+                        apply_settings_for_add.clone(),
                     );
+                    (apply_settings_for_add)();
                 }
             },
         );
@@ -550,7 +877,7 @@ pub fn build_settings_window(
     settings_page.add(&app_group);
 
     let app_flow = gtk::FlowBox::builder()
-        .homogeneous(true)
+        .homogeneous(false)
         .min_children_per_line(1)
         .max_children_per_line(3)
         .selection_mode(gtk::SelectionMode::None)
@@ -563,48 +890,24 @@ pub fn build_settings_window(
 
     let about_btn = Button::builder()
         .label("About Mimick")
-        .hexpand(true)
+        .hexpand(false)
+        .width_request(320)
+        .halign(gtk::Align::Start)
         .build();
     app_flow.insert(&about_btn, -1);
 
     let quit_btn = Button::builder()
         .label("Quit")
         .css_classes(vec!["destructive-action".to_string()])
-        .hexpand(true)
+        .hexpand(false)
+        .width_request(320)
+        .halign(gtk::Align::Start)
         .build();
     app_flow.insert(&quit_btn, -1);
-
-    let save_btn = Button::builder()
-        .label("Save Changes")
-        .css_classes(vec!["suggested-action".to_string()])
-        .hexpand(true)
-        .build();
-    app_flow.insert(&save_btn, -1);
 
     let window_clone_about = window.clone();
     about_btn.connect_clicked(move |_| {
         show_about_dialog(&window_clone_about);
-    });
-
-    let update_save_btn_state = clone!(
-        #[weak]
-        api_key_entry,
-        #[weak]
-        save_btn,
-        move || {
-            let has_key = !api_key_entry.text().is_empty();
-            save_btn.set_sensitive(has_key);
-
-            if has_key {
-                save_btn.add_css_class("suggested-action");
-            } else {
-                save_btn.remove_css_class("suggested-action");
-            }
-        }
-    );
-    update_save_btn_state();
-    api_key_entry.connect_changed(move |_| {
-        update_save_btn_state();
     });
 
     if let Some(qm) = queue_manager.clone() {
@@ -639,6 +942,14 @@ pub fn build_settings_window(
     } else {
         sync_now_btn.set_sensitive(false);
     }
+
+    background_sync_row.connect_active_notify(clone!(
+        #[strong]
+        auto_apply_settings,
+        move |_| {
+            (auto_apply_settings)();
+        }
+    ));
 
     export_btn.connect_clicked(clone!(
         #[weak]
@@ -713,254 +1024,10 @@ pub fn build_settings_window(
     ));
 
     save_btn.connect_clicked(clone!(
-        #[weak]
-        window,
-        #[weak]
-        internal_switch,
-        #[weak]
-        external_switch,
-        #[weak]
-        internal_entry,
-        #[weak]
-        external_entry,
-        #[weak]
-        api_key_entry,
-        #[weak]
-        startup_row,
-        #[weak]
-        metered_row,
-        #[weak]
-        battery_row,
-        #[weak]
-        notifications_row,
-        #[weak]
-        concurrency_row,
-        #[weak]
-        quiet_hours_row,
-        #[weak]
-        quiet_start_row,
-        #[weak]
-        quiet_end_row,
-        #[weak]
-        catchup_row,
-        #[weak]
-        save_btn,
         #[strong]
-        tracked_rows,
-        #[strong]
-        albums,
-        #[strong]
-        shared_state,
-        #[strong]
-        api_client,
-        #[strong]
-        queue_manager,
-        #[strong]
-        monitor_handle,
+        apply_settings,
         move |_| {
-            save_btn.set_sensitive(false);
-
-            let internal_url_enabled = internal_switch.is_active();
-            let external_url_enabled = external_switch.is_active();
-            let internal_url = internal_entry.text().to_string();
-            let external_url = external_entry.text().to_string();
-            let run_on_startup = startup_row.is_active();
-            let pause_on_metered_network = metered_row.is_active();
-            let pause_on_battery_power = battery_row.is_active();
-            let notifications_enabled = notifications_row.is_active();
-            let upload_concurrency = concurrency_row.value() as u8;
-            let quiet_hours_enabled = quiet_hours_row.is_active();
-            let quiet_hours_start = quiet_hours_enabled.then(|| quiet_start_row.value() as u8);
-            let quiet_hours_end = quiet_hours_enabled.then(|| quiet_end_row.value() as u8);
-            let catchup_mode = match catchup_row.selected() {
-                1 => StartupCatchupMode::RecentOnly,
-                2 => StartupCatchupMode::NewFilesOnly,
-                _ => StartupCatchupMode::Full,
-            };
-            let mut watch_paths = Vec::new();
-            let albums_map: HashMap<String, String> = albums.borrow().iter().cloned().collect();
-
-            for row_data in tracked_rows.borrow().iter() {
-                let folder = row_data.path.clone();
-                let rules = row_data.rules.borrow().clone();
-                let has_rules = rules != FolderRules::default();
-
-                let album_name = row_data.album_name.borrow().clone();
-
-                if (album_name.is_empty() || album_name == DEFAULT_ALBUM_LABEL) && !has_rules {
-                    watch_paths.push(WatchPathEntry::Simple(folder));
-                } else {
-                    let album_id = albums_map.get(&album_name).cloned();
-                    watch_paths.push(WatchPathEntry::WithConfig {
-                        path: folder,
-                        album_id,
-                        album_name: if album_name.is_empty() || album_name == DEFAULT_ALBUM_LABEL {
-                            None
-                        } else {
-                            Some(album_name)
-                        },
-                        rules,
-                    });
-                }
-            }
-
-            let api_key = api_key_entry.text().to_string();
-            let runtime_internal_url = if internal_url_enabled {
-                internal_url.clone()
-            } else {
-                String::new()
-            };
-            let runtime_external_url = if external_url_enabled {
-                external_url.clone()
-            } else {
-                String::new()
-            };
-            let startup_changed = run_on_startup != startup_initial;
-
-            glib::MainContext::default().spawn_local(clone!(
-                #[weak]
-                window,
-                #[weak]
-                startup_row,
-                #[weak]
-                save_btn,
-                #[strong]
-                shared_state,
-                #[strong]
-                api_client,
-                #[strong]
-                queue_manager,
-                #[strong]
-                monitor_handle,
-                async move {
-                    if startup_changed {
-                        match autostart::apply(&window, run_on_startup).await {
-                            Ok(granted) if granted == run_on_startup => {}
-                            Ok(_) => {
-                                startup_row.set_active(false);
-                                save_btn.set_sensitive(true);
-
-                                let dialog = adw::MessageDialog::builder()
-                                    .transient_for(&window)
-                                    .heading("Startup Permission Needed")
-                                    .body("Mimick was not allowed to start automatically at login.")
-                                    .build();
-                                dialog.add_response("ok", "OK");
-                                dialog.present();
-                                return;
-                            }
-                            Err(err) => {
-                                startup_row.set_active(startup_initial);
-                                save_btn.set_sensitive(true);
-
-                                let dialog = adw::MessageDialog::builder()
-                                    .transient_for(&window)
-                                    .heading("Could Not Update Startup Setting")
-                                    .body(&err)
-                                    .build();
-                                dialog.add_response("ok", "OK");
-                                dialog.present();
-                                return;
-                            }
-                        }
-                    }
-
-                    let mut new_config = Config::new();
-                    new_config.data.internal_url_enabled = internal_url_enabled;
-                    new_config.data.external_url_enabled = external_url_enabled;
-                    new_config.data.internal_url = internal_url;
-                    new_config.data.external_url = external_url;
-                    new_config.data.watch_paths = watch_paths.clone();
-                    new_config.data.run_on_startup = run_on_startup;
-                    new_config.data.pause_on_metered_network = pause_on_metered_network;
-                    new_config.data.pause_on_battery_power = pause_on_battery_power;
-                    new_config.data.notifications_enabled = notifications_enabled;
-                    new_config.data.startup_catchup_mode = catchup_mode;
-                    new_config.data.upload_concurrency = upload_concurrency;
-                    new_config.data.quiet_hours_start = quiet_hours_start;
-                    new_config.data.quiet_hours_end = quiet_hours_end;
-
-                    if !api_key.is_empty() && !new_config.set_api_key(&api_key) {
-                        save_btn.set_sensitive(true);
-
-                        let dialog = adw::MessageDialog::builder()
-                            .transient_for(&window)
-                            .heading("Could Not Save API Key")
-                            .body("Mimick could not store the API key in your desktop keyring.")
-                            .build();
-                        dialog.add_response("ok", "OK");
-                        dialog.present();
-                        return;
-                    }
-
-                    if !new_config.save() {
-                        save_btn.set_sensitive(true);
-
-                        let dialog = adw::MessageDialog::builder()
-                            .transient_for(&window)
-                            .heading("Could Not Save Settings")
-                            .body("Mimick could not write the updated configuration to disk.")
-                            .build();
-                        dialog.add_response("ok", "OK");
-                        dialog.present();
-                        return;
-                    }
-
-                    if let Some(client) = api_client.clone() {
-                        client
-                            .update_settings(
-                                runtime_internal_url.clone(),
-                                runtime_external_url.clone(),
-                                api_key.clone(),
-                            )
-                            .await;
-                    }
-
-                    if let Some(qm) = queue_manager.clone() {
-                        qm.set_worker_limit(upload_concurrency);
-                        qm.update_environment_policy(crate::queue_manager::EnvironmentPolicy {
-                            pause_on_metered_network,
-                            pause_on_battery_power,
-                            quiet_hours_start,
-                            quiet_hours_end,
-                        });
-                    }
-
-                    crate::notifications::set_enabled(notifications_enabled);
-
-                    if let Some(monitor) = monitor_handle.clone() {
-                        monitor.replace_watch_paths(watch_paths.clone());
-                    }
-
-                    {
-                        let mut state = shared_state.lock().unwrap();
-                        state.watched_folder_count = watch_paths.len();
-                        let current_paths = watch_paths
-                            .iter()
-                            .map(|entry| entry.path().to_string())
-                            .collect::<std::collections::HashSet<_>>();
-                        state
-                            .folder_statuses
-                            .retain(|path, _| current_paths.contains(path));
-                    }
-
-                    save_btn.set_sensitive(true);
-                    save_btn.set_label("Saved");
-                    save_btn.remove_css_class("suggested-action");
-
-                    glib::timeout_add_local_once(
-                        Duration::from_secs(2),
-                        clone!(
-                            #[weak]
-                            save_btn,
-                            move || {
-                                save_btn.set_label("Save Changes");
-                                save_btn.add_css_class("suggested-action");
-                            }
-                        ),
-                    );
-                }
-            ));
+            (apply_settings)(true);
         }
     ));
 
@@ -974,6 +1041,7 @@ pub fn build_settings_window(
     startup_row.set_active(config.data.run_on_startup);
     metered_row.set_active(config.data.pause_on_metered_network);
     battery_row.set_active(config.data.pause_on_battery_power);
+    background_sync_row.set_active(config.data.background_sync_enabled);
     notifications_row.set_active(config.data.notifications_enabled);
     concurrency_row.set_value(config.data.upload_concurrency as f64);
     let qh_enabled = config.data.quiet_hours_start.is_some();
@@ -1034,6 +1102,78 @@ pub fn build_settings_window(
                 dialog.present();
             }
             external_entry.set_sensitive(switch.is_active());
+        }
+    ));
+
+    startup_row.connect_active_notify(clone!(
+        #[strong]
+        auto_apply_settings,
+        move |_| {
+            (auto_apply_settings)();
+        }
+    ));
+
+    metered_row.connect_active_notify(clone!(
+        #[strong]
+        auto_apply_settings,
+        move |_| {
+            (auto_apply_settings)();
+        }
+    ));
+
+    battery_row.connect_active_notify(clone!(
+        #[strong]
+        auto_apply_settings,
+        move |_| {
+            (auto_apply_settings)();
+        }
+    ));
+
+    notifications_row.connect_active_notify(clone!(
+        #[strong]
+        auto_apply_settings,
+        move |_| {
+            (auto_apply_settings)();
+        }
+    ));
+
+    catchup_row.connect_selected_notify(clone!(
+        #[strong]
+        auto_apply_settings,
+        move |_| {
+            (auto_apply_settings)();
+        }
+    ));
+
+    concurrency_row.connect_value_notify(clone!(
+        #[strong]
+        auto_apply_settings,
+        move |_| {
+            (auto_apply_settings)();
+        }
+    ));
+
+    quiet_hours_row.connect_active_notify(clone!(
+        #[strong]
+        auto_apply_settings,
+        move |_| {
+            (auto_apply_settings)();
+        }
+    ));
+
+    quiet_start_row.connect_value_notify(clone!(
+        #[strong]
+        auto_apply_settings,
+        move |_| {
+            (auto_apply_settings)();
+        }
+    ));
+
+    quiet_end_row.connect_value_notify(clone!(
+        #[strong]
+        auto_apply_settings,
+        move |_| {
+            (auto_apply_settings)();
         }
     ));
 
@@ -1203,6 +1343,7 @@ fn add_folder_row(
     entry: &WatchPathEntry,
     albums_ref: Rc<RefCell<Vec<(String, String)>>>,
     tracked_rows: &Rc<RefCell<Vec<FolderRowData>>>,
+    on_settings_changed: Rc<dyn Fn()>,
 ) {
     let path = entry.path().to_string();
     let base_subtitle = watch_path_subtitle(&path).unwrap_or_default().to_string();
@@ -1238,6 +1379,7 @@ fn add_folder_row(
     let picker_btn_clone = picker_btn.clone();
     let album_name_clone = album_name.clone();
     let albums_ref_clone = albums_ref.clone();
+    let on_settings_changed_for_picker = on_settings_changed.clone();
 
     picker_btn.connect_clicked(clone!(
         #[weak]
@@ -1251,6 +1393,7 @@ fn add_folder_row(
                 let albums_ref_clone = albums_ref_clone.clone();
                 let album_name_clone = album_name_clone.clone();
                 let picker_btn_clone = picker_btn_clone.clone();
+                let on_settings_changed_for_picker = on_settings_changed_for_picker.clone();
 
                 glib::idle_add_local_once(move || {
                     show_album_picker_dialog(
@@ -1258,6 +1401,7 @@ fn add_folder_row(
                         albums_ref_clone,
                         album_name_clone,
                         picker_btn_clone,
+                        on_settings_changed_for_picker,
                     );
                 });
             }
@@ -1284,6 +1428,7 @@ fn add_folder_row(
     let path_clone = path.clone();
     let rules_clone = rules.clone();
     let path_for_rules = path.clone();
+    let on_settings_changed_for_rules = on_settings_changed.clone();
 
     rules_btn.connect_clicked(clone!(
         #[weak]
@@ -1296,12 +1441,20 @@ fn add_folder_row(
                 let window = window.clone();
                 let path_for_rules = path_for_rules.clone();
                 let rules_clone = rules_clone.clone();
+                let on_settings_changed_for_rules = on_settings_changed_for_rules.clone();
                 glib::idle_add_local_once(move || {
-                    show_folder_rules_dialog(&window, &path_for_rules, rules_clone);
+                    show_folder_rules_dialog(
+                        &window,
+                        &path_for_rules,
+                        rules_clone,
+                        on_settings_changed_for_rules,
+                    );
                 });
             }
         }
     ));
+
+    let on_settings_changed_for_remove = on_settings_changed.clone();
 
     remove_btn.connect_clicked(clone!(
         #[weak]
@@ -1311,12 +1464,14 @@ fn add_folder_row(
             let tracked_clone = tracked_clone.clone();
             let path_clone = path_clone.clone();
             let expander_row = expander_row.clone();
+            let on_settings_changed_for_remove = on_settings_changed_for_remove.clone();
             glib::idle_add_local_once(move || {
                 if let Some(focus_target) = list_clone.first_child() {
                     focus_target.grab_focus();
                 }
                 list_clone.remove(&expander_row);
                 tracked_clone.borrow_mut().retain(|r| r.path != path_clone);
+                (on_settings_changed_for_remove)();
             });
         }
     ));
@@ -1343,6 +1498,7 @@ fn show_folder_rules_dialog(
     parent: &impl gtk::prelude::IsA<gtk::Window>,
     folder_path: &str,
     rules_state: Rc<RefCell<FolderRules>>,
+    on_settings_changed: Rc<dyn Fn()>,
 ) {
     let dialog = adw::Window::builder()
         .transient_for(parent)
@@ -1441,6 +1597,7 @@ fn show_folder_rules_dialog(
                 max_file_size_mb,
                 allowed_extensions,
             };
+            (on_settings_changed)();
             dialog.close();
         }
     ));
@@ -1625,6 +1782,7 @@ fn show_album_picker_dialog(
     albums_ref: Rc<RefCell<Vec<(String, String)>>>,
     target_album_state: Rc<RefCell<String>>,
     trigger_btn: Button,
+    on_settings_changed: Rc<dyn Fn()>,
 ) {
     let dialog = adw::Window::builder()
         .transient_for(parent)
@@ -1689,9 +1847,11 @@ fn show_album_picker_dialog(
                 let dialog_clone = dialog.clone();
                 let state_clone = target_album_state.clone();
                 let btn_clone = trigger_btn.clone();
+                let on_settings_changed_clone = on_settings_changed.clone();
                 default_row.connect_activated(move |_| {
                     *state_clone.borrow_mut() = DEFAULT_ALBUM_LABEL.to_string();
                     btn_clone.set_label(&format!("Album: {}", DEFAULT_ALBUM_LABEL));
+                    (on_settings_changed_clone)();
                     dialog_clone.close();
                 });
                 list_box.append(&default_row);
@@ -1707,9 +1867,11 @@ fn show_album_picker_dialog(
                 let dialog_clone = dialog.clone();
                 let state_clone = target_album_state.clone();
                 let btn_clone = trigger_btn.clone();
+                let on_settings_changed_clone = on_settings_changed.clone();
                 create_row.connect_activated(move |_| {
                     *state_clone.borrow_mut() = typed_raw.clone();
                     btn_clone.set_label(&format!("Album: {}", typed_raw));
+                    (on_settings_changed_clone)();
                     dialog_clone.close();
                 });
                 list_box.append(&create_row);
@@ -1730,9 +1892,11 @@ fn show_album_picker_dialog(
                     let state_clone = target_album_state.clone();
                     let btn_clone = trigger_btn.clone();
                     let album_name_clone = album_name.clone();
+                    let on_settings_changed_clone = on_settings_changed.clone();
                     row.connect_activated(move |_| {
                         *state_clone.borrow_mut() = album_name_clone.clone();
                         btn_clone.set_label(&format!("Album: {}", album_name_clone));
+                        (on_settings_changed_clone)();
                         dialog_clone.close();
                     });
                     list_box.append(&row);

--- a/wiki/Development.md
+++ b/wiki/Development.md
@@ -48,12 +48,31 @@ Mimick uses `flexi_logger` and writes logs to both:
 - `~/.cache/mimick/mimick.log`
 
 Detailed timestamps are enabled for both outputs.
+Console logs are colorized by level (error/warn/info/debug/trace).
+File logging rotates automatically (approximately 2 MB per file, 5 files kept).
 
 Increase verbosity with:
 
 ```bash
 RUST_LOG=debug cargo run
 ```
+
+## Settings UX & Apply Behavior
+
+- Most UI changes in the Settings window are now applied live (auto-apply). This includes:
+	- upload worker count
+	- quiet hours start/end
+	- folder add/remove
+	- per-folder album target and folder rules
+
+- Connectivity fields (API Key, Internal/External server URLs) are treated as save-only. Changes to these fields are applied only when the user clicks **Save** in the Connectivity section to avoid partially-applied network credentials during configuration edits.
+
+See `/implementation.md` for the prioritized UX plan and acceptance criteria.
+
+## Notifications
+
+- Per-upload notifications were noisy when many workers were active. Mimick now aggregates worker outcomes into a single batch summary that states how many files were processed successfully and how many failed for the batch. Connectivity-related notifications (such as "Connection Lost") still fire independently to alert the user of network failures.
+
 
 ## Packaging
 


### PR DESCRIPTION
## Summary

This PR introduces four user-facing improvements and their supporting infrastructure changes, split across 5 atomic commits.

---

## Changes

### 1. Logging Overhaul (`refactor(logging)`)

- Replaced flexi_logger built-in formatters with custom `detailed_colored_format` (console) and `detailed_plain_format` (file) for cleaner, consistent output
- Log line format: `[timestamp] LEVEL [target] message file:line`
- Console output is now colorized by severity level (error/warn/info/debug/trace)
- File logs use a plain, machine-friendly format suitable for automated parsing
- Added automatic log rotation: ~2 MB per file, 5 rotated files kept
- Prevents unbounded log file growth in long-running instances

### 2. Background Sync Toggle (`feat(config)`)

- Added `background_sync_enabled` config field (defaults to `true` via `serde(default)` so existing configs are unaffected)
- When disabled:
  - No folder watches are registered with the filesystem monitor
  - The startup catch-up scan is skipped entirely
  - Appropriate log messages indicate the disabled state
- `Monitor::new`, `MonitorHandle::replace_watch_paths`, and `replace_watches` all accept the new flag
- `MonitorCommand::ReplaceWatchPaths` changed from tuple variant to struct variant for clarity
- Diagnostics summary and `RedactedConfigExport` include the new field
- Unit test verifies the `default = true` serde behavior on empty JSON

### 3. Batch Notification Fix (`fix(notifications)`)

- **Problem**: When multiple upload workers were active, each queue-drain triggered a separate desktop notification, resulting in notification spam
- **Solution**: Replaced the per-drain `last_notify_completed` counter with a `BatchNotifyState` struct that:
  - Tracks batch IDs to distinguish separate sync cycles
  - Records start offsets for processed/failed counts per batch
  - Uses a 2-second debounce (`tokio::time::sleep`) before emitting the notification
  - Only fires when the queue is truly idle (all workers done, total handled >= total queued)
- `activate_batch_if_needed` helper resets batch state at every work-introduction point (enqueue, retry-load, manual retry)
- `send_sync_summary` messaging simplified: unified "Sync complete" title, reports total processed count
- Connectivity-related notifications ("Connection Lost") are unaffected and still fire independently

### 4. Live Settings Auto-Apply (`feat(settings)`)

- Most settings changes in the Settings window now take effect immediately without requiring a manual save:
  - Upload worker count
  - Quiet hours enable/start/end
  - Pause on metered network / battery power
  - Notifications toggle
  - Background sync toggle
  - Startup catch-up mode
  - Folder additions/removals
  - Per-folder album target selection
  - Per-folder filter rules
- **Connectivity fields** (API key, Internal/External server URLs) are intentionally **save-only** -- a new "Save Connection Settings" button applies them explicitly to prevent partial credential states during exploratory edits
- `apply_in_flight` guard (`Cell<bool>`) prevents re-entrant apply calls
- `on_settings_changed` callback threaded through `add_folder_row`, `show_folder_rules_dialog`, and `show_album_picker_dialog`

### 5. Documentation Updates (`docs`)

- **CHANGELOG.md**: Added Unreleased section covering all three features
- **README.md**: New "Logging & Notifications" section; documented settings auto-apply vs save-only behavior
- **wiki/Development.md**: Documented colored console logging, file rotation config, settings UX & apply behavior, and batch notification design
- **roadmap.md**: Marked "Background Sync Toggle" as complete

---

## File Summary

| File | Lines Changed | Purpose |
|------|:---:|---------|
| `src/settings_window.rs` | +566 / -402 | Live auto-apply, background sync row, save button |
| `src/main.rs` | +68 / -17 | Custom log formatters, rotation, background sync wiring |
| `src/queue_manager.rs` | +98 / -13 | BatchNotifyState, debounced notifications |
| `src/monitor.rs` | +36 / -14 | background_sync_enabled plumbing |
| `src/notifications.rs` | +6 / -9 | Simplified summary wording |
| `src/config.rs` | +11 / -0 | New field + default + tests |
| `src/diagnostics.rs` | +6 / -0 | Export new field |
| `CHANGELOG.md` | +9 / -2 | Unreleased entries |
| `README.md` | +13 / -1 | Logging & settings docs |
| `wiki/Development.md` | +19 / -0 | Developer docs |
| `roadmap.md` | +1 / -1 | Mark item complete |

---

## Testing

- `cargo check` passes cleanly
- Existing unit tests updated (config default test, queue_manager test fixture)
- New unit test: `test_config_data_background_sync_defaults_true_when_missing`
