### PR TITLE
fix: bug-fixes batch (BUG-001..005) and drop MESA log env

### DIFF
--- a/dev.nicx.mimick.local.yml
+++ b/dev.nicx.mimick.local.yml
@@ -15,7 +15,6 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --device=dri
-  - --env=MESA_LOG_LEVEL=error
   - --share=ipc
   - --talk-name=org.kde.StatusNotifierWatcher
   - --share=network

--- a/dev.nicx.mimick.yml
+++ b/dev.nicx.mimick.yml
@@ -15,7 +15,6 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --device=dri
-  - --env=MESA_LOG_LEVEL=error
   - --share=ipc
   - --talk-name=org.kde.StatusNotifierWatcher
   - --share=network

--- a/src/library/local_source.rs
+++ b/src/library/local_source.rs
@@ -10,6 +10,7 @@
 //! looking up `SyncIndex.stored_checksum(path)` for paths the engine has
 //! already hashed; assets the user hasn't synced yet show as "Local only".
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -70,6 +71,7 @@ pub async fn enumerate_local(ctx: Arc<AppContext>) -> Vec<LocalAsset> {
 
 fn enumerate_blocking(watch_paths: &[WatchPathEntry]) -> Vec<LocalAsset> {
     let mut out = Vec::new();
+    let mut seen: HashSet<PathBuf> = HashSet::new();
     for entry in watch_paths {
         let root = PathBuf::from(entry.path());
         if !root.is_dir() {
@@ -92,6 +94,10 @@ fn enumerate_blocking(watch_paths: &[WatchPathEntry]) -> Vec<LocalAsset> {
                     continue;
                 }
                 if !rules.matches(&path) {
+                    continue;
+                }
+                let key = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+                if !seen.insert(key) {
                     continue;
                 }
                 if let Some(asset) = build_asset(&path) {

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -820,6 +820,10 @@ fn connect_sidebar_handlers(ui: Rc<LibraryWindowUi>) {
                 "photos" => sidebar_dispatch(ui.clone(), LibrarySource::Timeline),
                 "explore" => sidebar_dispatch(ui.clone(), LibrarySource::Explore),
                 "albums" => {
+                    ui.album_link_row.set_visible(false);
+                    if let Some(parent) = ui.album_link_row.parent() {
+                        parent.set_visible(false);
+                    }
                     ui.content_stack.set_visible_child_name("albums");
                     refresh_albums_view(ui.clone());
                 }
@@ -849,9 +853,11 @@ fn connect_sidebar_handlers(ui: Rc<LibraryWindowUi>) {
 
 /// Common path for sidebar selections. Skips redundant dispatches so the
 /// `reload_sidebar` programmatic re-selection doesn't loop into another
-/// fetch.
+/// fetch — but only when the content stack is already showing the current
+/// source, since the Albums grid moves the stack without changing source.
 fn sidebar_dispatch(ui: Rc<LibraryWindowUi>, source: LibrarySource) {
-    if ui.ctx.library_state.lock().unwrap().source == source {
+    let on_albums_grid = ui.content_stack.visible_child_name().as_deref() == Some("albums");
+    if !on_albums_grid && ui.ctx.library_state.lock().unwrap().source == source {
         return;
     }
     let request = ui.ctx.library_state.lock().unwrap().switch_source(source);

--- a/src/main.rs
+++ b/src/main.rs
@@ -549,8 +549,7 @@ async fn main() {
         let runtime_config = Config::new();
         let want_settings = argv.contains(&"--settings".to_string());
         let want_library = argv.contains(&"--library".to_string());
-        let setup_required = runtime_config.get_api_key().unwrap_or_default().is_empty()
-            || !runtime_config.data.background_sync_enabled;
+        let setup_required = runtime_config.get_api_key().unwrap_or_default().is_empty();
         let secondary_activation = cmdline.is_remote();
 
         let ctx_lookup = || {
@@ -564,7 +563,7 @@ async fn main() {
             open_settings_window_now(app, ctx_lookup());
         } else if want_library {
             open_library_window_now(app, ctx_lookup());
-        } else if secondary_activation {
+        } else if secondary_activation || !runtime_config.data.background_sync_enabled {
             open_default_window(app, ctx_lookup());
         }
 

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -648,18 +648,26 @@ pub fn build_settings_window_with_parent(
                 let has_rules = rules != FolderRules::default();
                 let album_name = row_data.album_name.borrow().clone();
 
-                if (album_name.is_empty() || album_name == DEFAULT_ALBUM_LABEL) && !has_rules {
+                let is_default = album_name.is_empty() || album_name == DEFAULT_ALBUM_LABEL;
+                let resolved_album_name = if is_default {
+                    Path::new(&folder)
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|s| s.to_string())
+                } else {
+                    Some(album_name)
+                };
+
+                if is_default && !has_rules && resolved_album_name.is_none() {
                     watch_paths.push(WatchPathEntry::Simple(folder));
                 } else {
-                    let album_id = albums_map.get(&album_name).cloned();
+                    let album_id = resolved_album_name
+                        .as_ref()
+                        .and_then(|n| albums_map.get(n).cloned());
                     watch_paths.push(WatchPathEntry::WithConfig {
                         path: folder,
                         album_id,
-                        album_name: if album_name.is_empty() || album_name == DEFAULT_ALBUM_LABEL {
-                            None
-                        } else {
-                            Some(album_name)
-                        },
+                        album_name: resolved_album_name,
                         rules,
                     });
                 }


### PR DESCRIPTION
## Changes per bug
- **BUG-001 — Wrong startup view when background sync is disabled** ([src/main.rs](src/main.rs))
  - `setup_required` no longer keys off `background_sync_enabled`; it is now driven solely by a missing API key.
  - When background sync is disabled, the default window opens (Library when enabled) instead of forcing Settings.
- **BUG-002 — Cannot navigate directly between Album and Explore** ([src/library/mod.rs](src/library/mod.rs))
  - `sidebar_dispatch` now permits re-dispatching the current source when the content stack is on the Albums grid, since entering an album moves the stack without changing the source.
- **BUG-003 — Default folder name doesn't auto-link; manual link duplicates config** ([src/settings_window.rs](src/settings_window.rs))
  - When the user picks "default folder name", the local directory name is resolved and used to look up an existing `album_id`, so re-saving reuses the entry instead of creating a duplicate.
- **BUG-004 — Folder-linking UI shown on Explore/Album when entered from album view** ([src/library/mod.rs](src/library/mod.rs))
  - The album-link row (and its parent container) is hidden on entry to the Albums grid, gating the control by current view rather than prior state.
- **BUG-005 — Album view miscounts local assets** ([src/library/local_source.rs](src/library/local_source.rs))
  - `enumerate_blocking` deduplicates paths via `std::fs::canonicalize` so symlinked / aliased paths can't inflate the local count.

## Flatpak manifests
- Removed `--env=MESA_LOG_LEVEL=error` from [dev.nicx.mimick.yml](dev.nicx.mimick.yml) and [dev.nicx.mimick.local.yml](dev.nicx.mimick.local.yml). It only suppressed Mesa log noise — purely cosmetic and not warranted as a published env override.

## Test plan
- [x] Disable background sync, ensure Library is enabled, launch the app → opens Library, not Settings.
- [x] From an album detail, navigate Album → Explore and Explore → Album directly (no Photos detour).
- [x] Add a watch path with "default folder name", save, reopen settings → only one entry exists; remote name is persisted; default name shown in UI.
- [x] Enter an album, then click `Explore` / `Albums` → folder-linking control is not visible.
- [x] Album with 2 local assets (including symlink/duplicate path scenarios) reports local count = 2.
- [x] `flatpak run` still launches with no rendering regressions after dropping `MESA_LOG_LEVEL`.