### PR TITLE
build: update GNOME platform runtime to version 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Settings: Live auto-apply for most preferences (workers, quiet hours, folder rules, per-folder album selection, watch-folders). Connectivity fields (API key and server URLs) are now applied only when explicitly saved from the Connectivity section.
 - Single-batch sync summary notification: multiple concurrent upload workers now aggregate results and emit a single "processed" summary notification when a sync batch completes.
+- Flatpak packaging now targets the GNOME 50 runtime for current desktop compatibility.
 
 ### Changed
 - Logging: Console output is colorized by level and file logs use a plain, machine-friendly formatter with automatic rotation (approx. 2 MB per file, keep 5). See README and wiki for configuration details.
-
 
 ## [9.3.0] - 2026-04-14
 

--- a/io.github.nicx17.mimick.local.yml
+++ b/io.github.nicx17.mimick.local.yml
@@ -1,7 +1,7 @@
 app-id: io.github.nicx17.mimick
 branch: stable
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable

--- a/io.github.nicx17.mimick.yml
+++ b/io.github.nicx17.mimick.yml
@@ -1,7 +1,7 @@
 app-id: io.github.nicx17.mimick
 branch: stable
 runtime: org.gnome.Platform
-runtime-version: "49"
+runtime-version: "50"
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable

--- a/wiki/Development.md
+++ b/wiki/Development.md
@@ -28,9 +28,9 @@ sudo pacman -S gtk4 libadwaita pkgconf base-devel
 
 If you plan to build or test the Flatpak bundle locally using `flatpak-builder`, you must install the following from [Flathub](https://flathub.org/setup):
 
-- **GNOME Platform 49 Runtime** (`org.gnome.Platform//49`)
-- **GNOME SDK 49** (`org.gnome.Sdk//49`)
-- **Freedesktop Rust Extension** (`org.freedesktop.Sdk.Extension.rust-stable//24.08`)
+- **GNOME Platform 50 Runtime** (`org.gnome.Platform//50`)
+- **GNOME SDK 50** (`org.gnome.Sdk//50`)
+- **Freedesktop Rust Extension** (`org.freedesktop.Sdk.Extension.rust-stable//25.08`)
 
 ## Build and Run
 


### PR DESCRIPTION

```
This PR bumps the Flatpak packaging and development environment to target the **GNOME 50** runtime, ensuring the application stays up to date with the latest desktop compatibility standards and security updates. 

### Changes Included
- **Flatpak Manifests:** Bumped `runtime-version` to `"50"` in both `io.github.nicx17.mimick.yml` and `io.github.nicx17.mimick.local.yml`.
- **Documentation:** Updated the prerequisites in `wiki/Development.md` to reflect `org.gnome.Platform//50` and `org.gnome.Sdk//50`.
- **Changelog:** Documented the runtime bump in `CHANGELOG.md`.

## Type of change

- [x] Dependency / Environment update
- [x] Documentation update

## Testing Performed

- [x] Verified local Flatpak build succeeds with the new GNOME 50 SDK.
```
