### PR TITLE
Update documentation for library view and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Each watched directory operates with isolated logical constraints:
 - Predetermined allowance lists strictly for explicit file extensions (e.g. `.avif`, `.mp4`).
 - Upper-bound maximum file size ceilings.
 
+### Library View (Optional)
+- Built-in album browser with thumbnail grid and Explore landing page.
+- Search modes: filename/metadata, Smart (CLIP), and OCR text lookup.
+- Download originals and open full-resolution previews in the lightbox.
+- Toggle via **Settings → Behavior → Enable Library View** (restart required).
+
 ---
 
 ## Installation (Recommended)
@@ -139,7 +145,7 @@ The UI is fully responsive and automatically adapts its layout for narrow widths
 
 1. **Internal URL** — LAN address (e.g., `http://192.168.1.50:2283`).
 2. **External URL** — WAN/Public address (e.g., `https://photos.example.com`). *At least one must be enabled.*
-3. **API Key** — Generate in Immich Web UI under Account Settings > API Keys. Needs **Asset** read/create/update permissions and **Album** read/create/update permissions.
+3. **API Key** — Generate in Immich Web UI under Account Settings > API Keys. Needs **Asset** read/create/update/download permissions and **Album** read/create/update permissions.
 4. **Watch Paths** — Add folders to monitor with the built-in folder picker. Each folder can be assigned a target Immich album.
 5. **Run on Startup** — Enable this in the **Behavior** section to start Mimick automatically when you log in.
 6. **Folder Rules** — Each watched folder can open a rules dialog to ignore hidden paths, set a max size in MB, or restrict uploads to specific extensions.

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -28,7 +28,7 @@ graph TD
     end
 
     subgraph Settings UI [Settings Window - GTK4 / Libadwaita]
-        Window[Settings Window - built once, hidden on close] -->|500ms timer - lock only| SharedState
+        Window[Settings Window] -->|500ms timer - lock only| SharedState
         Window -->|Diagnostics export| Diagnostics[diagnostics.rs]
     end
 
@@ -58,7 +58,7 @@ Initializes the GTK4 `adw::Application` with ID `dev.nicx.mimick`. Only the prim
 
 - `connect_command_line` opens the settings window when `--settings` is passed **or** when `cmdline.is_remote()` is true (user clicks the app icon while the daemon is already running)
 - Shared `Arc<Mutex<AppState>>` is created before all closures and threaded into both `connect_startup` (workers) and `connect_command_line` (settings window)
-- Shared `Arc<ImmichApiClient>` is stored in a `OnceLock` and reused by the settings window -- only one reqwest connection pool is ever allocated
+- Shared `AppContext` is stored in a `OnceLock` and reused by UI windows and shutdown paths (single API client, queue manager, monitor handle)
 
 ### 2. File Monitor (`src/monitor.rs`)
 
@@ -82,7 +82,7 @@ Thread-safe upload orchestrator using a single `Arc<Mutex<AppState>>` for all co
 - Reads persisted retries from disk on startup (crash recovery); re-queues after 5s delay
 - Supports manual `Pause / Resume`, `Sync Now`, queue inspection, per-item retry, retry-all, and failed-queue clearing
 - Records recent queue events and pause reasons in shared state for UI visibility and diagnostics
-- `QM_HANDLE: OnceLock<Arc<QueueManager>>` allows `main()` to call `flush_retries()` after `app.run()` returns
+- The `QueueManager` lives in `AppContext`; shutdown calls `flush_retries()` from the shared handle after `app.run()` returns
 - Environment-aware pause policy: metered network, battery power, and quiet-hours window deferral
 
 ### 4. API Client (`src/api_client.rs`)
@@ -92,14 +92,13 @@ Thread-safe upload orchestrator using a single `Arc<Mutex<AppState>>` for all co
 - Files streamed with `reqwest::multipart::Part::stream_with_length` -- zero RAM buffering
 - Full 40-char SHA-1 hex used as `device_asset_id` for reliable Immich server-side deduplication
 - Connection pool: max 1 idle connection per host, 30s idle timeout
-- Single shared instance via `API_CLIENT_HANDLE: OnceLock<Arc<ImmichApiClient>>` -- no new pool per settings window open
+- Single shared instance via `AppContext` -- no new reqwest pool per settings window open
 - Structured error diagnostics with actionable guidance for common failure modes
 
 ### 5. Settings UI (`src/settings_window.rs`)
 
-- **Built once per process**, then hidden on close (`window.connect_close_request` -> `set_visible(false)` + `Propagation::Stop`)  
-- Subsequent opens call `win.present()` on the existing hidden window -- zero new GTK allocations per open/close cycle
-- `Arc<Mutex<AppState>>` passed in directly; the 500ms `glib::timeout_add_local` timer reads it without any disk I/O
+- Built on demand from `AppContext`; close destroys the window (unless background sync is disabled, in which case the app quits)
+- `Arc<Mutex<AppState>>` accessed from `AppContext`; the 500ms `glib::timeout_add_local` timer reads it without any disk I/O
 - Album list fetched via the shared `Arc<ImmichApiClient>` on first show; a `glib::WeakRef` guard on the window ensures the async task returns early if the window is closed before the API responds
 - Test Connection button uses the shared client -- no new reqwest pool per click
 - Uses a two-page `Settings` / `Status` layout with a persistent footer for `Close`, `Quit`, and live `Save Changes`

--- a/wiki/Configuration-and-First-Run.md
+++ b/wiki/Configuration-and-First-Run.md
@@ -44,7 +44,7 @@ The window follows your desktop appearance preference, so it can render in eithe
     * Open your Immich Web Interface in a browser.
     * Go to **Account Settings** → **API Keys**.
     * Click **New API Key**, give it a name (like "Linux Desktop"), and click Create.
-    * Make sure the key includes **Asset Read/Create/Update** and **Album Read/Create/Update** permissions.
+    * Make sure the key includes **Asset Read/Create/Update/Download** and **Album Read/Create/Update** permissions.
     * Copy the key and paste it into the API Key field in Mimick.
     * *The key is stored securely using the `oo7` crate (encrypted portal file in Flatpak, or D-Bus Secret Service native).*
 
@@ -126,6 +126,23 @@ The export creates a timestamped `mimick-diagnostics-*` folder containing redact
 * `privacy-note.txt`
 
 API keys, raw logs, full local paths, and raw server URLs are intentionally omitted.
+
+---
+
+## Library View (Optional)
+
+Mimick includes an opt-in library browser for albums, Explore, and search.
+
+1. Enable **Settings → Behavior → Enable Library View**.
+2. Restart Mimick to switch the main window to the library view.
+3. Use the source selector for **Remote**, **Local**, or **Unified** browsing.
+4. Search modes:
+    * **Filename** (metadata/filename match)
+    * **Smart Search** (CLIP semantic search)
+    * **OCR** (text inside images)
+5. Use **Download** in the lightbox to save originals to a chosen folder.
+
+**Extra permissions:** Library browsing requires **Asset Read** and downloads require **Asset Download**.
 
 ---
 
@@ -218,6 +235,10 @@ The configuration is stored in a JSON file located at:
 | `run_on_startup` | Whether Mimick should register itself for automatic login startup. | `false` |
 | `pause_on_metered_network` | Whether uploads should pause while the active network connection appears metered. | `false` |
 | `pause_on_battery_power` | Whether uploads should pause while the system appears to be running on battery. | `false` |
+| `library_view_enabled` | Whether the in-app library view opens instead of the settings window. | `false` |
+| `download_target_path` | Target folder for library downloads (chosen on first download). | `"/home/user/Pictures/Downloads"` |
+| `library_preview_full_resolution` | Load full-resolution originals in the lightbox instead of previews. | `false` |
+| `library_thumbnail_cache_mb` | RAM cap for decoded thumbnails (0 = default 80 MB). | `80` |
 
 ### `watch_paths` Object Form
 
@@ -236,7 +257,7 @@ When a watch path is stored as an object, these fields can appear:
 
 When generating an API Key in the Immich Web UI (Account Settings > API Keys), you can restrict its permissions for better security. `mimick` requires the following minimum permissions:
 
-- **Asset**: `Read` (to check for duplicates), `Create` (to upload new media), `Update` (to reapply final asset timezone metadata after upload)
+- **Asset**: `Read` (to check for duplicates), `Create` (to upload new media), `Update` (to reapply final asset timezone metadata after upload), `Download` (for library view downloads)
 - **Album**: `Read` (to list existing albums), `Create` (to create new albums), `Update` (to add uploaded media to albums)
 
 ### Systemd Service Configuration (Native Only)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -32,6 +32,7 @@ Mimick is a Linux background app that watches selected folders and syncs photos 
 ## Current App Highlights
 
 - Two-page `Settings` / `Status` settings window
+- Optional in-app library viewer with albums, Explore, and search
 - Queue inspector with retry actions
 - Per-folder rules for hidden paths, size limits, and extension filters
 - Diagnostics bundle export for support and bug reports


### PR DESCRIPTION
Enhance the documentation to include details about the optional library view feature, its functionalities, and the necessary permissions for API keys. Update permissions required for asset operations to reflect the new download capability.