### PR TITLE
fix: sync status accuracy, remove SyncState sort, bundle icons via GResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Relocated the server connection status indicator from the sidebar top to the bottom for better visibility and layout balance.
 - Removed the redundant checkbox toggle icon from the library header bar; selection mode is now managed via Ctrl-hold or keyboard interaction.
 - Removed support for `.xmp` files from the media scanning and MIME detection logic as they are not utilized by the application.
+- Removed the "Sync State" option from the library sort dropdown; it was only meaningful in unified/local views and produced no useful ordering in the standard photos view.
+- Transfer direction in the progress bar is now shown as an icon (`mimick-upload-symbolic` / `mimick-download-symbolic`) rather than the text prefix "Uploading" / "Downloading", keeping the label focused on the active filename and speed.
 
 ### Fixed
 
 - Escape key and Clear button now properly exit selection mode entirely instead of just clearing selected items.
+- Asset sync status in the lightbox details pane and thumbnail hover now reflects the asset's true state (local only, remote only, or both) instead of being implied by the active view. Root cause: Immich returns SHA-1 checksums as base64 in API responses while the sync index stores them as lowercase hex; the representations are now normalised on read so checksum-to-path reverse lookups resolve correctly across all views including unified and album-unified.
+- In-app symbolic icons (`mimick-upload-symbolic`, `mimick-download-symbolic`) are now compiled into the binary via `glib-build-tools::compile_resources` and registered at startup with `gtk::IconTheme::add_resource_path("/dev/nicx/mimick/icons")`, replacing a `theme.add_search_path(env!("CARGO_MANIFEST_DIR"))` call that resolved to a nonexistent path in all non-`cargo run` environments.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -818,6 +818,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "glib-build-tools"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf3abfd1e60b194dded50f802277c68a59121a5a221701102f02db223cdda27"
+dependencies = [
+ "gio",
+]
+
+[[package]]
 name = "glib-macros"
 version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1288,7 +1297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1462,7 +1471,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1518,6 +1527,7 @@ dependencies = [
  "futures-util",
  "gdk4",
  "glib",
+ "glib-build-tools",
  "gtk4",
  "ksni",
  "libadwaita",
@@ -2397,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ base64 = "0.22"
 [dev-dependencies]
 tempfile = "3.27.0"
 
+[build-dependencies]
+glib-build-tools = "0.22"
+
 [profile.release]
 opt-level = "z"        # Optimise for binary size (less code = less mapped pages)
 codegen-units = 1      # Full whole-program optimisation

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    glib_build_tools::compile_resources(
+        &["src/assets"],
+        "src/assets/mimick.gresource.xml",
+        "mimick.gresource",
+    );
+}

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -275,14 +275,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cc/cc-1.2.61.crate",
-        "sha256": "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d",
-        "dest": "cargo/vendor/cc-1.2.61"
+        "url": "https://static.crates.io/crates/cc/cc-1.2.62.crate",
+        "sha256": "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98",
+        "dest": "cargo/vendor/cc-1.2.62"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d\", \"files\": {}}",
-        "dest": "cargo/vendor/cc-1.2.61",
+        "contents": "{\"package\": \"a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.2.62",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1081,6 +1081,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glib-build-tools/glib-build-tools-0.22.0.crate",
+        "sha256": "4bf3abfd1e60b194dded50f802277c68a59121a5a221701102f02db223cdda27",
+        "dest": "cargo/vendor/glib-build-tools-0.22.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4bf3abfd1e60b194dded50f802277c68a59121a5a221701102f02db223cdda27\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-build-tools-0.22.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.22.6.crate",
         "sha256": "506d23499707c7142898429757e8d9a3871d965239a2cb66dfa05052be6d6f19",
         "dest": "cargo/vendor/glib-macros-0.22.6"
@@ -1237,14 +1250,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.17.0.crate",
-        "sha256": "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51",
-        "dest": "cargo/vendor/hashbrown-0.17.0"
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.17.1.crate",
+        "sha256": "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a",
+        "dest": "cargo/vendor/hashbrown-0.17.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51\", \"files\": {}}",
-        "dest": "cargo/vendor/hashbrown-0.17.0",
+        "contents": "{\"package\": \"ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.17.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2979,14 +2992,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tokio/tokio-1.52.2.crate",
-        "sha256": "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386",
-        "dest": "cargo/vendor/tokio-1.52.2"
+        "url": "https://static.crates.io/crates/tokio/tokio-1.52.3.crate",
+        "sha256": "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe",
+        "dest": "cargo/vendor/tokio-1.52.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386\", \"files\": {}}",
-        "dest": "cargo/vendor/tokio-1.52.2",
+        "contents": "{\"package\": \"8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-1.52.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/assets/mimick.gresource.xml
+++ b/src/assets/mimick.gresource.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/dev/nicx/mimick/icons">
+    <file alias="scalable/actions/mimick-upload-symbolic.svg"
+          compressed="true"
+          preprocess="xml-stripblanks">scalable/actions/mimick-upload-symbolic.svg</file>
+    <file alias="scalable/actions/mimick-download-symbolic.svg"
+          compressed="true"
+          preprocess="xml-stripblanks">scalable/actions/mimick-download-symbolic.svg</file>
+  </gresource>
+</gresources>

--- a/src/assets/scalable/actions/mimick-download-symbolic.svg
+++ b/src/assets/scalable/actions/mimick-download-symbolic.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M8 14 L3 8 H6 V3 H10 V8 H13 Z"/>
+  <rect fill="currentColor" x="3" y="14" width="10" height="1.5" rx="0.75"/>
+</svg>

--- a/src/assets/scalable/actions/mimick-upload-symbolic.svg
+++ b/src/assets/scalable/actions/mimick-upload-symbolic.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M8 2 L13 8 H10 V13 H6 V8 H3 Z"/>
+  <rect fill="currentColor" x="3" y="14" width="10" height="1.5" rx="0.75"/>
+</svg>

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -98,6 +98,13 @@ fn finish_download_item(ctx: &Arc<AppContext>, item_id: &str) {
         .finish_item(TransferDirection::Download, item_id, route);
 }
 
+fn register_app_icons() {
+    if let Some(display) = gtk::gdk::Display::default() {
+        let theme = gtk::IconTheme::for_display(&display);
+        theme.add_resource_path("/dev/nicx/mimick/icons");
+    }
+}
+
 fn load_texture_oriented(path: &std::path::Path) -> Option<gdk4::Texture> {
     let raw = gtk::gdk_pixbuf::Pixbuf::from_file(path).ok()?;
     let pixbuf = raw.apply_embedded_orientation().unwrap_or(raw);
@@ -118,6 +125,7 @@ struct LibraryWindowUi {
     error_label: gtk::Label,
     transfer_bar: gtk::Box,
     transfer_progress: gtk::ProgressBar,
+    transfer_icon: gtk::Image,
     transfer_label: gtk::Label,
     search_entry: gtk::SearchEntry,
     search_mode: gtk::DropDown,
@@ -139,6 +147,7 @@ struct LibraryWindowUi {
 
 pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>) {
     style::ensure_registered();
+    register_app_icons();
 
     let window = libadwaita::ApplicationWindow::builder()
         .application(app)
@@ -221,7 +230,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .icon_name("view-more-symbolic")
         .tooltip_text("Advanced filters (date, location, camera, EXIF)")
         .build();
-    let sort_model = gtk::StringList::new(&["Newest", "Filename", "File Type", "Sync State"]);
+    let sort_model = gtk::StringList::new(&["Newest", "Filename", "File Type"]);
     let sort_mode = gtk::DropDown::builder()
         .model(&sort_model)
         .selected(0)
@@ -283,6 +292,11 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .valign(gtk::Align::Center)
         .css_classes(vec!["mimick-transfer-progress".to_string()])
         .build();
+    let transfer_icon = gtk::Image::builder()
+        .icon_size(gtk::IconSize::Normal)
+        .css_classes(vec!["dim-label".to_string()])
+        .visible(false)
+        .build();
     let transfer_label = gtk::Label::builder()
         .xalign(0.0)
         .hexpand(true)
@@ -300,6 +314,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .css_classes(vec!["mimick-transfer-shell".to_string()])
         .build();
     transfer_bar.append(&transfer_progress);
+    transfer_bar.append(&transfer_icon);
     transfer_bar.append(&transfer_label);
 
     let album_link_row = libadwaita::ActionRow::builder()
@@ -418,6 +433,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         error_label,
         transfer_bar,
         transfer_progress,
+        transfer_icon,
         transfer_label,
         search_entry,
         search_mode,
@@ -758,7 +774,6 @@ fn connect_controls(
             let sort_mode = match dropdown.selected() {
                 1 => LibrarySortMode::Filename,
                 2 => LibrarySortMode::FileType,
-                3 => LibrarySortMode::SyncState,
                 _ => LibrarySortMode::NewestFirst,
             };
 
@@ -2091,6 +2106,7 @@ fn update_transfer_ui(ui: &LibraryWindowUi) {
     if !transfer.active {
         ui.transfer_bar.remove_css_class("active");
         ui.transfer_progress.set_fraction(0.0);
+        ui.transfer_icon.set_visible(false);
         let idle_summary =
             if transfer.last_upload_avg_bps > 0.0 || transfer.last_download_avg_bps > 0.0 {
                 format!(
@@ -2106,10 +2122,13 @@ fn update_transfer_ui(ui: &LibraryWindowUi) {
     }
     ui.transfer_bar.add_css_class("active");
 
-    let direction = match transfer.direction {
-        TransferDirection::Upload => "Uploading",
-        TransferDirection::Download => "Downloading",
+    let icon_name = match transfer.direction {
+        TransferDirection::Upload => "mimick-upload-symbolic",
+        TransferDirection::Download => "mimick-download-symbolic",
     };
+    ui.transfer_icon.set_icon_name(Some(icon_name));
+    ui.transfer_icon.set_visible(true);
+
     let detail = transfer
         .active_item_label
         .as_deref()
@@ -2119,9 +2138,8 @@ fn update_transfer_ui(ui: &LibraryWindowUi) {
         });
     let live_speed = format_rate(transfer.instant_bps);
     let avg_speed = format_rate(transfer.session_avg_bps);
-    ui.transfer_label.set_label(&format!(
-        "{direction} {detail}  {live_speed}  avg {avg_speed}"
-    ));
+    ui.transfer_label
+        .set_label(&format!("{detail}  {live_speed}  avg {avg_speed}"));
 
     match transfer.total_bytes {
         Some(total) if total > 0 => {
@@ -2176,6 +2194,12 @@ fn build_status_view(icon_name: &str, title: &str, subtitle: &str) -> gtk::Box {
     container
 }
 
+fn immich_checksum_to_hex(b64: &str) -> Option<String> {
+    use base64::Engine as _;
+    let bytes = base64::engine::general_purpose::STANDARD.decode(b64).ok()?;
+    Some(bytes.iter().map(|b| format!("{:02x}", b)).collect())
+}
+
 fn asset_objects_from_state(assets: &[LibraryAsset], ctx: &AppContext) -> Vec<AssetObject> {
     let sync_index = ctx.sync_index.lock().unwrap();
     assets
@@ -2197,10 +2221,13 @@ fn asset_objects_from_state(assets: &[LibraryAsset], ctx: &AppContext) -> Vec<As
                 return object;
             }
             // Remote rows: 2 = "both" when a sibling local copy exists, else 0 (remote-only).
+            // Immich returns checksum as base64 SHA-1; SyncIndex stores hex SHA-1.
             let local_match = asset
                 .checksum
                 .as_deref()
-                .and_then(|checksum| sync_index.local_path_for_checksum(checksum));
+                .and_then(immich_checksum_to_hex)
+                .as_deref()
+                .and_then(|hex| sync_index.local_path_for_checksum(hex));
             let sync_state = if local_match.is_some() { 2 } else { 0 };
             let object = AssetObject::new(
                 &asset.id,
@@ -2398,11 +2425,10 @@ fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         .hscrollbar_policy(gtk::PolicyType::Never)
         .vexpand(true)
         .hexpand(false)
-        .width_request(320)
+        .min_content_width(320)
+        .max_content_width(320)
         .visible(false)
         .build();
-    details_pane.set_size_request(320, -1);
-    details_pane.set_propagate_natural_width(false);
     let details_filename = gtk::Label::builder()
         .xalign(0.0)
         .wrap(true)
@@ -2944,7 +2970,8 @@ async fn merge_unified_page(
         Ok(idx) => remote
             .iter()
             .filter_map(|a| a.checksum.as_deref())
-            .filter_map(|cs| idx.local_path_for_checksum(cs))
+            .filter_map(immich_checksum_to_hex)
+            .filter_map(|hex| idx.local_path_for_checksum(&hex))
             .collect(),
         Err(_) => std::collections::HashSet::new(),
     };
@@ -2988,7 +3015,8 @@ async fn merge_album_unified_page(
         Ok(idx) => remote
             .iter()
             .filter_map(|a| a.checksum.as_deref())
-            .filter_map(|cs| idx.local_path_for_checksum(cs))
+            .filter_map(immich_checksum_to_hex)
+            .filter_map(|hex| idx.local_path_for_checksum(&hex))
             .collect(),
         Err(_) => std::collections::HashSet::new(),
     };

--- a/src/library/state.rs
+++ b/src/library/state.rs
@@ -74,7 +74,6 @@ pub enum LibrarySortMode {
     NewestFirst,
     Filename,
     FileType,
-    SyncState,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -224,7 +223,6 @@ impl LibraryState {
                     .then_with(|| a.filename.cmp(&b.filename))
                     .then_with(|| a.id.cmp(&b.id))
             }),
-            LibrarySortMode::SyncState => self.assets.sort_by(|a, b| a.id.cmp(&b.id)),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,9 @@ async fn main() {
         .start()
         .expect("Failed to initialize logger");
 
+    gtk::gio::resources_register_include!("mimick.gresource")
+        .expect("Failed to register bundled GResource");
+
     let app = adw::Application::builder()
         .application_id("dev.nicx.mimick")
         .flags(gtk::gio::ApplicationFlags::HANDLES_COMMAND_LINE)

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -1891,14 +1891,6 @@ pub fn show_queue_inspector(
 }
 
 fn show_about_dialog(parent: &impl gtk::prelude::IsA<gtk::Widget>) {
-    // Register asset search path so the "icon" name resolves
-    let display = gtk::gdk::Display::default();
-    if let Some(display) = display {
-        let theme = gtk::IconTheme::for_display(&display);
-        let assets_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/assets");
-        theme.add_search_path(&assets_dir);
-    }
-
     let about = adw::AboutDialog::builder()
         .application_name("Mimick")
         .application_icon("dev.nicx.mimick")


### PR DESCRIPTION
## Summary

-  Asset sync status in the lightbox details pane and thumbnail hover now reflects the asset's true state. Root cause: Immich returns SHA-1 checksums as base64 in API responses while `SyncIndex` stores them as lowercase hex. `immich_checksum_to_hex` now normalises before every `local_path_for_checksum` call, fixing lookups in `asset_objects_from_state`, `merge_unified_page`, and `merge_album_unified_page`.
-  Upload/download symbolic icons are now compiled into the binary via `glib-build-tools::compile_resources` and registered with `gtk::IconTheme::add_resource_path("/dev/nicx/mimick/icons")`. Replaces the previous `add_search_path(env!("CARGO_MANIFEST_DIR"))` which resolved to a nonexistent path in all non-`cargo run` environments. Redundant flatpak yml install lines for action icons removed.
- `SyncState` variant removed from `LibrarySortMode` and its dropdown entry removed from the library header. The option produced no meaningful ordering in the standard remote photos view.

## Test plan
- [x] Trigger an upload or download → transfer bar shows upload/download icon instead of text prefix
- [x] Open library sort dropdown → "Sync State" no longer appears; existing selection falls back to "Newest"
- [x] Build as Flatpak → icons render (no GResource registration needed at runtime; binary carries them)