### PR TITLE
feat: generate .flatpakref file for one-click graphical installs

### DIFF
--- a/.github/workflows/flatpak-repo.yml
+++ b/.github/workflows/flatpak-repo.yml
@@ -123,6 +123,24 @@ jobs:
             printf 'GPGKey=%s\n' "$REPO_GPG_KEY"
           } > repo/mimick.flatpakrepo
 
+      - name: Generate .flatpakref file
+        env:
+          REPO_GPG_KEY: ${{ steps.signing_key.outputs.public_key_b64 }}
+        run: |
+          {
+            printf '[Flatpak Ref]\n'
+            printf 'Title=Mimick\n'
+            printf 'Name=io.github.nicx17.mimick\n'
+            printf 'Branch=stable\n'
+            printf 'Url=https://nicx17.github.io/mimick/\n'
+            printf 'SuggestRemoteName=mimick\n'
+            printf 'Homepage=https://github.com/nicx17/mimick\n'
+            printf 'Icon=https://nicx17.github.io/mimick/icon.png\n'
+            printf 'RuntimeRepo=https://dl.flathub.org/repo/flathub.flatpakrepo\n'
+            printf 'IsRuntime=false\n'
+            printf 'GPGKey=%s\n' "$REPO_GPG_KEY"
+          } > repo/mimick.flatpakref
+
       - name: Copy landing page assets
         run: |
           cp site/index.html repo/index.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Settings: Live auto-apply for most preferences (workers, quiet hours, folder rules, per-folder album selection, watch-folders). Connectivity fields (API key and server URLs) are now applied only when explicitly saved from the Connectivity section.
 - Single-batch sync summary notification: multiple concurrent upload workers now aggregate results and emit a single "processed" summary notification when a sync batch completes.
 - Flatpak packaging now targets the GNOME 50 runtime for current desktop compatibility.
+- GitHub Pages repository pipeline now dynamically generates a `mimick.flatpakref` file for one-click graphical installations.
 
 ### Changed
 - Logging: Console output is colorized by level and file logs use a plain, machine-friendly formatter with automatic rotation (approx. 2 MB per file, keep 5). See README and wiki for configuration details.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ The easiest and official way to install Mimick on any Linux distribution is via 
 
 **Prerequisites**: Flatpak must be installed and the [Flathub](https://flathub.org/setup) remote must be configured on your system (required for GNOME runtime dependencies).
 
+### Graphical Install (One-Click)
+
+You can easily install Mimick by downloading and opening the `.flatpakref` file. Your system's software center (like GNOME Software or KDE Discover) should open it and handle adding the repository and installing the app automatically:
+
+[Download mimick.flatpakref](https://nicx17.github.io/mimick/mimick.flatpakref)
+
+### Command Line Install
+
+Alternatively, install using the terminal:
+
 ```bash
 # Add the official Mimick repository
 flatpak remote-add --user --if-not-exists mimick-repo https://nicx17.github.io/mimick/mimick.flatpakrepo

--- a/site/index.html
+++ b/site/index.html
@@ -46,22 +46,29 @@ flatpak install --user mimick-repo io.github.nicx17.mimick</code></pre>
             </section>
 
             <section class="links-container" aria-label="Repository links">
-                <a class="link-block" href="mimick.flatpakrepo">
+                <a class="link-block" href="mimick.flatpakref">
                     <span class="link-icon">01</span>
+                    <span class="link-copy">
+                        <strong>Graphical Install (One-Click)</strong>
+                        <span>Download the <code>.flatpakref</code> to open in your software center.</span>
+                    </span>
+                </a>
+                <a class="link-block" href="mimick.flatpakrepo">
+                    <span class="link-icon">02</span>
                     <span class="link-copy">
                         <strong>Download repository file</strong>
                         <span>Get the <code>.flatpakrepo</code> directly.</span>
                     </span>
                 </a>
                 <a class="link-block" href="https://github.com/nicx17/mimick">
-                    <span class="link-icon">02</span>
+                    <span class="link-icon">03</span>
                     <span class="link-copy">
                         <strong>View on GitHub</strong>
                         <span>Browse source, releases, and issues.</span>
                     </span>
                 </a>
                 <a class="link-block" href="https://github.com/nicx17/mimick/blob/main/CHANGELOG.md">
-                    <span class="link-icon">03</span>
+                    <span class="link-icon">04</span>
                     <span class="link-copy">
                         <strong>Read the changelog</strong>
                         <span>See the latest app and packaging changes.</span>

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -9,6 +9,14 @@ The recommended install method is the official Flatpak repository.
 
 ## Install Mimick
 
+### Graphical Install (One-Click)
+You can easily install Mimick by downloading and opening the `.flatpakref` file. Your system's software center (like GNOME Software or KDE Discover) should open it and handle adding the repository and installing the app automatically:
+
+[Download mimick.flatpakref](https://nicx17.github.io/mimick/mimick.flatpakref)
+
+### Command Line Install
+Alternatively, install using the terminal:
+
 ```bash
 # Add the official Mimick repository
 flatpak remote-add --user --if-not-exists mimick-repo https://nicx17.github.io/mimick/mimick.flatpakrepo


### PR DESCRIPTION

This PR introduces graphical, one-click installation support by dynamically generating and distributing a `.flatpakref` file. 

By simply clicking this file, a user's system software center (e.g., GNOME Software, KDE Discover) will automatically add the Flatpak repository and install Mimick.

### Changes Included
- **GitHub Actions Workflow:** Appended a `Generate .flatpakref file` step to the `flatpak-repo.yml` pipeline. This creates `mimick.flatpakref` and embeds the base64-encoded GPG public key.
- **Repository Landing Page:** Updated `site/index.html` to prominently feature a new "Graphical Install (One-Click)" download link at the top of the resources list.
- **Documentation:** Updated the `README.md` and `wiki/Installation.md` to provide instructions for the new graphical install method.
- **Changelog:** Added an entry in `CHANGELOG.md` to document the new installation path.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
