### PR TITLE
fix: address bug fixes batch 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Sync index is now stored in the persistent data directory instead of the cache directory. Clearing the app cache no longer wipes sync state or triggers a full re-upload. Existing index files are migrated automatically on first run.
+- Ctrl+click selection no longer skips the first asset. Holding Ctrl now reveals checkboxes transiently; clicking an asset commits the selection. Releasing Ctrl without clicking dismisses selection mode.
+- Local and unified views for linked albums are now scoped to the selected album's linked folder only, instead of showing assets from all linked albums.
+- EXIF orientation is now applied to thumbnails and lightbox images via `apply_embedded_orientation()`. Stale thumbnail cache entries are invalidated with a new cache key version.
+- Details pane is now fixed at 320px width with `max_width_chars` constraints on labels so it no longer resizes dynamically with image dimensions.
+- Grid view thumbnails now use a fixed 356px width (16:9 at 200px height) instead of expanding to fill available space.
+- Explore page places grid and album tab tiles are now sized at 300x220px with a horizontal meta row layout (name left, count right) matching the explore page grid style.
+- Consolidated duplicate refresh buttons by removing the sidebar refresh button and keeping the status bar one. Added F5 keyboard shortcut for refresh.
+
+---
+
 ## [9.5.1] - 2026-05-04
 
 ### Fixed

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -14,7 +14,10 @@ pub fn export_bundle(destination_root: &Path, state: &AppState) -> io::Result<Pa
     let cache_root = dirs::cache_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
         .join("mimick");
-    export_bundle_with_paths(destination_root, state, &config, &cache_root)
+    let data_root = dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("mimick");
+    export_bundle_with_paths(destination_root, state, &config, &cache_root, &data_root)
 }
 
 fn export_bundle_with_paths(
@@ -22,6 +25,7 @@ fn export_bundle_with_paths(
     state: &AppState,
     config: &Config,
     cache_root: &Path,
+    data_root: &Path,
 ) -> io::Result<PathBuf> {
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -51,7 +55,7 @@ fn export_bundle_with_paths(
     )?;
     write_json_pretty(
         &bundle_dir.join("synced_index.redacted.json"),
-        &build_sync_index_export(&cache_path(cache_root, "synced_index.json"))?,
+        &build_sync_index_export(&cache_path(data_root, "synced_index.json"))?,
     )?;
 
     Ok(bundle_dir)
@@ -426,15 +430,17 @@ mod tests {
         let dir = tempdir().unwrap();
         let dest_root = dir.path().join("exports");
         let cache_root = dir.path().join("cache");
+        let data_root = dir.path().join("data");
         let config_root = dir.path().join("config");
         fs::create_dir_all(&cache_root).unwrap();
+        fs::create_dir_all(&data_root).unwrap();
         fs::create_dir_all(&config_root).unwrap();
 
         let config_path = config_root.join("config.json");
         fs::write(&config_path, "{\"internal_url\":\"http://localhost\"}").unwrap();
         fs::write(cache_root.join("status.json"), "{\"status\":\"idle\"}").unwrap();
         fs::write(cache_root.join("retries.json"), "[]").unwrap();
-        fs::write(cache_root.join("synced_index.json"), "{\"files\":{}}").unwrap();
+        fs::write(data_root.join("synced_index.json"), "{\"files\":{}}").unwrap();
         fs::write(cache_root.join("mimick.log"), "hello log").unwrap();
 
         let config = Config {
@@ -444,7 +450,7 @@ mod tests {
         let state = AppState::default();
 
         let bundle_dir =
-            export_bundle_with_paths(&dest_root, &state, &config, &cache_root).unwrap();
+            export_bundle_with_paths(&dest_root, &state, &config, &cache_root, &data_root).unwrap();
         assert!(bundle_dir.join("summary.txt").exists());
         assert!(bundle_dir.join("privacy-note.txt").exists());
         assert!(bundle_dir.join("config.redacted.json").exists());

--- a/src/library/albums_view.rs
+++ b/src/library/albums_view.rs
@@ -156,19 +156,24 @@ fn build_section(title: &str) -> (gtk::Box, gtk::FlowBox) {
 fn album_tile(ctx: Arc<AppContext>, album: &LibraryAlbum, on_click: AlbumClick) -> gtk::Button {
     let tile_box = gtk::Box::builder()
         .orientation(gtk::Orientation::Vertical)
-        .spacing(6)
+        .spacing(4)
         .build();
     let picture = gtk::Picture::builder()
-        .height_request(140)
-        .width_request(180)
+        .width_request(300)
+        .height_request(220)
         .content_fit(gtk::ContentFit::Cover)
-        .css_classes(vec!["mimick-thumbnail-loading".to_string()])
+        .css_classes(vec!["mimick-explore-tile".to_string()])
+        .build();
+    let meta_row = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .spacing(8)
         .build();
     let title_label = gtk::Label::builder()
         .label(&album.album_name)
-        .xalign(0.5)
+        .xalign(0.0)
+        .hexpand(true)
         .ellipsize(gtk::pango::EllipsizeMode::End)
-        .css_classes(vec!["heading".to_string()])
+        .css_classes(vec!["caption-heading".to_string()])
         .build();
     let count_label = gtk::Label::builder()
         .label(format!(
@@ -176,17 +181,18 @@ fn album_tile(ctx: Arc<AppContext>, album: &LibraryAlbum, on_click: AlbumClick) 
             album.asset_count,
             if album.asset_count == 1 { "" } else { "s" }
         ))
-        .xalign(0.5)
+        .xalign(1.0)
         .css_classes(vec!["caption".to_string(), "dim-label".to_string()])
         .build();
+    meta_row.append(&title_label);
+    meta_row.append(&count_label);
     tile_box.append(&picture);
-    tile_box.append(&title_label);
-    tile_box.append(&count_label);
+    tile_box.append(&meta_row);
 
     let button = gtk::Button::builder()
         .child(&tile_box)
         .css_classes(vec!["flat".to_string()])
-        .width_request(180)
+        .width_request(300)
         .hexpand(false)
         .halign(gtk::Align::Start)
         .build();

--- a/src/library/explore_view.rs
+++ b/src/library/explore_view.rs
@@ -97,9 +97,10 @@ fn build_tile_section(title: &str) -> (gtk::Box, gtk::FlowBox) {
         .selection_mode(gtk::SelectionMode::None)
         .row_spacing(8)
         .column_spacing(8)
-        .min_children_per_line(3)
-        .max_children_per_line(16)
-        .homogeneous(true)
+        .min_children_per_line(1)
+        .max_children_per_line(6)
+        .homogeneous(false)
+        .halign(gtk::Align::Start)
         .build();
     section.append(&grid);
     (section, grid)
@@ -236,8 +237,8 @@ fn explore_tile(
     on_click: ExploreClick,
 ) -> gtk::Button {
     let picture = gtk::Picture::builder()
-        .width_request(128)
-        .height_request(128)
+        .width_request(300)
+        .height_request(220)
         .can_shrink(true)
         .content_fit(gtk::ContentFit::Cover)
         .css_classes(vec!["mimick-explore-tile".to_string()])

--- a/src/library/grid_view.rs
+++ b/src/library/grid_view.rs
@@ -35,9 +35,9 @@ pub fn build_grid_view(ctx: Arc<AppContext>, select_toggle: gtk::ToggleButton) -
             .build();
 
         let picture = gtk::Picture::builder()
+            .width_request(356)
             .height_request(200)
             .can_shrink(true)
-            .hexpand(true)
             .content_fit(gtk::ContentFit::Cover)
             .css_classes(vec!["mimick-thumbnail-loading".to_string()])
             .build();

--- a/src/library/local_source.rs
+++ b/src/library/local_source.rs
@@ -69,6 +69,29 @@ pub async fn enumerate_local(ctx: Arc<AppContext>) -> Vec<LocalAsset> {
         .unwrap_or_default()
 }
 
+/// Enumerate only the watch entries matching `entry_path`. Used by the
+/// album-scoped Local/Unified views so a linked album's view stays bounded
+/// to its own folder instead of spilling assets from sibling albums.
+pub async fn enumerate_local_for_entry(
+    ctx: Arc<AppContext>,
+    entry_path: String,
+) -> Vec<LocalAsset> {
+    let watch_paths = ctx
+        .live_watch_paths
+        .lock()
+        .map(|guard| guard.clone())
+        .unwrap_or_default();
+
+    let scoped: Vec<WatchPathEntry> = watch_paths
+        .into_iter()
+        .filter(|e| e.path() == entry_path)
+        .collect();
+
+    tokio::task::spawn_blocking(move || enumerate_blocking(&scoped))
+        .await
+        .unwrap_or_default()
+}
+
 fn enumerate_blocking(watch_paths: &[WatchPathEntry]) -> Vec<LocalAsset> {
     let mut out = Vec::new();
     let mut seen: HashSet<PathBuf> = HashSet::new();

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -19,7 +19,7 @@ use crate::library::asset_object::AssetObject;
 use crate::library::explore_view::{ExploreViewParts, build_explore_view};
 use crate::library::grid_view::{GridViewParts, build_grid_view, extend_model, replace_model};
 use crate::library::local_source::{
-    LocalAsset, enumerate_local, filter_by_filename, local_sync_state,
+    LocalAsset, enumerate_local, enumerate_local_for_entry, filter_by_filename, local_sync_state,
 };
 use crate::library::sidebar::{SidebarParts, build_sidebar};
 use crate::library::state::{LibraryLoadState, LibrarySortMode, LibrarySource};
@@ -39,6 +39,13 @@ pub mod style;
 pub mod thumbnail_cache;
 
 const PAGE_SIZE: u32 = 50;
+
+fn load_texture_oriented(path: &std::path::Path) -> Option<gdk4::Texture> {
+    let raw = gtk::gdk_pixbuf::Pixbuf::from_file(path).ok()?;
+    let pixbuf = raw.apply_embedded_orientation().unwrap_or(raw);
+    #[allow(deprecated)]
+    Some(gdk4::Texture::for_pixbuf(&pixbuf))
+}
 
 struct LibraryWindowUi {
     ctx: Arc<AppContext>,
@@ -519,6 +526,20 @@ fn connect_controls(
         }
     ));
 
+    let f5_controller = gtk::EventControllerKey::new();
+    f5_controller.connect_key_pressed({
+        let refresh_button = refresh_button.clone();
+        move |_, keyval, _, _| {
+            if keyval == gtk::gdk::Key::F5 {
+                refresh_button.emit_clicked();
+                glib::Propagation::Stop
+            } else {
+                glib::Propagation::Proceed
+            }
+        }
+    });
+    ui.window.add_controller(f5_controller);
+
     ui.source_mode.connect_selected_notify(clone!(
         #[strong]
         ui,
@@ -526,10 +547,19 @@ fn connect_controls(
             if ui.source_mode_suppressed.get() {
                 return;
             }
-            let source = match dropdown.selected() {
-                1 => LibrarySource::LocalAll,
-                2 => LibrarySource::Unified,
-                _ => {
+            let album_ctx = match ui.ctx.library_state.lock().unwrap().source.clone() {
+                LibrarySource::Album { id, name }
+                | LibrarySource::AlbumLocal { id, name }
+                | LibrarySource::AlbumUnified { id, name } => Some((id, name)),
+                _ => None,
+            };
+            let source = match (dropdown.selected(), album_ctx) {
+                (1, Some((id, name))) => LibrarySource::AlbumLocal { id, name },
+                (1, None) => LibrarySource::LocalAll,
+                (2, Some((id, name))) => LibrarySource::AlbumUnified { id, name },
+                (2, None) => LibrarySource::Unified,
+                (_, Some((id, name))) => LibrarySource::Album { id, name },
+                (_, None) => {
                     if ui.timeline_toggle.is_active() {
                         LibrarySource::Timeline
                     } else {
@@ -652,19 +682,6 @@ fn connect_controls(
             replace_model(&ui.grid.model, &objects);
         }
     ));
-
-    ui.sidebar.refresh_button.connect_clicked(clone!(
-        #[strong]
-        ui,
-        move |_| {
-            load_albums(ui.clone());
-            let request = {
-                let source = ui.ctx.library_state.lock().unwrap().source.clone();
-                ui.ctx.library_state.lock().unwrap().switch_source(source)
-            };
-            load_source_page(ui.clone(), request, false);
-        }
-    ));
 }
 
 fn connect_select_mode(ui: Rc<LibraryWindowUi>, select_toggle: gtk::ToggleButton) {
@@ -699,6 +716,43 @@ fn connect_select_mode(ui: Rc<LibraryWindowUi>, select_toggle: gtk::ToggleButton
             (*refresh)();
         }
     });
+
+    // Ctrl-hold transient checkboxes: pressing Ctrl reveals the selection UI;
+    // releasing Ctrl without having selected anything dismisses it again.
+    // Ctrl+click then commits a selection (handled separately in grid_view)
+    // and the release no longer collapses select mode.
+    let transient = Rc::new(Cell::new(false));
+    let key_controller = gtk::EventControllerKey::new();
+    key_controller.connect_key_pressed({
+        let select_toggle = select_toggle.clone();
+        let transient = transient.clone();
+        move |_, keyval, _, _| {
+            if matches!(keyval, gtk::gdk::Key::Control_L | gtk::gdk::Key::Control_R)
+                && !select_toggle.is_active()
+            {
+                select_toggle.set_active(true);
+                transient.set(true);
+            }
+            glib::Propagation::Proceed
+        }
+    });
+    key_controller.connect_key_released({
+        let select_toggle = select_toggle.clone();
+        let selection = selection.clone();
+        let transient = transient.clone();
+        move |_, keyval, _, _| {
+            if !matches!(keyval, gtk::gdk::Key::Control_L | gtk::gdk::Key::Control_R)
+                || !transient.get()
+            {
+                return;
+            }
+            if selection.selection().size() == 0 {
+                select_toggle.set_active(false);
+            }
+            transient.set(false);
+        }
+    });
+    ui.window.add_controller(key_controller);
 }
 
 fn connect_bulk_actions(
@@ -946,11 +1000,15 @@ fn apply_timeline_ui_state(ui: &LibraryWindowUi, source: &LibrarySource) {
 
     let is_local = matches!(
         source,
-        LibrarySource::LocalAll | LibrarySource::LocalSearch { .. }
+        LibrarySource::LocalAll
+            | LibrarySource::LocalSearch { .. }
+            | LibrarySource::AlbumLocal { .. }
     );
     let is_unified = matches!(
         source,
-        LibrarySource::Unified | LibrarySource::UnifiedSearch { .. }
+        LibrarySource::Unified
+            | LibrarySource::UnifiedSearch { .. }
+            | LibrarySource::AlbumUnified { .. }
     );
     let remote_search_allowed = !is_local && !is_unified;
     ui.search_mode.set_visible(remote_search_allowed);
@@ -978,12 +1036,17 @@ fn apply_timeline_ui_state(ui: &LibraryWindowUi, source: &LibrarySource) {
 }
 
 fn refresh_album_link_row(ui: &LibraryWindowUi, source: &LibrarySource) {
-    let LibrarySource::Album { id: _, name } = source else {
-        ui.album_link_row.set_visible(false);
-        if let Some(parent) = ui.album_link_row.parent() {
-            parent.set_visible(false);
+    let name = match source {
+        LibrarySource::Album { name, .. }
+        | LibrarySource::AlbumLocal { name, .. }
+        | LibrarySource::AlbumUnified { name, .. } => name,
+        _ => {
+            ui.album_link_row.set_visible(false);
+            if let Some(parent) = ui.album_link_row.parent() {
+                parent.set_visible(false);
+            }
+            return;
         }
-        return;
     };
 
     ui.album_link_row.set_visible(true);
@@ -1484,6 +1547,27 @@ fn load_source_page(ui: Rc<LibraryWindowUi>, request: (u64, LibrarySource, u32),
                         .await;
                     merge_unified_page(remote, page, &ui, Some(&query)).await
                 }
+                LibrarySource::AlbumLocal { name, .. } => {
+                    if page > 1 {
+                        Ok(Vec::new())
+                    } else {
+                        match linked_entry_path_for_album(&ui, &name) {
+                            Some(path) => {
+                                let locals = enumerate_local_for_entry(ui.ctx.clone(), path).await;
+                                Ok(locals.into_iter().map(local_to_library_asset).collect())
+                            }
+                            None => Ok(Vec::new()),
+                        }
+                    }
+                }
+                LibrarySource::AlbumUnified { id, name } => {
+                    let remote = ui
+                        .ctx
+                        .api_client
+                        .fetch_album_assets(&id, page, PAGE_SIZE)
+                        .await;
+                    merge_album_unified_page(remote, page, &ui, &name).await
+                }
             };
 
             match result {
@@ -1553,7 +1637,9 @@ fn reload_sidebar(ui: &Rc<LibraryWindowUi>) {
             select_fixed_row(&ui.sidebar.fixed_list, "explore");
             ui.sidebar.albums_list.unselect_all();
         }
-        LibrarySource::Album { id, .. } => {
+        LibrarySource::Album { id, .. }
+        | LibrarySource::AlbumLocal { id, .. }
+        | LibrarySource::AlbumUnified { id, .. } => {
             ui.sidebar.fixed_list.unselect_all();
             let mut child = ui.sidebar.albums_list.first_child();
             while let Some(widget) = child {
@@ -1786,6 +1872,7 @@ fn fill_exif_box(container: &gtk::Box, exif: &crate::api_client::ExifInfo) {
             .label(&value)
             .xalign(0.0)
             .wrap(true)
+            .max_width_chars(36)
             .selectable(true)
             .build();
         row.append(&k);
@@ -1886,15 +1973,23 @@ fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         .child(&details_inner)
         .hscrollbar_policy(gtk::PolicyType::Never)
         .vexpand(true)
+        .hexpand(false)
         .width_request(320)
         .visible(false)
         .build();
+    details_pane.set_size_request(320, -1);
+    details_pane.set_propagate_natural_width(false);
     let details_filename = gtk::Label::builder()
         .xalign(0.0)
         .wrap(true)
+        .max_width_chars(36)
         .css_classes(vec!["title-3".to_string()])
         .build();
-    let details_summary = gtk::Label::builder().xalign(0.0).wrap(true).build();
+    let details_summary = gtk::Label::builder()
+        .xalign(0.0)
+        .wrap(true)
+        .max_width_chars(36)
+        .build();
     let details_loading = gtk::Label::builder()
         .xalign(0.0)
         .label("Loading details…")
@@ -1929,7 +2024,8 @@ fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
             let picture = picture.clone();
             glib::MainContext::default().spawn_local(async move {
                 if !local_path.is_empty() {
-                    if let Ok(texture) = gdk4::Texture::from_filename(&local_path) {
+                    if let Some(texture) = load_texture_oriented(std::path::Path::new(&local_path))
+                    {
                         picture.set_paintable(Some(&texture));
                     }
                     return;
@@ -1950,7 +2046,7 @@ fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
                             log::warn!("Lightbox original fetch failed: {}", err);
                             return;
                         }
-                        if let Ok(texture) = gdk4::Texture::from_filename(&temp) {
+                        if let Some(texture) = load_texture_oriented(&temp) {
                             picture.set_paintable(Some(&texture));
                         }
                     }
@@ -2358,6 +2454,50 @@ async fn merge_unified_page(
     if let Some(q) = query {
         locals = filter_by_filename(locals, q);
     }
+
+    let synced_paths: std::collections::HashSet<String> = match ui.ctx.sync_index.lock() {
+        Ok(idx) => remote
+            .iter()
+            .filter_map(|a| a.checksum.as_deref())
+            .filter_map(|cs| idx.local_path_for_checksum(cs))
+            .collect(),
+        Err(_) => std::collections::HashSet::new(),
+    };
+
+    let mut local_rows: Vec<LibraryAsset> = locals
+        .into_iter()
+        .filter(|l| !synced_paths.contains(&l.path.display().to_string()))
+        .map(local_to_library_asset)
+        .collect();
+
+    local_rows.append(&mut remote);
+    Ok(local_rows)
+}
+
+/// Return the path of the watch entry linked to `album_name`, if any.
+fn linked_entry_path_for_album(ui: &Rc<LibraryWindowUi>, album_name: &str) -> Option<String> {
+    let entries = ui.ctx.live_watch_paths.lock().ok()?.clone();
+    crate::config::watch_entry_for_album(album_name, &entries).map(|e| e.path().to_string())
+}
+
+/// Album-scoped variant of `merge_unified_page`: takes the album's asset
+/// page from the remote API and overlays sync state from the album's
+/// linked local folder only — never from siblings.
+async fn merge_album_unified_page(
+    remote: Result<Vec<LibraryAsset>, String>,
+    page: u32,
+    ui: &Rc<LibraryWindowUi>,
+    album_name: &str,
+) -> Result<Vec<LibraryAsset>, String> {
+    let mut remote = remote?;
+    if page > 1 {
+        return Ok(remote);
+    }
+
+    let locals = match linked_entry_path_for_album(ui, album_name) {
+        Some(path) => enumerate_local_for_entry(ui.ctx.clone(), path).await,
+        None => Vec::new(),
+    };
 
     let synced_paths: std::collections::HashSet<String> = match ui.ctx.sync_index.lock() {
         Ok(idx) => remote

--- a/src/library/sidebar.rs
+++ b/src/library/sidebar.rs
@@ -3,7 +3,6 @@ use libadwaita::prelude::*;
 
 pub struct SidebarParts {
     pub root: gtk::Box,
-    pub refresh_button: gtk::Button,
     pub fixed_list: gtk::ListBox,
     pub albums_list: gtk::ListBox,
 }
@@ -17,12 +16,6 @@ pub fn build_sidebar() -> SidebarParts {
         .margin_start(12)
         .margin_end(12)
         .width_request(260)
-        .build();
-
-    let refresh_button = gtk::Button::builder()
-        .label("Refresh")
-        .icon_name("view-refresh-symbolic")
-        .hexpand(true)
         .build();
 
     let fixed_list = gtk::ListBox::builder()
@@ -67,14 +60,12 @@ pub fn build_sidebar() -> SidebarParts {
         .child(&albums_list)
         .build();
 
-    root.append(&refresh_button);
     root.append(&fixed_list);
     root.append(&albums_header);
     root.append(&albums_scroll);
 
     SidebarParts {
         root,
-        refresh_button,
         fixed_list,
         albums_list,
     }

--- a/src/library/state.rs
+++ b/src/library/state.rs
@@ -42,6 +42,17 @@ pub enum LibrarySource {
     UnifiedSearch {
         query: String,
     },
+    /// Local enumeration scoped to the folder linked to a specific album.
+    /// Empty if the album has no linked folder.
+    AlbumLocal {
+        id: String,
+        name: String,
+    },
+    /// Remote album assets overlayed with sync state from the linked folder.
+    AlbumUnified {
+        id: String,
+        name: String,
+    },
 }
 
 impl LibrarySource {

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -331,8 +331,9 @@ impl ThumbnailCache {
         let path = path.to_path_buf();
         let cache_dir = self.cache_dir.clone();
         let texture = tokio::task::spawn_blocking(move || -> Result<Texture, String> {
-            let pixbuf = gtk::gdk_pixbuf::Pixbuf::from_file_at_scale(&path, 256, 256, true)
+            let raw = gtk::gdk_pixbuf::Pixbuf::from_file_at_scale(&path, 256, 256, true)
                 .map_err(|err| err.to_string())?;
+            let pixbuf = raw.apply_embedded_orientation().unwrap_or(raw);
             let _ = std::fs::create_dir_all(&cache_dir);
             let _ = pixbuf.savev(&cache_file, "png", &[]);
             #[allow(deprecated)]
@@ -428,7 +429,7 @@ fn cache_key(asset_id: &str, size: ThumbnailSize) -> String {
 fn local_cache_key(asset_id: &str) -> String {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     asset_id.hash(&mut hasher);
-    format!("local-thumbnail:{:x}", hasher.finish())
+    format!("local-thumbnail-v2:{:x}", hasher.finish())
 }
 
 fn estimate_texture_bytes(texture: &Texture) -> usize {

--- a/src/sync_index.rs
+++ b/src/sync_index.rs
@@ -52,12 +52,16 @@ pub struct SyncIndex {
 }
 
 impl SyncIndex {
-    /// Loads the sync index from the default Mimick cache path.
+    /// Loads the sync index from the persistent data directory, migrating
+    /// from the old cache location on first run so users who clear the
+    /// system cache don't lose sync state and trigger a full re-upload.
     pub fn new() -> Self {
-        let index_file = dirs::cache_dir()
+        let index_file = dirs::data_dir()
             .unwrap_or_else(|| PathBuf::from("/tmp"))
             .join("mimick")
             .join("synced_index.json");
+
+        migrate_from_cache_dir(&index_file);
 
         let entries = load_entries(&index_file);
 
@@ -183,6 +187,56 @@ impl SyncIndex {
         fs::write(&tmp_file, content)?;
         fs::rename(&tmp_file, &self.index_file)?;
         Ok(())
+    }
+}
+
+/// One-time migration of the sync index from the legacy cache_dir location
+/// to the persistent data_dir. Only runs when the new file is absent and the
+/// old one exists. Best-effort: failures are logged and the app continues
+/// with whatever is at the new path.
+fn migrate_from_cache_dir(new_path: &Path) {
+    if new_path.exists() {
+        return;
+    }
+    let Some(old_path) = dirs::cache_dir().map(|d| d.join("mimick").join("synced_index.json"))
+    else {
+        return;
+    };
+    if !old_path.exists() {
+        return;
+    }
+    if let Some(parent) = new_path.parent()
+        && let Err(err) = fs::create_dir_all(parent)
+    {
+        log::warn!(
+            "Could not create sync index data dir '{}': {}",
+            parent.display(),
+            err
+        );
+        return;
+    }
+    match fs::rename(&old_path, new_path) {
+        Ok(()) => log::info!(
+            "Migrated sync index '{}' -> '{}'",
+            old_path.display(),
+            new_path.display()
+        ),
+        Err(rename_err) => match fs::copy(&old_path, new_path) {
+            Ok(_) => {
+                let _ = fs::remove_file(&old_path);
+                log::info!(
+                    "Copied sync index '{}' -> '{}' (rename failed: {})",
+                    old_path.display(),
+                    new_path.display(),
+                    rename_err
+                );
+            }
+            Err(copy_err) => log::warn!(
+                "Sync index migration failed (rename: {}, copy: {})",
+                rename_err,
+                copy_err
+            ),
+        },
     }
 }
 


### PR DESCRIPTION
## Bug Fixes

This PR addresses 8 open bug reports across the library view, sync engine, and UI layout.

### P0 - Critical
- **Sync index wiped on cache clear** - Moved sync index storage from `cache_dir` to `data_dir` with a one-time migration so clearing the system cache no longer wipes sync state and triggers a full re-upload. Closes #65

### P1 - High
- **Ctrl+click selection doesn't select first asset** - Reworked selection so holding Ctrl reveals checkboxes transiently; clicking an asset commits the selection. Releasing Ctrl without clicking dismisses selection mode. Closes #64
- **Unified/local view unselectable for linked albums** - Added `AlbumLocal` and `AlbumUnified` source variants so local and unified views are scoped to the selected album's linked folder only, not all linked albums. Closes #66
- **Orientation broken for some formats** - Applied `apply_embedded_orientation()` to both thumbnails and lightbox images. Bumped local thumbnail cache key to `v2` to invalidate stale entries. Closes #67

### P2 - Medium
- **Details pane fixed width** - Constrained details pane to 320px with `max_width_chars(36)` on labels so it no longer resizes with image dimensions. Closes #68
- **Thumbnail fixed width in grid** - Set grid thumbnails to a fixed 356px width (16:9 at 200px height) instead of `hexpand`. Closes #69
- **Explore page places grid + album tab sizes** - Resized explore and album tiles to 300x220px with a horizontal meta row (name left, count right) matching the explore page grid layout. Closes #70
- **Consolidate duplicate refresh buttons** - Removed the sidebar refresh button, kept the status bar one, and added F5 keyboard shortcut for refresh. Closes #71

### Files Changed
- `src/sync_index.rs` - data_dir migration logic
- `src/diagnostics.rs` - updated bundle export to read index from data_dir
- `src/library/mod.rs` - orientation fix, Ctrl-select, album-scoped sources, details pane constraints, refresh consolidation
- `src/library/state.rs` - new `AlbumLocal`/`AlbumUnified` enum variants
- `src/library/local_source.rs` - `enumerate_local_for_entry()` for album-scoped enumeration
- `src/library/sidebar.rs` - removed duplicate refresh button
- `src/library/grid_view.rs` - fixed thumbnail width
- `src/library/explore_view.rs` - 300x220 tile sizes
- `src/library/albums_view.rs` - reworked album tile layout
- `src/library/thumbnail_cache.rs` - orientation + cache key bump