### PR TITLE
Harden security sanitization and centralize config access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "ashpd"
 version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +132,20 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -256,6 +282,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
@@ -1460,6 +1492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1562,7 @@ version = "9.5.2"
 dependencies = [
  "ashpd",
  "base64",
+ "blake3",
  "chrono",
  "dirs",
  "flexi_logger",
@@ -1535,6 +1577,7 @@ dependencies = [
  "lru",
  "notify",
  "oo7",
+ "parking_lot",
  "reqwest",
  "serde",
  "serde_json",
@@ -1543,6 +1586,7 @@ dependencies = [
  "thumbhash",
  "tokio",
  "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -1827,6 +1871,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,6 +2021,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2131,6 +2207,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ ksni = "0.3.4"
 libadwaita = { version = "0.9.1", features = ["v1_6"] }
 log = "0.4.29"
 lru = "0.18.0"
+parking_lot = "0.12.5"
+blake3 = "1.8.5"
+url = "2.5.8"
 notify = "8.2.0"
 oo7 = { version = "0.6.0", default-features = false, features = ["tokio", "native_crypto"] }
 reqwest = { version = "0.13.2", default-features = false, features = ["native-tls", "charset", "http2", "json", "multipart", "stream"] }

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -67,6 +67,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arrayref/arrayref-0.3.9.crate",
+        "sha256": "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb",
+        "dest": "cargo/vendor/arrayref-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb\", \"files\": {}}",
+        "dest": "cargo/vendor/arrayref-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.6.crate",
+        "sha256": "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50",
+        "dest": "cargo/vendor/arrayvec-0.7.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50\", \"files\": {}}",
+        "dest": "cargo/vendor/arrayvec-0.7.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ashpd/ashpd-0.13.10.crate",
         "sha256": "3118453e020b8e3e0da25ef9a1d0d51d668874358af11aded9d91a8b9c25f323",
         "dest": "cargo/vendor/ashpd-0.13.10"
@@ -166,6 +192,19 @@
         "type": "inline",
         "contents": "{\"package\": \"c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3\", \"files\": {}}",
         "dest": "cargo/vendor/bitflags-2.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/blake3/blake3-1.8.5.crate",
+        "sha256": "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce",
+        "dest": "cargo/vendor/blake3-1.8.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce\", \"files\": {}}",
+        "dest": "cargo/vendor/blake3-1.8.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -361,6 +400,19 @@
         "type": "inline",
         "contents": "{\"package\": \"a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c\", \"files\": {}}",
         "dest": "cargo/vendor/const-oid-0.10.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/constant_time_eq/constant_time_eq-0.4.2.crate",
+        "sha256": "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b",
+        "dest": "cargo/vendor/constant_time_eq-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b\", \"files\": {}}",
+        "dest": "cargo/vendor/constant_time_eq-0.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1822,6 +1874,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.14.crate",
+        "sha256": "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965",
+        "dest": "cargo/vendor/lock_api-0.4.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965\", \"files\": {}}",
+        "dest": "cargo/vendor/lock_api-0.4.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/log/log-0.4.29.crate",
         "sha256": "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897",
         "dest": "cargo/vendor/log-0.4.29"
@@ -2225,6 +2290,32 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking_lot/parking_lot-0.12.5.crate",
+        "sha256": "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a",
+        "dest": "cargo/vendor/parking_lot-0.12.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot-0.12.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.12.crate",
+        "sha256": "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1",
+        "dest": "cargo/vendor/parking_lot_core-0.9.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot_core-0.9.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pastey/pastey-0.2.2.crate",
         "sha256": "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a",
         "dest": "cargo/vendor/pastey-0.2.2"
@@ -2433,6 +2524,19 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.5.18.crate",
+        "sha256": "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d",
+        "dest": "cargo/vendor/redox_syscall-0.5.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_syscall-0.5.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/redox_users/redox_users-0.5.2.crate",
         "sha256": "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac",
         "dest": "cargo/vendor/redox_users-0.5.2"
@@ -2610,6 +2714,19 @@
         "type": "inline",
         "contents": "{\"package\": \"91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939\", \"files\": {}}",
         "dest": "cargo/vendor/schannel-0.1.29",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/scopeguard/scopeguard-1.2.0.crate",
+        "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
+        "dest": "cargo/vendor/scopeguard-1.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49\", \"files\": {}}",
+        "dest": "cargo/vendor/scopeguard-1.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -2,10 +2,11 @@
 
 use chrono::{SecondsFormat, TimeZone, Utc};
 use futures_util::TryStreamExt;
+use parking_lot::RwLock;
 use reqwest::Client;
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, Semaphore};
 
@@ -161,7 +162,6 @@ pub struct ExploreSection {
 
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 pub struct ExifInfo {
     #[serde(default)]
     pub make: Option<String>,
@@ -197,24 +197,13 @@ pub struct ExifInfo {
     pub exif_image_width: Option<u32>,
     #[serde(default)]
     pub exif_image_height: Option<u32>,
-    #[serde(default)]
-    pub orientation: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 pub struct AssetDetails {
-    pub id: String,
-    pub original_file_name: String,
-    #[serde(rename = "type")]
-    pub asset_type: String,
     #[serde(default)]
     pub exif_info: Option<ExifInfo>,
-    #[serde(default)]
-    pub duration: Option<String>,
-    #[serde(default)]
-    pub file_created_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -304,7 +293,7 @@ impl ImmichApiClient {
         api_key: String,
     ) {
         {
-            let mut settings = self.settings.write().unwrap();
+            let mut settings = self.settings.write();
             settings.internal_url = internal_url.trim_end_matches('/').to_string();
             settings.external_url = external_url.trim_end_matches('/').to_string();
             settings.api_key = api_key;
@@ -324,11 +313,11 @@ impl ImmichApiClient {
     }
 
     fn settings_snapshot(&self) -> ApiClientSettings {
-        self.settings.read().unwrap().clone()
+        self.settings.read().clone()
     }
 
     fn route_label_for_url(&self, url: &str) -> String {
-        let settings = self.settings.read().unwrap().clone();
+        let settings = self.settings.read().clone();
         let trimmed = url.trim_end_matches('/');
         if !settings.internal_url.is_empty() && trimmed == settings.internal_url {
             "LAN".to_string()
@@ -342,7 +331,7 @@ impl ImmichApiClient {
     /// Determine which base URL to use, preferring the internal address when reachable.
     pub async fn check_connection(&self) -> bool {
         log::debug!("Checking connectivity...");
-        let settings = self.settings.read().unwrap().clone();
+        let settings = self.settings.read().clone();
         let was_active = self.active_url.lock().await.clone();
 
         if self.ping_url(&settings.internal_url).await {
@@ -554,7 +543,7 @@ impl ImmichApiClient {
             .text("isFavorite", "false");
 
         let url = format!("{}/api/assets", base_url);
-        let api_key = self.settings.read().unwrap().api_key.clone();
+        let api_key = self.settings.read().api_key.clone();
 
         match self
             .client
@@ -672,7 +661,7 @@ impl ImmichApiClient {
         time_zone: Option<String>,
     ) {
         let client = self.client.clone();
-        let api_key = self.settings.read().unwrap().api_key.clone();
+        let api_key = self.settings.read().api_key.clone();
 
         tokio::spawn(async move {
             let Some(time_zone) = time_zone else {
@@ -711,7 +700,7 @@ impl ImmichApiClient {
         };
 
         let url = format!("{}/api/albums", base_url);
-        let api_key = self.settings.read().unwrap().api_key.clone();
+        let api_key = self.settings.read().api_key.clone();
         log::info!("Fetching album list...");
 
         match self
@@ -784,7 +773,7 @@ impl ImmichApiClient {
             .await
             .ok_or_else(|| "No active connection".to_string())?;
         let url = format!("{}/api/albums", base_url);
-        let api_key = self.settings.read().unwrap().api_key.clone();
+        let api_key = self.settings.read().api_key.clone();
 
         log::info!("Creating album: '{}'", album_name);
 
@@ -885,7 +874,7 @@ impl ImmichApiClient {
     pub async fn find_existing_asset_id(&self, checksum: &str) -> Option<String> {
         let base_url = self.get_active_url().await?;
         let url = format!("{}/api/assets/bulk-upload-check", base_url);
-        let api_key = self.settings.read().unwrap().api_key.clone();
+        let api_key = self.settings.read().api_key.clone();
         let body = serde_json::json!({
             "assets": [
                 {
@@ -946,7 +935,7 @@ impl ImmichApiClient {
         };
 
         let url = format!("{}/api/albums/{}/assets", base_url, album_id);
-        let api_key = self.settings.read().unwrap().api_key.clone();
+        let api_key = self.settings.read().api_key.clone();
         let body = serde_json::json!({ "ids": asset_ids });
 
         log::info!(
@@ -1249,46 +1238,6 @@ impl ImmichApiClient {
             }
             Ok(resp) => Err(format!("HTTP {}", resp.status())),
             Err(err) => Err(err.to_string()),
-        }
-    }
-
-    #[allow(dead_code)]
-    pub async fn delete_album(&self, album_id: &str) -> Result<(), String> {
-        let base_url = self
-            .get_active_url()
-            .await
-            .ok_or_else(|| "No active connection".to_string())?;
-        let settings = self.settings_snapshot();
-        let url = format!("{}/api/albums/{}", base_url, album_id);
-
-        match self
-            .client
-            .delete(&url)
-            .header("x-api-key", &settings.api_key)
-            .header("Accept", "application/json")
-            .timeout(Duration::from_secs(10))
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() => {
-                self.clear_issue().await;
-                Ok(())
-            }
-            Ok(resp) => {
-                self.set_issue(classify_http_issue(
-                    RequestContext::AlbumDelete,
-                    resp.status().as_u16(),
-                    Some(album_id),
-                ))
-                .await;
-                Err(format!("HTTP {}", resp.status()))
-            }
-            Err(err) => {
-                *self.active_url.lock().await = None;
-                self.set_issue(classify_network_issue(RequestContext::AlbumDelete, &err))
-                    .await;
-                Err(err.to_string())
-            }
         }
     }
 
@@ -1597,7 +1546,6 @@ impl ImmichApiClient {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[allow(dead_code)]
 enum RequestContext {
     Upload,
     Albums,
@@ -1608,7 +1556,6 @@ enum RequestContext {
     SmartSearch,
     MetadataSearch,
     AssetDownload,
-    AlbumDelete,
     ServerStats,
     ServerAbout,
 }
@@ -1670,9 +1617,6 @@ fn classify_http_issue(context: RequestContext, status: u16, subject: Option<&st
                 RequestContext::AssetDownload => {
                     "Immich could not download the selected asset".to_string()
                 }
-                RequestContext::AlbumDelete => {
-                    "Immich could not delete the selected album".to_string()
-                }
                 RequestContext::ServerStats => {
                     "Immich could not load library statistics".to_string()
                 }
@@ -1725,9 +1669,6 @@ fn classify_network_issue(context: RequestContext, error: &reqwest::Error) -> Ap
                 }
                 RequestContext::AssetDownload => {
                     "The asset download request failed before completion".to_string()
-                }
-                RequestContext::AlbumDelete => {
-                    "The album deletion request failed before completion".to_string()
                 }
                 RequestContext::ServerStats => {
                     "The library statistics request failed before completion".to_string()

--- a/src/app_context.rs
+++ b/src/app_context.rs
@@ -3,12 +3,13 @@
 //! Replaces the growing list of individual `Arc<T>` parameters that were previously
 //! threaded through `build_settings_window()` and `open_settings_if_needed()`.
 
+use parking_lot::{Mutex, RwLock};
+use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::api_client::ImmichApiClient;
-use crate::config::WatchPathEntry;
+use crate::config::{Config, WatchPathEntry};
 use crate::library::state::LibraryState;
 use crate::library::thumbnail_cache::ThumbnailCache;
 use crate::monitor::MonitorHandle;
@@ -19,6 +20,7 @@ use crate::sync_index::SyncIndex;
 /// Shared application context holding all dependency handles that UI and background
 /// tasks need. Wrapped in `Arc` at construction time so it can be cloned cheaply.
 pub struct AppContext {
+    pub config: Arc<RwLock<Config>>,
     pub state: Arc<Mutex<AppState>>,
     pub api_client: Arc<ImmichApiClient>,
     pub queue_manager: Arc<QueueManager>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,6 +217,7 @@ fn default_upload_concurrency() -> u8 {
     3
 }
 
+#[derive(Clone)]
 pub struct Config {
     pub data: ConfigData,
     pub config_file: PathBuf,
@@ -262,17 +263,21 @@ impl Config {
     }
 
     pub fn save(&self) -> bool {
-        if let Some(parent) = self.config_file.parent() {
-            let _ = fs::create_dir_all(parent);
-        }
         if let Ok(content) = serde_json::to_string_pretty(&self.data) {
-            let ok = fs::write(&self.config_file, content).is_ok();
-            if ok {
-                log::info!("Config saved to: {}", self.config_file.display());
-            } else {
-                log::error!("Failed to write config: {}", self.config_file.display());
+            match crate::util::atomic_write(&self.config_file, content.as_bytes()) {
+                Ok(()) => {
+                    log::info!("Config saved to: {}", self.config_file.display());
+                    true
+                }
+                Err(err) => {
+                    log::error!(
+                        "Failed to write config {}: {}",
+                        self.config_file.display(),
+                        err
+                    );
+                    false
+                }
             }
-            ok
         } else {
             false
         }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -9,15 +9,18 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub fn export_bundle(destination_root: &Path, state: &AppState) -> io::Result<PathBuf> {
-    let config = Config::new();
+pub fn export_bundle(
+    destination_root: &Path,
+    state: &AppState,
+    config: &Config,
+) -> io::Result<PathBuf> {
     let cache_root = dirs::cache_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
         .join("mimick");
     let data_root = dirs::data_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
         .join("mimick");
-    export_bundle_with_paths(destination_root, state, &config, &cache_root, &data_root)
+    export_bundle_with_paths(destination_root, state, config, &cache_root, &data_root)
 }
 
 fn export_bundle_with_paths(

--- a/src/library/album_sync.rs
+++ b/src/library/album_sync.rs
@@ -86,7 +86,7 @@ async fn resolve_local_checksums(ctx: Arc<AppContext>, locals: Vec<LocalAsset>) 
     let mut to_compute: Vec<LocalAsset> = Vec::new();
 
     {
-        let index = ctx.sync_index.lock().unwrap();
+        let index = ctx.sync_index.lock();
         for asset in locals {
             let path_str = asset.path.to_string_lossy().to_string();
             match index.stored_checksum(&path_str) {
@@ -149,7 +149,7 @@ pub async fn execute_downloads(
     let mut ok = 0;
     let mut failed = 0;
     {
-        let mut state = ctx.state.lock().unwrap();
+        let mut state = ctx.state.lock();
         let route = state.active_server_route.clone();
         state.transfer.begin_group(
             TransferDirection::Download,
@@ -158,7 +158,9 @@ pub async fn execute_downloads(
         );
     }
     for asset in assets {
-        let dest = unique_destination(&watch_path, &asset.filename);
+        let safe_name =
+            crate::sanitize::safe_filename(&asset.filename).unwrap_or_else(|| asset.id.clone());
+        let dest = unique_destination(&watch_path, &safe_name);
         let progress = album_download_progress(&ctx, asset.id.clone(), asset.filename.clone());
         match ctx
             .api_client
@@ -180,7 +182,8 @@ pub async fn execute_downloads(
 }
 
 fn unique_destination(folder: &Path, filename: &str) -> PathBuf {
-    let mut candidate = folder.join(filename);
+    let safe = crate::sanitize::safe_filename(filename).unwrap_or_else(|| "download".to_string());
+    let mut candidate = folder.join(&safe);
     if !candidate.exists() {
         return candidate;
     }
@@ -213,7 +216,7 @@ fn album_download_progress(
 ) -> TransferProgressCallback {
     let state_ref = ctx.state.clone();
     {
-        let mut state = state_ref.lock().unwrap();
+        let mut state = state_ref.lock();
         let route = state.active_server_route.clone();
         state.transfer.register_item(
             TransferDirection::Download,
@@ -225,7 +228,7 @@ fn album_download_progress(
     }
 
     Arc::new(move |bytes_done, total_bytes| {
-        let mut state = state_ref.lock().unwrap();
+        let mut state = state_ref.lock();
         if let Some(total_bytes) = total_bytes {
             let current = state
                 .transfer
@@ -245,7 +248,7 @@ fn album_download_progress(
 }
 
 fn finish_album_download(ctx: &Arc<AppContext>, item_id: &str) {
-    let mut state = ctx.state.lock().unwrap();
+    let mut state = ctx.state.lock();
     let route = state.active_server_route.clone();
     state
         .transfer

--- a/src/library/albums_view.rs
+++ b/src/library/albums_view.rs
@@ -87,12 +87,7 @@ pub fn populate_albums(
     clear(&parts.owned_grid);
     clear(&parts.shared_grid);
 
-    let current_user = ctx
-        .current_user_id
-        .lock()
-        .unwrap()
-        .clone()
-        .unwrap_or_default();
+    let current_user = ctx.current_user_id.lock().clone().unwrap_or_default();
 
     let mut recent: Vec<&LibraryAlbum> = albums.iter().collect();
     recent.sort_by(|a, b| b.created_at.cmp(&a.created_at));

--- a/src/library/local_source.rs
+++ b/src/library/local_source.rs
@@ -34,23 +34,9 @@ pub struct LocalAsset {
     pub mime: String,
     /// "IMAGE" or "VIDEO".
     pub asset_type: &'static str,
-    /// File size in bytes (carried for future use — not currently displayed).
-    #[allow(dead_code)]
-    pub size: u64,
     /// ISO-8601 modification time, used as `created_at` for sort consistency
     /// with remote `LibraryAsset`.
     pub created_at: String,
-}
-
-impl LocalAsset {
-    /// Synthetic identity used by the GridView model. Using the path keeps
-    /// dedup logic stable across enumerations even when modification times
-    /// change. Currently unused outside tests, but kept as the canonical
-    /// recipe so future call sites match the prefix logic in `mod.rs`.
-    #[allow(dead_code)]
-    pub fn synthetic_id(&self) -> String {
-        format!("local::{}", self.path.display())
-    }
 }
 
 /// Walk every configured watch path and return matching media files.
@@ -58,11 +44,7 @@ impl LocalAsset {
 /// Runs the synchronous walk on a Tokio blocking thread so the UI thread
 /// stays responsive even on libraries with tens of thousands of files.
 pub async fn enumerate_local(ctx: Arc<AppContext>) -> Vec<LocalAsset> {
-    let watch_paths = ctx
-        .live_watch_paths
-        .lock()
-        .map(|guard| guard.clone())
-        .unwrap_or_default();
+    let watch_paths = ctx.live_watch_paths.lock().clone();
 
     tokio::task::spawn_blocking(move || enumerate_blocking(&watch_paths))
         .await
@@ -76,11 +58,7 @@ pub async fn enumerate_local_for_entry(
     ctx: Arc<AppContext>,
     entry_path: String,
 ) -> Vec<LocalAsset> {
-    let watch_paths = ctx
-        .live_watch_paths
-        .lock()
-        .map(|guard| guard.clone())
-        .unwrap_or_default();
+    let watch_paths = ctx.live_watch_paths.lock().clone();
 
     let scoped: Vec<WatchPathEntry> = watch_paths
         .into_iter()
@@ -135,7 +113,6 @@ fn enumerate_blocking(watch_paths: &[WatchPathEntry]) -> Vec<LocalAsset> {
 fn build_asset(path: &Path) -> Option<LocalAsset> {
     let filename = path.file_name()?.to_string_lossy().into_owned();
     let metadata = std::fs::metadata(path).ok()?;
-    let size = metadata.len();
     let created_at = format_modified(&metadata);
     let mime = mime_for_extension(path);
     let asset_type = if mime.starts_with("video/") {
@@ -148,7 +125,6 @@ fn build_asset(path: &Path) -> Option<LocalAsset> {
         filename,
         mime: mime.into(),
         asset_type,
-        size,
         created_at,
     })
 }
@@ -221,7 +197,7 @@ pub fn filter_by_filename(items: Vec<LocalAsset>, query: &str) -> Vec<LocalAsset
 /// Takes a borrowed `&SyncIndex` rather than `&AppContext` because callers
 /// like `asset_objects_from_state` already hold the `sync_index` mutex
 /// guard while iterating assets. Re-acquiring it inside this function
-/// would deadlock against the outer guard (`std::sync::Mutex` is
+/// would deadlock against the outer guard (`parking_lot::Mutex` is
 /// non-reentrant). Returns 2 when the file's path is recorded as synced
 /// (badge "Both"), 1 otherwise (LocalOnly).
 pub fn local_sync_state(idx: &crate::sync_index::SyncIndex, path: &Path) -> u32 {
@@ -242,9 +218,15 @@ mod tests {
             filename: name.into(),
             mime: "image/jpeg".into(),
             asset_type: "IMAGE",
-            size: 0,
             created_at: String::new(),
         }
+    }
+
+    /// Synthetic identity used by the GridView model. Using the path keeps
+    /// dedup logic stable across enumerations even when modification times
+    /// change.
+    fn synthetic_id(asset: &LocalAsset) -> String {
+        format!("local::{}", asset.path.display())
     }
 
     #[test]
@@ -263,6 +245,6 @@ mod tests {
     #[test]
     fn synthetic_id_is_stable_across_clones() {
         let a = make("/tmp/a.jpg");
-        assert_eq!(a.synthetic_id(), a.clone().synthetic_id());
+        assert_eq!(synthetic_id(&a), synthetic_id(&a.clone()));
     }
 }

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -13,7 +13,6 @@ use crate::api_client::{
     LibraryAsset, MetadataSearchFilters, ThumbnailSize, TransferProgressCallback,
 };
 use crate::app_context::AppContext;
-use crate::config::Config;
 use crate::library::albums_view::{
     AlbumClick, AlbumsViewParts, build_albums_view, populate_albums,
 };
@@ -45,7 +44,7 @@ const PAGE_SIZE: u32 = 50;
 
 fn begin_download_session(ctx: &Arc<AppContext>, item_label: String) {
     let state_ref = ctx.state.clone();
-    let mut state = state_ref.lock().unwrap();
+    let mut state = state_ref.lock();
     let route = state.active_server_route.clone();
     state
         .transfer
@@ -60,7 +59,7 @@ fn track_download_item(
 ) -> TransferProgressCallback {
     let state_ref = ctx.state.clone();
     {
-        let mut state = state_ref.lock().unwrap();
+        let mut state = state_ref.lock();
         let route = state.active_server_route.clone();
         state.transfer.register_item(
             TransferDirection::Download,
@@ -71,7 +70,7 @@ fn track_download_item(
         );
     }
     Arc::new(move |bytes_done, total_bytes| {
-        let mut state = state_ref.lock().unwrap();
+        let mut state = state_ref.lock();
         if let Some(total_bytes) = total_bytes {
             let current = state
                 .transfer
@@ -91,7 +90,7 @@ fn track_download_item(
 }
 
 fn finish_download_item(ctx: &Arc<AppContext>, item_id: &str) {
-    let mut state = ctx.state.lock().unwrap();
+    let mut state = ctx.state.lock();
     let route = state.active_server_route.clone();
     state
         .transfer
@@ -476,7 +475,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
 
 fn bootstrap_window(ui: Rc<LibraryWindowUi>) {
     let initial_request = {
-        let mut state = ui.ctx.library_state.lock().unwrap();
+        let mut state = ui.ctx.library_state.lock();
         state.load_initial_source()
     };
 
@@ -504,7 +503,7 @@ fn spawn_server_ping_loop(ui: Rc<LibraryWindowUi>) {
 
 fn spawn_transfer_poll_loop(ui: Rc<LibraryWindowUi>) {
     glib::timeout_add_local(std::time::Duration::from_millis(250), move || {
-        let completed_batches = ui.ctx.state.lock().unwrap().completed_upload_batches;
+        let completed_batches = ui.ctx.state.lock().completed_upload_batches;
         if completed_batches != ui.last_seen_upload_batch.get() {
             ui.last_seen_upload_batch.set(completed_batches);
             refresh_library_after_mutation(ui.clone(), true);
@@ -515,13 +514,13 @@ fn spawn_transfer_poll_loop(ui: Rc<LibraryWindowUi>) {
 }
 
 fn fetch_current_user(ui: Rc<LibraryWindowUi>) {
-    if ui.ctx.current_user_id.lock().unwrap().is_some() {
+    if ui.ctx.current_user_id.lock().is_some() {
         return;
     }
     glib::MainContext::default().spawn_local(async move {
         match ui.ctx.api_client.fetch_current_user_id().await {
             Ok(id) => {
-                *ui.ctx.current_user_id.lock().unwrap() = Some(id);
+                *ui.ctx.current_user_id.lock() = Some(id);
             }
             Err(err) => log::warn!("Could not fetch current user id: {}", err),
         }
@@ -651,7 +650,7 @@ fn connect_controls(
             if ui.source_mode_suppressed.get() {
                 return;
             }
-            let album_ctx = match ui.ctx.library_state.lock().unwrap().source.clone() {
+            let album_ctx = match ui.ctx.library_state.lock().source.clone() {
                 LibrarySource::Album { id, name }
                 | LibrarySource::AlbumLocal { id, name }
                 | LibrarySource::AlbumUnified { id, name } => Some((id, name)),
@@ -674,7 +673,7 @@ fn connect_controls(
             // Searching while switching sources would require thread-safe
             // re-routing of the search field; clear it on source change.
             ui.search_entry.set_text("");
-            let request = ui.ctx.library_state.lock().unwrap().switch_source(source);
+            let request = ui.ctx.library_state.lock().switch_source(source);
             apply_timeline_ui_state(&ui, &request.1);
             load_source_page(ui.clone(), request, false);
         }
@@ -687,7 +686,7 @@ fn connect_controls(
             if !toggle.is_sensitive() {
                 return;
             }
-            let current = ui.ctx.library_state.lock().unwrap().source.clone();
+            let current = ui.ctx.library_state.lock().source.clone();
             if !matches!(current, LibrarySource::AllAssets | LibrarySource::Timeline) {
                 toggle.set_active(false);
                 return;
@@ -701,12 +700,7 @@ fn connect_controls(
             } else {
                 LibrarySource::AllAssets
             };
-            let request = ui
-                .ctx
-                .library_state
-                .lock()
-                .unwrap()
-                .switch_source(next_source);
+            let request = ui.ctx.library_state.lock().switch_source(next_source);
             apply_timeline_ui_state(&ui, &request.1);
             load_source_page(ui.clone(), request, false);
         }
@@ -730,7 +724,7 @@ fn connect_controls(
                     _ => LibrarySource::MetadataSearch { query },
                 },
             };
-            let request = ui.ctx.library_state.lock().unwrap().switch_source(source);
+            let request = ui.ctx.library_state.lock().switch_source(source);
             apply_timeline_ui_state(&ui, &request.1);
             load_source_page(ui.clone(), request, false);
         }
@@ -758,7 +752,6 @@ fn connect_controls(
                 .ctx
                 .library_state
                 .lock()
-                .unwrap()
                 .clear_search_restore_previous_source();
             if let Some(request) = request {
                 apply_timeline_ui_state(&ui, &request.1);
@@ -778,7 +771,7 @@ fn connect_controls(
             };
 
             let objects = {
-                let mut state = ui.ctx.library_state.lock().unwrap();
+                let mut state = ui.ctx.library_state.lock();
                 state.apply_sort(sort_mode);
                 asset_objects_from_state(&state.assets, &ui.ctx)
             };
@@ -793,8 +786,8 @@ fn refresh_library_surfaces(ui: Rc<LibraryWindowUi>, include_current_source: boo
     ui.explore.populated.set(false);
     if include_current_source {
         let request = {
-            let source = ui.ctx.library_state.lock().unwrap().source.clone();
-            ui.ctx.library_state.lock().unwrap().switch_source(source)
+            let source = ui.ctx.library_state.lock().source.clone();
+            ui.ctx.library_state.lock().switch_source(source)
         };
         load_source_page(ui, request, false);
     }
@@ -945,7 +938,7 @@ fn collect_selected_assets(ui: &Rc<LibraryWindowUi>) -> Vec<(String, String)> {
 
 fn should_refresh_after_download(ui: &LibraryWindowUi) -> bool {
     matches!(
-        ui.ctx.library_state.lock().unwrap().source,
+        ui.ctx.library_state.lock().source,
         LibrarySource::LocalAll
             | LibrarySource::LocalSearch { .. }
             | LibrarySource::Unified
@@ -1055,10 +1048,10 @@ fn connect_sidebar_handlers(ui: Rc<LibraryWindowUi>) {
 /// source, since the Albums grid moves the stack without changing source.
 fn sidebar_dispatch(ui: Rc<LibraryWindowUi>, source: LibrarySource) {
     let on_albums_grid = ui.content_stack.visible_child_name().as_deref() == Some("albums");
-    if !on_albums_grid && ui.ctx.library_state.lock().unwrap().source == source {
+    if !on_albums_grid && ui.ctx.library_state.lock().source == source {
         return;
     }
-    let request = ui.ctx.library_state.lock().unwrap().switch_source(source);
+    let request = ui.ctx.library_state.lock().switch_source(source);
     apply_timeline_ui_state(&ui, &request.1);
     load_source_page(ui.clone(), request, false);
 }
@@ -1113,12 +1106,7 @@ fn connect_grid_handlers(ui: Rc<LibraryWindowUi>) {
                     return;
                 }
 
-                let next = ui
-                    .ctx
-                    .library_state
-                    .lock()
-                    .unwrap()
-                    .load_next_page_if_needed();
+                let next = ui.ctx.library_state.lock().load_next_page_if_needed();
                 if let Some(request) = next {
                     load_source_page(ui.clone(), request, true);
                 }
@@ -1316,7 +1304,9 @@ async fn ensure_original_asset_path(
         .join("mimick")
         .join("open-in");
     let _ = std::fs::create_dir_all(&cache_dir);
-    let path = cache_dir.join(filename);
+    let safe_name =
+        crate::sanitize::safe_filename(filename).unwrap_or_else(|| asset_id.to_string());
+    let path = cache_dir.join(&safe_name);
     if path.exists() {
         return Ok(path);
     }
@@ -1416,7 +1406,7 @@ fn refresh_album_link_row(ui: &LibraryWindowUi, source: &LibrarySource) {
         parent.set_visible(true);
     }
 
-    let entries = ui.ctx.live_watch_paths.lock().unwrap().clone();
+    let entries = ui.ctx.live_watch_paths.lock().clone();
     match crate::config::watch_entry_for_album(name, &entries) {
         Some(entry) => {
             ui.album_link_row.set_title("Linked folder");
@@ -1448,7 +1438,7 @@ fn connect_album_link_row(ui: Rc<LibraryWindowUi>, _listbox: gtk::ListBox) {
 }
 
 fn handle_album_sync_click(ui: Rc<LibraryWindowUi>) {
-    let source = ui.ctx.library_state.lock().unwrap().source.clone();
+    let source = ui.ctx.library_state.lock().source.clone();
     let LibrarySource::Album {
         id: album_id,
         name: album_name,
@@ -1456,7 +1446,7 @@ fn handle_album_sync_click(ui: Rc<LibraryWindowUi>) {
     else {
         return;
     };
-    let entries = ui.ctx.live_watch_paths.lock().unwrap().clone();
+    let entries = ui.ctx.live_watch_paths.lock().clone();
     let Some(entry) = crate::config::watch_entry_for_album(&album_name, &entries) else {
         return;
     };
@@ -1614,7 +1604,7 @@ fn present_sync_dialog(
 }
 
 fn handle_album_link_click(ui: Rc<LibraryWindowUi>) {
-    let source = ui.ctx.library_state.lock().unwrap().source.clone();
+    let source = ui.ctx.library_state.lock().source.clone();
     let LibrarySource::Album {
         id: album_id,
         name: album_name,
@@ -1623,7 +1613,7 @@ fn handle_album_link_click(ui: Rc<LibraryWindowUi>) {
         return;
     };
 
-    let entries = ui.ctx.live_watch_paths.lock().unwrap().clone();
+    let entries = ui.ctx.live_watch_paths.lock().clone();
     let already_linked = crate::config::watch_entry_for_album(&album_name, &entries).is_some();
 
     if already_linked {
@@ -1650,17 +1640,19 @@ fn handle_album_link_click(ui: Rc<LibraryWindowUi>) {
 }
 
 fn unlink_album(ui: Rc<LibraryWindowUi>, album_name: &str) {
-    let mut config = Config::new();
-    config
-        .data
-        .watch_paths
-        .retain(|entry| entry.album_name() != Some(album_name));
-    if !config.save() {
-        log::error!("Failed to save config after unlink");
-        return;
+    {
+        let mut config = ui.ctx.config.write();
+        config
+            .data
+            .watch_paths
+            .retain(|entry| entry.album_name() != Some(album_name));
+        if !config.save() {
+            log::error!("Failed to save config after unlink");
+            return;
+        }
+        *ui.ctx.live_watch_paths.lock() = config.data.watch_paths.clone();
     }
-    *ui.ctx.live_watch_paths.lock().unwrap() = config.data.watch_paths.clone();
-    let source_after = ui.ctx.library_state.lock().unwrap().source.clone();
+    let source_after = ui.ctx.library_state.lock().source.clone();
     refresh_album_link_row(&ui, &source_after);
 }
 
@@ -1671,31 +1663,33 @@ fn link_album_to_path(
     path: std::path::PathBuf,
 ) {
     let path_string = path.to_string_lossy().to_string();
-    let mut config = Config::new();
-    config
-        .data
-        .watch_paths
-        .retain(|entry| entry.album_name() != Some(album_name.as_str()));
-    config
-        .data
-        .watch_paths
-        .push(crate::config::WatchPathEntry::WithConfig {
-            path: path_string,
-            album_id: Some(album_id),
-            album_name: Some(album_name),
-            rules: crate::config::FolderRules::default(),
-        });
-    if !config.save() {
-        log::error!("Failed to save config after link");
-        return;
+    {
+        let mut config = ui.ctx.config.write();
+        config
+            .data
+            .watch_paths
+            .retain(|entry| entry.album_name() != Some(album_name.as_str()));
+        config
+            .data
+            .watch_paths
+            .push(crate::config::WatchPathEntry::WithConfig {
+                path: path_string,
+                album_id: Some(album_id),
+                album_name: Some(album_name),
+                rules: crate::config::FolderRules::default(),
+            });
+        if !config.save() {
+            log::error!("Failed to save config after link");
+            return;
+        }
+        *ui.ctx.live_watch_paths.lock() = config.data.watch_paths.clone();
     }
-    *ui.ctx.live_watch_paths.lock().unwrap() = config.data.watch_paths.clone();
-    let source_after = ui.ctx.library_state.lock().unwrap().source.clone();
+    let source_after = ui.ctx.library_state.lock().source.clone();
     refresh_album_link_row(&ui, &source_after);
 }
 
 fn update_timeline_banner_if_active(ui: &Rc<LibraryWindowUi>, adj: &gtk::Adjustment) {
-    let state = ui.ctx.library_state.lock().unwrap();
+    let state = ui.ctx.library_state.lock();
     if !matches!(state.source, LibrarySource::Timeline) {
         return;
     }
@@ -1744,7 +1738,7 @@ fn load_albums(ui: Rc<LibraryWindowUi>) {
         async move {
             match ui.ctx.api_client.fetch_library_albums().await {
                 Ok(albums) => {
-                    ui.ctx.library_state.lock().unwrap().load_albums(albums);
+                    ui.ctx.library_state.lock().load_albums(albums);
                     reload_sidebar(&ui);
                 }
                 Err(err) => {
@@ -1767,7 +1761,7 @@ fn load_status(ui: Rc<LibraryWindowUi>) {
             let route = ui.ctx.api_client.active_route_label().await;
 
             {
-                let mut state = ui.ctx.library_state.lock().unwrap();
+                let mut state = ui.ctx.library_state.lock();
                 state.set_status(stats, about);
             }
             update_footer(&ui, route);
@@ -1796,7 +1790,7 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
                     person_ids: Some(vec![id]),
                     ..Default::default()
                 };
-                let request = click_ui.ctx.library_state.lock().unwrap().switch_source(
+                let request = click_ui.ctx.library_state.lock().switch_source(
                     LibrarySource::AdvancedSearch {
                         filters: Box::new(filters),
                     },
@@ -1822,12 +1816,7 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
                             query: value.clone(),
                         },
                     };
-                    let request = click_ui
-                        .ctx
-                        .library_state
-                        .lock()
-                        .unwrap()
-                        .switch_source(next);
+                    let request = click_ui.ctx.library_state.lock().switch_source(next);
                     click_ui.search_entry.set_text(&value);
                     apply_timeline_ui_state(&click_ui, &request.1);
                     load_source_page(click_ui.clone(), request, false);
@@ -1938,7 +1927,7 @@ fn load_source_page(ui: Rc<LibraryWindowUi>, request: (u64, LibrarySource, u32),
             match result {
                 Ok(items) => {
                     let outcome = {
-                        let mut state = ui.ctx.library_state.lock().unwrap();
+                        let mut state = ui.ctx.library_state.lock();
                         let prev_len = state.assets.len();
                         let applied = if append {
                             state.append_assets(generation, items)
@@ -1962,7 +1951,7 @@ fn load_source_page(ui: Rc<LibraryWindowUi>, request: (u64, LibrarySource, u32),
                     update_timeline_banner_if_active(&ui, &ui.grid.scrolled.vadjustment());
                 }
                 Err(err) => {
-                    let mut state = ui.ctx.library_state.lock().unwrap();
+                    let mut state = ui.ctx.library_state.lock();
                     state.mark_error(generation, err.clone());
                     ui.error_label
                         .set_label(&format!("Could not load library assets: {}", err));
@@ -1978,8 +1967,8 @@ fn reload_sidebar(ui: &Rc<LibraryWindowUi>) {
         ui.sidebar.albums_list.remove(&row);
     }
 
-    let selected_source = ui.ctx.library_state.lock().unwrap().source.clone();
-    let albums = ui.ctx.library_state.lock().unwrap().albums.clone();
+    let selected_source = ui.ctx.library_state.lock().source.clone();
+    let albums = ui.ctx.library_state.lock().albums.clone();
     for album in albums {
         let subtitle = format!("{} asset(s)", album.asset_count);
         let action = libadwaita::ActionRow::builder()
@@ -2045,7 +2034,7 @@ fn select_fixed_row(list: &gtk::ListBox, key: &str) {
 }
 
 fn sync_content_state(ui: &LibraryWindowUi) {
-    match &ui.ctx.library_state.lock().unwrap().load_state {
+    match &ui.ctx.library_state.lock().load_state {
         LibraryLoadState::Idle | LibraryLoadState::Loading => {
             ui.content_stack.set_visible_child_name("loading");
         }
@@ -2063,7 +2052,7 @@ fn sync_content_state(ui: &LibraryWindowUi) {
 }
 
 fn update_footer(ui: &LibraryWindowUi, route: Option<String>) {
-    let state = ui.ctx.library_state.lock().unwrap();
+    let state = ui.ctx.library_state.lock();
     let route_subtitle = route
         .as_deref()
         .map(|route| match route {
@@ -2093,7 +2082,7 @@ fn update_footer(ui: &LibraryWindowUi, route: Option<String>) {
 
 fn update_transfer_ui(ui: &LibraryWindowUi) {
     let transfer = {
-        let mut state = ui.ctx.state.lock().unwrap();
+        let mut state = ui.ctx.state.lock();
         if state.transfer.active
             && state.transfer.active_uploads == 0
             && state.transfer.active_downloads == 0
@@ -2201,7 +2190,7 @@ fn immich_checksum_to_hex(b64: &str) -> Option<String> {
 }
 
 fn asset_objects_from_state(assets: &[LibraryAsset], ctx: &AppContext) -> Vec<AssetObject> {
-    let sync_index = ctx.sync_index.lock().unwrap();
+    let sync_index = ctx.sync_index.lock();
     assets
         .iter()
         .map(|asset| {
@@ -2395,7 +2384,7 @@ fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         .vexpand(true)
         .hexpand(true)
         .build();
-    let initial_full = Config::new().data.library_preview_full_resolution;
+    let initial_full = ui.ctx.config.read().data.library_preview_full_resolution;
     let resolution_toggle = gtk::ToggleButton::builder()
         .label(if initial_full { "Original" } else { "Preview" })
         .tooltip_text("Toggle preview vs original full-resolution image")
@@ -2633,12 +2622,7 @@ fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
                 (*render)();
                 return;
             }
-            let next_request = ui
-                .ctx
-                .library_state
-                .lock()
-                .unwrap()
-                .load_next_page_if_needed();
+            let next_request = ui.ctx.library_state.lock().load_next_page_if_needed();
             let Some(req) = next_request else {
                 return;
             };
@@ -2763,7 +2747,9 @@ fn spawn_video_handoff(ui: Rc<LibraryWindowUi>, asset_id: String, filename: Stri
             return;
         };
         let _ = std::fs::create_dir_all(&cache_dir);
-        let path = cache_dir.join(&filename);
+        let safe_name =
+            crate::sanitize::safe_filename(&filename).unwrap_or_else(|| asset_id.clone());
+        let path = cache_dir.join(&safe_name);
         if !path.exists()
             && let Err(err) = {
                 begin_download_session(&ui.ctx, filename.clone());
@@ -2810,7 +2796,9 @@ fn start_download_with_session(
             let Some(target_dir) = ensure_download_target(&ui).await else {
                 return;
             };
-            let output_path = target_dir.join(&filename);
+            let safe_name =
+                crate::sanitize::safe_filename(&filename).unwrap_or_else(|| asset_id.clone());
+            let output_path = target_dir.join(&safe_name);
             if output_path.exists() {
                 let dialog = libadwaita::AlertDialog::builder()
                     .heading("File already exists")
@@ -2879,7 +2867,7 @@ fn spawn_download(
                 Ok(()) => {
                     let session_finished = {
                         finish_download_item(&ui.ctx, &asset_id);
-                        !ui.ctx.state.lock().unwrap().transfer.active
+                        !ui.ctx.state.lock().transfer.active
                     };
                     if should_refresh_after_download(&ui) && session_finished {
                         refresh_library_after_mutation(ui.clone(), true);
@@ -2912,8 +2900,8 @@ fn spawn_download(
 }
 
 async fn ensure_download_target(ui: &LibraryWindowUi) -> Option<PathBuf> {
-    let config = Config::new();
-    if let Some(path) = config.data.download_target_path {
+    let existing_target = ui.ctx.config.read().data.download_target_path.clone();
+    if let Some(path) = existing_target {
         return Some(PathBuf::from(path));
     }
 
@@ -2930,9 +2918,11 @@ async fn ensure_download_target(ui: &LibraryWindowUi) -> Option<PathBuf> {
     });
 
     let path = rx.await.ok().flatten()?;
-    let mut config = Config::new();
-    config.data.download_target_path = Some(path.to_string_lossy().to_string());
-    let _ = config.save();
+    {
+        let mut config = ui.ctx.config.write();
+        config.data.download_target_path = Some(path.to_string_lossy().to_string());
+        let _ = config.save();
+    }
     Some(path)
 }
 
@@ -2966,14 +2956,14 @@ async fn merge_unified_page(
         locals = filter_by_filename(locals, q);
     }
 
-    let synced_paths: std::collections::HashSet<String> = match ui.ctx.sync_index.lock() {
-        Ok(idx) => remote
+    let synced_paths: std::collections::HashSet<String> = {
+        let idx = ui.ctx.sync_index.lock();
+        remote
             .iter()
             .filter_map(|a| a.checksum.as_deref())
             .filter_map(immich_checksum_to_hex)
             .filter_map(|hex| idx.local_path_for_checksum(&hex))
-            .collect(),
-        Err(_) => std::collections::HashSet::new(),
+            .collect()
     };
 
     let mut local_rows: Vec<LibraryAsset> = locals
@@ -2988,7 +2978,7 @@ async fn merge_unified_page(
 
 /// Return the path of the watch entry linked to `album_name`, if any.
 fn linked_entry_path_for_album(ui: &Rc<LibraryWindowUi>, album_name: &str) -> Option<String> {
-    let entries = ui.ctx.live_watch_paths.lock().ok()?.clone();
+    let entries = ui.ctx.live_watch_paths.lock().clone();
     crate::config::watch_entry_for_album(album_name, &entries).map(|e| e.path().to_string())
 }
 
@@ -3011,14 +3001,14 @@ async fn merge_album_unified_page(
         None => Vec::new(),
     };
 
-    let synced_paths: std::collections::HashSet<String> = match ui.ctx.sync_index.lock() {
-        Ok(idx) => remote
+    let synced_paths: std::collections::HashSet<String> = {
+        let idx = ui.ctx.sync_index.lock();
+        remote
             .iter()
             .filter_map(|a| a.checksum.as_deref())
             .filter_map(immich_checksum_to_hex)
             .filter_map(|hex| idx.local_path_for_checksum(&hex))
-            .collect(),
-        Err(_) => std::collections::HashSet::new(),
+            .collect()
     };
 
     let mut local_rows: Vec<LibraryAsset> = locals
@@ -3242,7 +3232,6 @@ fn present_advanced_filters_dialog(ui: Rc<LibraryWindowUi>) {
                 ui.ctx
                     .library_state
                     .lock()
-                    .unwrap()
                     .switch_source(LibrarySource::AdvancedSearch {
                         filters: Box::new(filters),
                     });

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -1,8 +1,9 @@
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use gdk4::Texture;
 use gdk4::prelude::TextureExt;
@@ -31,9 +32,8 @@ impl InflightGuard {
 
 impl Drop for InflightGuard {
     fn drop(&mut self) {
-        if let Ok(mut map) = self.inflight.lock() {
-            map.remove(&self.key);
-        }
+        let mut map = self.inflight.lock();
+        map.remove(&self.key);
     }
 }
 
@@ -147,7 +147,7 @@ impl ThumbnailCache {
 
     pub fn get_cached(&self, asset_id: &str, size: ThumbnailSize) -> Option<Texture> {
         let key = cache_key(asset_id, size);
-        self.memory.lock().unwrap().get(&key)
+        self.memory.lock().get(&key)
     }
 
     pub async fn load_thumbnail(
@@ -220,10 +220,7 @@ impl ThumbnailCache {
             let texture = decode_to_scaled_texture(bytes)
                 .await
                 .map_err(|err| err.to_string())?;
-            self.memory
-                .lock()
-                .unwrap()
-                .insert(key.to_string(), texture.clone());
+            self.memory.lock().insert(key.to_string(), texture.clone());
             return Ok(texture);
         }
 
@@ -243,21 +240,8 @@ impl ThumbnailCache {
             .await
             .map_err(|err| err.to_string())?;
 
-        self.memory
-            .lock()
-            .unwrap()
-            .insert(key.to_string(), texture.clone());
+        self.memory.lock().insert(key.to_string(), texture.clone());
         Ok(texture)
-    }
-
-    #[allow(dead_code)]
-    pub async fn load_local_thumbnail(
-        &self,
-        asset_id: &str,
-        path: &std::path::Path,
-    ) -> Result<Texture, String> {
-        self.load_local_thumbnail_cancellable(asset_id, path, || false)
-            .await
     }
 
     pub async fn load_local_thumbnail_cancellable<F>(
@@ -270,7 +254,7 @@ impl ThumbnailCache {
         F: Fn() -> bool,
     {
         let key = cache_key(asset_id, ThumbnailSize::Thumbnail);
-        if let Some(texture) = self.memory.lock().unwrap().get(&key) {
+        if let Some(texture) = self.memory.lock().get(&key) {
             return Ok(texture);
         }
 
@@ -305,7 +289,7 @@ impl ThumbnailCache {
         if is_cancelled() {
             return Err("cancelled".to_string());
         }
-        if let Some(texture) = self.memory.lock().unwrap().get(key) {
+        if let Some(texture) = self.memory.lock().get(key) {
             return Ok(texture);
         }
 
@@ -321,10 +305,7 @@ impl ThumbnailCache {
         .map_err(|err| err.to_string())?;
 
         if let Some(texture) = from_disk {
-            self.memory
-                .lock()
-                .unwrap()
-                .insert(key.to_string(), texture.clone());
+            self.memory.lock().insert(key.to_string(), texture.clone());
             return Ok(texture);
         }
 
@@ -341,15 +322,12 @@ impl ThumbnailCache {
         })
         .await
         .map_err(|err| err.to_string())??;
-        self.memory
-            .lock()
-            .unwrap()
-            .insert(key.to_string(), texture.clone());
+        self.memory.lock().insert(key.to_string(), texture.clone());
         Ok(texture)
     }
 
     pub fn clear(&self) -> Result<(), String> {
-        self.memory.lock().unwrap().clear();
+        self.memory.lock().clear();
         if self.cache_dir.exists() {
             std::fs::remove_dir_all(&self.cache_dir).map_err(|err| err.to_string())?;
         }
@@ -405,7 +383,7 @@ impl ThumbnailCache {
     }
 
     fn enter_inflight(&self, key: &str) -> Result<InflightGuard, InflightRx> {
-        let mut map = self.inflight.lock().unwrap();
+        let mut map = self.inflight.lock();
         if let Some(rx) = map.get(key) {
             return Err(rx.clone());
         }
@@ -491,7 +469,6 @@ mod tests {
         cache
             .memory
             .lock()
-            .unwrap()
             .insert("thumbnail:1".into(), texture_from_png());
 
         assert!(cache.get_cached("1", ThumbnailSize::Thumbnail).is_some());
@@ -512,15 +489,13 @@ mod tests {
         cache
             .memory
             .lock()
-            .unwrap()
             .insert("thumbnail:1".into(), texture_from_png());
         cache
             .memory
             .lock()
-            .unwrap()
             .insert("thumbnail:2".into(), texture_from_png());
 
-        assert!(cache.memory.lock().unwrap().inner.len() <= 1);
+        assert!(cache.memory.lock().inner.len() <= 1);
     }
 
     #[test]
@@ -531,12 +506,11 @@ mod tests {
         cache
             .memory
             .lock()
-            .unwrap()
             .insert("thumbnail:3".into(), texture_from_png());
 
         cache.clear().unwrap();
 
-        assert!(cache.memory.lock().unwrap().inner.is_empty());
+        assert!(cache.memory.lock().inner.is_empty());
         assert!(!cache.cache_dir.exists());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,9 @@
 use gtk::prelude::*;
 use libadwaita as adw;
 use log::Record;
+use parking_lot::Mutex;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 
 mod api_client;
@@ -17,11 +18,13 @@ mod monitor;
 mod notifications;
 mod queue_manager;
 mod runtime_env;
+mod sanitize;
 mod settings_window;
 mod startup_scan;
 mod state_manager;
 mod sync_index;
 mod tray_icon;
+mod util;
 mod watch_path_display;
 
 use api_client::ImmichApiClient;
@@ -124,7 +127,7 @@ async fn main() {
     let is_primary_instance = Arc::new(AtomicBool::new(false));
     let is_primary_instance_clone = is_primary_instance.clone();
 
-    let shared_state: Arc<Mutex<AppState>> = Arc::new(Mutex::new({
+    let shared_state: Arc<parking_lot::Mutex<AppState>> = Arc::new(parking_lot::Mutex::new({
         let mut saved = StateManager::new().read_state();
         // Any items left in the channel during shutdown were dropped, so we must
         // sync total_queued down to processed_count to clear the stuck queue state.
@@ -176,7 +179,7 @@ async fn main() {
         );
 
         {
-            let mut state = shared_state_startup.lock().unwrap();
+            let mut state = shared_state_startup.lock();
             state.watched_folder_count = watch_folder_count;
         }
 
@@ -199,13 +202,14 @@ async fn main() {
             runtime_external_url,
             api_key,
         ));
-        let sync_index = Arc::new(Mutex::new(SyncIndex::new()));
+        let sync_index = Arc::new(parking_lot::Mutex::new(SyncIndex::new()));
 
         let sync_index_flusher = sync_index.clone();
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
-                if let Ok(mut index) = sync_index_flusher.lock() {
+                {
+                    let mut index = sync_index_flusher.lock();
                     let _ = index.flush();
                 }
             }
@@ -250,7 +254,7 @@ async fn main() {
                 log::info!("Queuing: {} (sha1={})", path, checksum);
 
                 let (album_id, album_name, watch_path) = {
-                    let path_configs = live_watch_paths_for_queue.lock().unwrap();
+                    let path_configs = live_watch_paths_for_queue.lock();
                     best_matching_watch_entry(std::path::Path::new(&path), &path_configs)
                         .map(|entry| match entry {
                             config::WatchPathEntry::WithConfig {
@@ -290,8 +294,10 @@ async fn main() {
             api_client.clone(),
             config.data.library_thumbnail_cache_mb,
         ));
-        let library_state = Arc::new(Mutex::new(LibraryState::new()));
+        let library_state = Arc::new(parking_lot::Mutex::new(LibraryState::new()));
+        let shared_config = Arc::new(parking_lot::RwLock::new(config));
         let ctx = Arc::new(AppContext {
+            config: shared_config.clone(),
             state: shared_state_startup.clone(),
             api_client: api_client.clone(),
             queue_manager: qm.clone(),
@@ -302,7 +308,7 @@ async fn main() {
             thumbnail_cache,
             library_state,
             library_timeline_active: std::sync::atomic::AtomicBool::new(false),
-            current_user_id: Arc::new(Mutex::new(None)),
+            current_user_id: Arc::new(parking_lot::Mutex::new(None)),
         });
         let _ = APP_CONTEXT.set(ctx.clone());
 
@@ -310,13 +316,14 @@ async fn main() {
         if background_sync_enabled {
             let shared_state_startup_task = shared_state_startup.clone();
             let startup_api = ctx.api_client.clone();
+            let catchup_mode = shared_config.read().data.startup_catchup_mode.clone();
             tokio::spawn(async move {
                 queue_unsynced_files(
                     startup_paths,
                     startup_qm,
                     startup_sync_index,
                     startup_api,
-                    config::Config::new().data.startup_catchup_mode,
+                    catchup_mode,
                     shared_state_startup_task,
                 )
                 .await;
@@ -332,7 +339,7 @@ async fn main() {
             let route = status_api.active_route_label().await;
             let latest_issue = status_api.latest_issue().await;
 
-            let mut state = startup_state.lock().unwrap();
+            let mut state = startup_state.lock();
             state.active_server_route = route;
             if connected {
                 state.last_error = None;
@@ -347,15 +354,19 @@ async fn main() {
         let manual_sync_index = sync_index.clone();
         let manual_sync_api = ctx.api_client.clone();
         let shared_state_manual_task = shared_state_startup.clone();
+        let manual_config = shared_config.clone();
         tokio::spawn(async move {
             while manual_sync_rx.recv().await.is_some() {
-                let config = Config::new();
+                let (watch_paths, catchup_mode) = {
+                    let cfg = manual_config.read();
+                    (cfg.data.watch_paths.clone(), cfg.data.startup_catchup_mode.clone())
+                };
                 queue_unsynced_files(
-                    config.data.watch_paths.clone(),
+                    watch_paths,
                     manual_qm.clone(),
                     manual_sync_index.clone(),
                     manual_sync_api.clone(),
-                    config.data.startup_catchup_mode,
+                    catchup_mode,
                     shared_state_manual_task.clone(),
                 )
                 .await;
@@ -367,22 +378,22 @@ async fn main() {
 
         // Cross-thread flag: Tokio sets it; the GTK timer reads and clears it.
         // Arc<Mutex<bool>> is Send + Sync, so it can cross the tokio::spawn boundary.
-        let settings_flag = Arc::new(std::sync::Mutex::new(false));
+        let settings_flag = Arc::new(parking_lot::Mutex::new(false));
         let settings_flag_writer = settings_flag.clone(); // moves into tokio::spawn (Send ✓)
-        let library_flag = Arc::new(std::sync::Mutex::new(false));
+        let library_flag = Arc::new(parking_lot::Mutex::new(false));
         let library_flag_writer = library_flag.clone();
-        let quit_flag = Arc::new(std::sync::Mutex::new(false));
+        let quit_flag = Arc::new(parking_lot::Mutex::new(false));
         let quit_flag_writer = quit_flag.clone(); // moves into tokio::spawn (Send ✓)
-        let pause_flag = Arc::new(std::sync::Mutex::new(false));
+        let pause_flag = Arc::new(parking_lot::Mutex::new(false));
         let pause_flag_writer = pause_flag.clone();
-        let sync_now_flag = Arc::new(std::sync::Mutex::new(false));
+        let sync_now_flag = Arc::new(parking_lot::Mutex::new(false));
         let sync_now_flag_writer = sync_now_flag.clone();
 
         // GTK-side: poll the flag every 250ms on the main thread.
         // The application handle stays on the GTK thread and never enters Tokio tasks.
         glib::timeout_add_local(std::time::Duration::from_millis(250), move || {
             let settings_triggered = {
-                let mut f = settings_flag.lock().unwrap();
+                let mut f = settings_flag.lock();
                 if *f {
                     *f = false;
                     true
@@ -399,7 +410,7 @@ async fn main() {
             }
 
             let library_triggered = {
-                let mut f = library_flag.lock().unwrap();
+                let mut f = library_flag.lock();
                 if *f {
                     *f = false;
                     true
@@ -416,7 +427,7 @@ async fn main() {
             }
 
             let quit_triggered = {
-                let mut f = quit_flag.lock().unwrap();
+                let mut f = quit_flag.lock();
                 if *f {
                     *f = false;
                     true
@@ -430,7 +441,7 @@ async fn main() {
             }
 
             let pause_triggered = {
-                let mut f = pause_flag.lock().unwrap();
+                let mut f = pause_flag.lock();
                 if *f {
                     *f = false;
                     true
@@ -453,7 +464,7 @@ async fn main() {
             }
 
             let sync_now_triggered = {
-                let mut f = sync_now_flag.lock().unwrap();
+                let mut f = sync_now_flag.lock();
                 if *f {
                     *f = false;
                     true
@@ -474,9 +485,10 @@ async fn main() {
 
         // Tokio-side: build the tray and forward watch signals into the flag.
         // Only *_writer flags (Send ✓) and watch receivers (Send ✓) are captured here.
+        let tray_library_enabled = shared_config.read().data.library_view_enabled;
         tokio::spawn(async move {
             log::info!("Starting system tray");
-            match build_tray().await {
+            match build_tray(tray_library_enabled).await {
                 Ok(handles) => {
                     let crate::tray_icon::TrayHandles {
                         handle: _handle,
@@ -493,7 +505,7 @@ async fn main() {
                                     break;
                                 }
                                 if *settings_rx.borrow() {
-                                    *settings_flag_writer.lock().unwrap() = true;
+                                    *settings_flag_writer.lock() = true;
                                 }
                             }
                             res = library_rx.changed() => {
@@ -501,7 +513,7 @@ async fn main() {
                                     break;
                                 }
                                 if *library_rx.borrow() {
-                                    *library_flag_writer.lock().unwrap() = true;
+                                    *library_flag_writer.lock() = true;
                                 }
                             }
                             res = quit_rx.changed() => {
@@ -509,7 +521,7 @@ async fn main() {
                                     break;
                                 }
                                 if *quit_rx.borrow() {
-                                    *quit_flag_writer.lock().unwrap() = true;
+                                    *quit_flag_writer.lock() = true;
                                 }
                             }
                             res = pause_rx.changed() => {
@@ -517,7 +529,7 @@ async fn main() {
                                     break;
                                 }
                                 if *pause_rx.borrow() {
-                                    *pause_flag_writer.lock().unwrap() = true;
+                                    *pause_flag_writer.lock() = true;
                                 }
                             }
                             res = sync_now_rx.changed() => {
@@ -525,7 +537,7 @@ async fn main() {
                                     break;
                                 }
                                 if *sync_now_rx.borrow() {
-                                    *sync_now_flag_writer.lock().unwrap() = true;
+                                    *sync_now_flag_writer.lock() = true;
                                 }
                             }
                         }
@@ -550,10 +562,13 @@ async fn main() {
             return 0.into();
         }
 
-        let runtime_config = Config::new();
+        let ctx_early = APP_CONTEXT.get().cloned();
         let want_settings = argv.contains(&"--settings".to_string());
         let want_library = argv.contains(&"--library".to_string());
-        let setup_required = runtime_config.get_api_key().unwrap_or_default().is_empty();
+        let setup_required = ctx_early
+            .as_ref()
+            .map(|c| c.config.read().get_api_key().unwrap_or_default().is_empty())
+            .unwrap_or(true);
         let secondary_activation = cmdline.is_remote();
 
         let ctx_lookup = || {
@@ -567,7 +582,12 @@ async fn main() {
             open_settings_window_now(app, ctx_lookup());
         } else if want_library {
             open_library_window_now(app, ctx_lookup());
-        } else if secondary_activation || !runtime_config.data.background_sync_enabled {
+        } else if secondary_activation
+            || !ctx_early
+                .as_ref()
+                .map(|c| c.config.read().data.background_sync_enabled)
+                .unwrap_or(false)
+        {
             open_default_window(app, ctx_lookup());
         }
 
@@ -589,8 +609,8 @@ async fn main() {
         }
         let state = APP_CONTEXT
             .get()
-            .map(|ctx| ctx.state.lock().unwrap().clone())
-            .unwrap_or_else(|| shared_state.lock().unwrap().clone());
+            .map(|ctx| ctx.state.lock().clone())
+            .unwrap_or_else(|| shared_state.lock().clone());
         StateManager::new().write_state(state);
         log::info!("Mimick exiting");
     }
@@ -605,7 +625,7 @@ fn open_default_window(app: &adw::Application, ctx: Arc<AppContext>) {
         win.present();
         return;
     }
-    if Config::new().data.library_view_enabled {
+    if ctx.config.read().data.library_view_enabled {
         open_library_window_now(app, ctx);
     } else {
         open_settings_window_now(app, ctx);
@@ -626,7 +646,7 @@ fn open_library_window_now(app: &adw::Application, ctx: Arc<AppContext>) {
         win.present();
         return;
     }
-    if !Config::new().data.library_view_enabled {
+    if !ctx.config.read().data.library_view_enabled {
         log::info!("Library view is disabled in settings; opening Settings instead");
         open_settings_window_now(app, ctx);
         return;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -88,8 +88,9 @@ impl Monitor {
             // Track files that are currently waiting for size stability.
             // Prevents long-running records (like screencasts) from spawning
             // duplicate tasks every 2 seconds.
-            let active_tasks: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>> =
-                std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+            let active_tasks: std::sync::Arc<
+                parking_lot::Mutex<std::collections::HashSet<String>>,
+            > = std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new()));
 
             loop {
                 while let Ok(command) = command_rx.try_recv() {
@@ -145,7 +146,7 @@ impl Monitor {
                                 }
 
                                 // Bail immediately if we're already waiting on this file to finish.
-                                if active_tasks.lock().unwrap().contains(&path_str) {
+                                if active_tasks.lock().contains(&path_str) {
                                     continue;
                                 }
 
@@ -166,7 +167,7 @@ impl Monitor {
 
                                 log::info!("New file event: {}", path_str);
                                 debounce_map.insert(path_str.clone(), now);
-                                active_tasks.lock().unwrap().insert(path_str.clone());
+                                active_tasks.lock().insert(path_str.clone());
 
                                 let tx_clone = tx.clone();
                                 let active_clone = active_tasks.clone();
@@ -202,7 +203,7 @@ impl Monitor {
                                     }
 
                                     // Clear from active tasks so future modifications can be sensed.
-                                    active_clone.lock().unwrap().remove(&path_str);
+                                    active_clone.lock().remove(&path_str);
                                 });
                             }
                         }
@@ -378,9 +379,28 @@ mod tests {
     use super::{
         compute_sha1_chunked, is_flatpak_sandbox, is_supported_media_path, is_temporary_file,
     };
-    use std::io::Write;
+    use std::io::{BufReader, Read, Write};
     use std::path::Path;
     use tempfile::NamedTempFile;
+
+    /// Compute BLAKE3 in chunks. Prepared for Phase 1.5 when hashing switches
+    /// from SHA-1 to BLAKE3 for local content identity. Will be promoted to
+    /// `pub(crate)` once it replaces SHA-1 in the production path.
+    fn compute_blake3_chunked(path: &str) -> std::io::Result<String> {
+        const BUF_SIZE: usize = 65536;
+        let file = std::fs::File::open(path)?;
+        let mut reader = BufReader::with_capacity(BUF_SIZE, file);
+        let mut hasher = blake3::Hasher::new();
+        let mut buf = vec![0u8; BUF_SIZE];
+        loop {
+            let n = reader.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+        }
+        Ok(hasher.finalize().to_hex().to_string())
+    }
 
     #[test]
     fn test_compute_sha1_chunked() {
@@ -390,6 +410,17 @@ mod tests {
 
         let hash = compute_sha1_chunked(file.path().to_str().unwrap()).unwrap();
         assert_eq!(hash, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
+    }
+
+    #[test]
+    fn test_compute_blake3_chunked() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"hello world").unwrap();
+
+        let hash = compute_blake3_chunked(file.path().to_str().unwrap()).unwrap();
+        // Known BLAKE3 hash of "hello world"
+        let expected = blake3::hash(b"hello world").to_hex().to_string();
+        assert_eq!(hash, expected);
     }
 
     #[test]

--- a/src/queue_manager.rs
+++ b/src/queue_manager.rs
@@ -15,12 +15,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, mpsc};
 
 fn upload_progress_callback(
-    shared_state: &Arc<std::sync::Mutex<AppState>>,
+    shared_state: &Arc<parking_lot::Mutex<AppState>>,
     item_id: String,
 ) -> TransferProgressCallback {
     let state_ref = shared_state.clone();
     Arc::new(move |bytes_done, total_bytes| {
-        let mut state = state_ref.lock().unwrap();
+        let mut state = state_ref.lock();
         let route = state.active_server_route.clone();
         if let Some(total_bytes) = total_bytes {
             let current = state
@@ -60,18 +60,18 @@ pub struct FileTask {
 pub struct QueueManager {
     sender: mpsc::Sender<FileTask>,
     /// Shared in-memory state accessed by both workers and the UI.
-    shared_state: Arc<std::sync::Mutex<AppState>>,
+    shared_state: Arc<parking_lot::Mutex<AppState>>,
     /// Failed tasks accumulated in memory and flushed during graceful shutdown.
-    retry_list: Arc<std::sync::Mutex<Vec<FileTask>>>,
+    retry_list: Arc<parking_lot::Mutex<Vec<FileTask>>>,
     /// Paths already queued or awaiting retry.
     ///
     /// Prevents duplicate entries when the startup scan and live watcher both
     /// notice the same file in a short time window.
-    pending_paths: Arc<std::sync::Mutex<HashSet<String>>>,
+    pending_paths: Arc<parking_lot::Mutex<HashSet<String>>>,
     retry_path: PathBuf,
-    policy: Arc<std::sync::Mutex<EnvironmentPolicy>>,
+    policy: Arc<parking_lot::Mutex<EnvironmentPolicy>>,
     worker_limit: Arc<AtomicUsize>,
-    batch_notify_state: Arc<std::sync::Mutex<BatchNotifyState>>,
+    batch_notify_state: Arc<parking_lot::Mutex<BatchNotifyState>>,
 }
 
 #[derive(Debug, Default)]
@@ -98,8 +98,8 @@ impl QueueManager {
     pub fn new(
         api_client: Arc<ImmichApiClient>,
         workers: usize,
-        shared_state: Arc<std::sync::Mutex<AppState>>,
-        sync_index: Arc<std::sync::Mutex<SyncIndex>>,
+        shared_state: Arc<parking_lot::Mutex<AppState>>,
+        sync_index: Arc<parking_lot::Mutex<SyncIndex>>,
         policy: EnvironmentPolicy,
     ) -> Self {
         const MAX_WORKERS: usize = 10;
@@ -122,22 +122,22 @@ impl QueueManager {
                 loaded_retries.len()
             );
             let _ = fs::write(&retry_path, "[]");
-            shared_state.lock().unwrap().failed_count = loaded_retries.len();
+            shared_state.lock().failed_count = loaded_retries.len();
         }
 
         // Retry state stays in memory during the session to avoid per-failure disk writes.
-        let retry_list = Arc::new(std::sync::Mutex::new(Vec::<FileTask>::new()));
-        let pending_paths = Arc::new(std::sync::Mutex::new(
+        let retry_list = Arc::new(parking_lot::Mutex::new(Vec::<FileTask>::new()));
+        let pending_paths = Arc::new(parking_lot::Mutex::new(
             loaded_retries
                 .iter()
                 .map(|task| task.path.clone())
                 .collect(),
         ));
-        let policy_ref = Arc::new(std::sync::Mutex::new(policy));
+        let policy_ref = Arc::new(parking_lot::Mutex::new(policy));
         let worker_limit = Arc::new(AtomicUsize::new(workers.clamp(1, MAX_WORKERS)));
-        let batch_notify_state = Arc::new(std::sync::Mutex::new(BatchNotifyState::default()));
-        let connectivity_lost_notified = Arc::new(std::sync::Mutex::new(false));
-        let consecutive_failures = Arc::new(std::sync::Mutex::new(0usize));
+        let batch_notify_state = Arc::new(parking_lot::Mutex::new(BatchNotifyState::default()));
+        let connectivity_lost_notified = Arc::new(parking_lot::Mutex::new(false));
+        let consecutive_failures = Arc::new(parking_lot::Mutex::new(0usize));
 
         let qm = Self {
             sender: tx,
@@ -182,7 +182,7 @@ impl QueueManager {
 
                             // Update the shared progress snapshot before handing off to the API.
                             let (pc, tq) = {
-                                let mut s = state_ref.lock().unwrap();
+                                let mut s = state_ref.lock();
                                 s.active_workers += 1;
                                 s.status = "uploading".to_string();
                                 s.pause_reason = None;
@@ -235,10 +235,10 @@ impl QueueManager {
 
                             if success {
                                 log::info!("Upload SUCCESS: {} ({:.2}s)", file_task.path, elapsed);
-                                pending_ref.lock().unwrap().remove(&file_task.path);
+                                pending_ref.lock().remove(&file_task.path);
 
                                 if let Some(target) = sync_target.as_ref()
-                                    && let Err(err) = sync_index_ref.lock().unwrap().record_synced(
+                                    && let Err(err) = sync_index_ref.lock().record_synced(
                                         &file_task.path,
                                         &file_task.checksum,
                                         target,
@@ -253,7 +253,7 @@ impl QueueManager {
 
                                 // Drain retries and requeue them once connectivity is working again.
                                 let retries: Vec<FileTask> = {
-                                    let mut rl = retry_ref.lock().unwrap();
+                                    let mut rl = retry_ref.lock();
                                     std::mem::take(&mut *rl)
                                 };
                                 if !retries.is_empty() {
@@ -262,8 +262,8 @@ impl QueueManager {
                                         retries.len()
                                     );
                                     {
-                                        let mut s = state_ref.lock().unwrap();
-                                        let mut batch_state = batch_notify_ref.lock().unwrap();
+                                        let mut s = state_ref.lock();
+                                        let mut batch_state = batch_notify_ref.lock();
                                         activate_batch_if_needed(&mut batch_state, &s);
                                         s.failed_count =
                                             s.failed_count.saturating_sub(retries.len());
@@ -275,7 +275,7 @@ impl QueueManager {
                                     }
                                 }
 
-                                let mut s = state_ref.lock().unwrap();
+                                let mut s = state_ref.lock();
                                 let attempts = current_attempt_count(&s, &file_task.path);
                                 s.active_server_route = active_route;
                                 s.last_successful_sync_at = Some(unix_timestamp_now());
@@ -305,8 +305,8 @@ impl QueueManager {
                                     elapsed
                                 );
                                 // Keep failed tasks in memory until the next graceful shutdown.
-                                retry_ref.lock().unwrap().push(file_task.clone());
-                                let mut s = state_ref.lock().unwrap();
+                                retry_ref.lock().push(file_task.clone());
+                                let mut s = state_ref.lock();
                                 s.failed_count += 1;
                                 s.active_server_route = active_route;
                                 let error_text = latest_issue
@@ -344,13 +344,13 @@ impl QueueManager {
 
                             // Track consecutive failures for connectivity-lost detection.
                             if success {
-                                *consec_fail_ref.lock().unwrap() = 0;
+                                *consec_fail_ref.lock() = 0;
                             } else {
-                                let mut cf = consec_fail_ref.lock().unwrap();
+                                let mut cf = consec_fail_ref.lock();
                                 *cf += 1;
                                 // Fire connectivity-lost the first time N consecutive uploads fail.
                                 if *cf >= 3 {
-                                    let mut notified = connectivity_notified_ref.lock().unwrap();
+                                    let mut notified = connectivity_notified_ref.lock();
                                     if !*notified {
                                         *notified = true;
                                         notifications::send_connectivity_lost();
@@ -360,7 +360,7 @@ impl QueueManager {
 
                             // Update processed count and determine idle state.
                             let summary_batch = {
-                                let mut s = state_ref.lock().unwrap();
+                                let mut s = state_ref.lock();
                                 if success {
                                     s.processed_count += 1;
                                 }
@@ -388,7 +388,7 @@ impl QueueManager {
                                     };
                                     s.progress = 100;
                                     log::info!("All {} file(s) processed. Idle.", s.total_queued);
-                                    let mut batch_state = batch_notify_ref.lock().unwrap();
+                                    let mut batch_state = batch_notify_ref.lock();
                                     if batch_state.active
                                         && batch_state.current_batch_id
                                             != batch_state.last_notified_batch_id
@@ -421,8 +421,8 @@ impl QueueManager {
                                     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
                                     let summary = {
-                                        let s = state_ref.lock().unwrap();
-                                        let mut batch_state = batch_notify_ref.lock().unwrap();
+                                        let s = state_ref.lock();
+                                        let mut batch_state = batch_notify_ref.lock();
                                         let total_handled = s.processed_count + s.failed_count;
                                         let queue_idle = total_handled >= s.total_queued
                                             && s.active_workers == 0;
@@ -475,8 +475,8 @@ impl QueueManager {
             tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
             if !loaded_retries.is_empty() {
                 {
-                    let mut s = state_ref2.lock().unwrap();
-                    let mut batch_state = batch_notify_state.lock().unwrap();
+                    let mut s = state_ref2.lock();
+                    let mut batch_state = batch_notify_state.lock();
                     activate_batch_if_needed(&mut batch_state, &s);
                     // Retry items are now being actively queued — reset failed_count.
                     s.failed_count = 0;
@@ -496,7 +496,7 @@ impl QueueManager {
     pub async fn add_to_queue(&self, task: FileTask) -> bool {
         log::debug!("Queuing: {}", task.path);
         {
-            let mut pending = self.pending_paths.lock().unwrap();
+            let mut pending = self.pending_paths.lock();
             if pending.contains(&task.path) {
                 log::debug!("Skipping already pending task: {}", task.path);
                 return false;
@@ -505,8 +505,8 @@ impl QueueManager {
         }
 
         {
-            let mut s = self.shared_state.lock().unwrap();
-            let mut batch_state = self.batch_notify_state.lock().unwrap();
+            let mut s = self.shared_state.lock();
+            let mut batch_state = self.batch_notify_state.lock();
             activate_batch_if_needed(&mut batch_state, &s);
             s.total_queued += 1;
             s.queue_size = s.total_queued.saturating_sub(s.processed_count);
@@ -529,10 +529,10 @@ impl QueueManager {
         }
         if let Err(e) = self.sender.send(task).await {
             log::error!("Failed to send task to queue: {}", e);
-            self.pending_paths.lock().unwrap().remove(&e.0.path);
+            self.pending_paths.lock().remove(&e.0.path);
 
             // Revert the total_queued increment since it will never be processed.
-            let mut s = self.shared_state.lock().unwrap();
+            let mut s = self.shared_state.lock();
             s.total_queued = s.total_queued.saturating_sub(1);
             s.queue_size = s.total_queued.saturating_sub(s.processed_count);
             let route = s.active_server_route.clone();
@@ -551,7 +551,7 @@ impl QueueManager {
     }
 
     pub fn set_paused(&self, paused: bool, reason: Option<String>) {
-        let mut state = self.shared_state.lock().unwrap();
+        let mut state = self.shared_state.lock();
         state.paused = paused;
         state.pause_reason = reason;
         state.status = if paused {
@@ -564,7 +564,7 @@ impl QueueManager {
     }
 
     pub fn is_paused(&self) -> bool {
-        self.shared_state.lock().unwrap().paused
+        self.shared_state.lock().paused
     }
 
     pub fn set_worker_limit(&self, workers: u8) {
@@ -573,20 +573,20 @@ impl QueueManager {
     }
 
     pub fn update_environment_policy(&self, policy: EnvironmentPolicy) {
-        *self.policy.lock().unwrap() = policy;
+        *self.policy.lock() = policy;
     }
 
     pub fn recent_events(&self) -> Vec<crate::state_manager::QueueEvent> {
-        self.shared_state.lock().unwrap().recent_events.clone()
+        self.shared_state.lock().recent_events.clone()
     }
 
     pub fn failed_tasks(&self) -> Vec<FileTask> {
-        self.retry_list.lock().unwrap().clone()
+        self.retry_list.lock().clone()
     }
 
     pub fn clear_failed(&self) -> usize {
         let tasks = {
-            let mut retries = self.retry_list.lock().unwrap();
+            let mut retries = self.retry_list.lock();
             std::mem::take(&mut *retries)
         };
         if tasks.is_empty() {
@@ -594,13 +594,13 @@ impl QueueManager {
         }
 
         {
-            let mut pending = self.pending_paths.lock().unwrap();
+            let mut pending = self.pending_paths.lock();
             for task in &tasks {
                 pending.remove(&task.path);
             }
         }
 
-        let mut state = self.shared_state.lock().unwrap();
+        let mut state = self.shared_state.lock();
         state.failed_count = state.failed_count.saturating_sub(tasks.len());
         for task in &tasks {
             let attempts = current_attempt_count(&state, &task.path);
@@ -617,7 +617,7 @@ impl QueueManager {
 
     pub async fn retry_all_failed(&self) -> usize {
         let tasks = {
-            let mut retries = self.retry_list.lock().unwrap();
+            let mut retries = self.retry_list.lock();
             std::mem::take(&mut *retries)
         };
         self.requeue_failed(tasks, "Manual retry".to_string()).await
@@ -625,7 +625,7 @@ impl QueueManager {
 
     pub async fn retry_failed_path(&self, path: &str) -> bool {
         let task = {
-            let mut retries = self.retry_list.lock().unwrap();
+            let mut retries = self.retry_list.lock();
             let index = retries.iter().position(|task| task.path == path);
             index.map(|index| retries.remove(index))
         };
@@ -641,7 +641,7 @@ impl QueueManager {
 
     /// Persist any in-memory retry items so they survive a clean shutdown.
     pub fn flush_retries(&self) {
-        let retries = self.retry_list.lock().unwrap();
+        let retries = self.retry_list.lock();
         if !retries.is_empty() {
             save_retries(&self.retry_path, &retries);
             log::info!(
@@ -657,8 +657,8 @@ impl QueueManager {
         }
 
         {
-            let mut state = self.shared_state.lock().unwrap();
-            let mut batch_state = self.batch_notify_state.lock().unwrap();
+            let mut state = self.shared_state.lock();
+            let mut batch_state = self.batch_notify_state.lock();
             activate_batch_if_needed(&mut batch_state, &state);
             state.failed_count = state.failed_count.saturating_sub(tasks.len());
             state.total_queued += tasks.len();
@@ -730,13 +730,13 @@ fn is_quiet_hour(start: Option<u8>, end: Option<u8>) -> bool {
 }
 
 async fn wait_until_allowed(
-    state_ref: &Arc<std::sync::Mutex<AppState>>,
-    policy_ref: &Arc<std::sync::Mutex<EnvironmentPolicy>>,
+    state_ref: &Arc<parking_lot::Mutex<AppState>>,
+    policy_ref: &Arc<parking_lot::Mutex<EnvironmentPolicy>>,
 ) {
     loop {
-        let policy = *policy_ref.lock().unwrap();
+        let policy = *policy_ref.lock();
         let defer_reason = {
-            let state = state_ref.lock().unwrap();
+            let state = state_ref.lock();
             if state.paused {
                 Some(
                     state
@@ -757,7 +757,7 @@ async fn wait_until_allowed(
 
         if let Some(reason) = defer_reason {
             {
-                let mut state = state_ref.lock().unwrap();
+                let mut state = state_ref.lock();
                 state.status = "paused".to_string();
                 state.pause_reason = Some(reason);
             }
@@ -765,7 +765,7 @@ async fn wait_until_allowed(
             continue;
         }
 
-        let mut state = state_ref.lock().unwrap();
+        let mut state = state_ref.lock();
         if state.status == "paused" && !state.paused {
             state.status = "idle".to_string();
             state.pause_reason = None;
@@ -947,8 +947,9 @@ fn load_retries(path: &PathBuf) -> Vec<FileTask> {
 mod tests {
     use super::*;
     use crate::state_manager::AppState;
+    use parking_lot::Mutex;
     use std::collections::HashSet;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
     use tempfile::tempdir;
     use tokio::sync::mpsc;
 
@@ -1046,8 +1047,8 @@ mod tests {
 
         let queued = rx.recv().await.unwrap();
         assert_eq!(queued.path, task.path);
-        assert!(pending_paths.lock().unwrap().contains("/a/1.jpg"));
-        assert_eq!(shared_state.lock().unwrap().total_queued, 1);
+        assert!(pending_paths.lock().contains("/a/1.jpg"));
+        assert_eq!(shared_state.lock().total_queued, 1);
     }
 
     #[tokio::test]
@@ -1062,17 +1063,17 @@ mod tests {
             reassociate_only: false,
         };
 
-        retry_list.lock().unwrap().push(task.clone());
-        pending_paths.lock().unwrap().insert(task.path.clone());
-        shared_state.lock().unwrap().failed_count = 1;
+        retry_list.lock().push(task.clone());
+        pending_paths.lock().insert(task.path.clone());
+        shared_state.lock().failed_count = 1;
 
         assert!(qm.retry_failed_path(&task.path).await);
 
         let requeued = rx.recv().await.unwrap();
         assert_eq!(requeued.path, task.path);
-        assert!(retry_list.lock().unwrap().is_empty());
+        assert!(retry_list.lock().is_empty());
 
-        let state = shared_state.lock().unwrap();
+        let state = shared_state.lock();
         assert_eq!(state.failed_count, 0);
         assert_eq!(state.total_queued, 1);
         assert_eq!(state.recent_events[0].status, "pending");
@@ -1096,15 +1097,15 @@ mod tests {
             reassociate_only: false,
         };
 
-        retry_list.lock().unwrap().push(task.clone());
-        pending_paths.lock().unwrap().insert(task.path.clone());
-        shared_state.lock().unwrap().failed_count = 1;
+        retry_list.lock().push(task.clone());
+        pending_paths.lock().insert(task.path.clone());
+        shared_state.lock().failed_count = 1;
 
         assert_eq!(qm.clear_failed(), 1);
-        assert!(retry_list.lock().unwrap().is_empty());
-        assert!(!pending_paths.lock().unwrap().contains(&task.path));
+        assert!(retry_list.lock().is_empty());
+        assert!(!pending_paths.lock().contains(&task.path));
 
-        let state = shared_state.lock().unwrap();
+        let state = shared_state.lock();
         assert_eq!(state.failed_count, 0);
         assert_eq!(state.recent_events[0].status, "cleared");
     }

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -1,0 +1,133 @@
+//! Input sanitisation for file paths and URLs.
+//!
+//! Guards against:
+//! * Directory traversal in filenames originating from Immich API responses
+//! * Non-HTTP(S) URL schemes in user-provided server addresses
+
+use std::path::Path;
+
+/// Strip a filename to its final component and reject traversal attempts.
+///
+/// Returns `None` if the input is empty, contains only path separators, or
+/// resolves to `.` / `..` after extraction.
+///
+/// # Examples
+/// ```ignore
+/// assert_eq!(safe_filename("photo.jpg"), Some("photo.jpg".into()));
+/// assert_eq!(safe_filename("../../../etc/passwd"), Some("passwd".into()));
+/// assert_eq!(safe_filename("sub/dir/file.jpg"), Some("file.jpg".into()));
+/// ```
+pub fn safe_filename(name: &str) -> Option<String> {
+    let name = name.trim();
+    if name.is_empty() {
+        return None;
+    }
+
+    let p = Path::new(name);
+    let stem = p.file_name()?;
+    let s = stem.to_string_lossy();
+
+    // Reject hidden traversal through the file_name component itself.
+    if s == "." || s == ".." || s.is_empty() {
+        return None;
+    }
+
+    Some(s.into_owned())
+}
+
+/// Validate that a URL string uses an HTTP or HTTPS scheme.
+///
+/// Returns the parsed, normalised URL on success, or a human-readable error
+/// string suitable for display in the settings UI.
+pub fn validate_http_url(raw: &str) -> Result<url::Url, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("URL is empty".into());
+    }
+
+    let parsed = url::Url::parse(trimmed).map_err(|e| format!("Invalid URL: {}", e))?;
+
+    match parsed.scheme() {
+        "http" | "https" => Ok(parsed),
+        other => Err(format!(
+            "Unsupported URL scheme '{}'. Only http:// and https:// are allowed.",
+            other
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- safe_filename --
+
+    #[test]
+    fn safe_filename_extracts_basename() {
+        assert_eq!(safe_filename("photo.jpg"), Some("photo.jpg".into()));
+    }
+
+    #[test]
+    fn safe_filename_strips_directory_components() {
+        assert_eq!(safe_filename("sub/dir/file.jpg"), Some("file.jpg".into()));
+    }
+
+    #[test]
+    fn safe_filename_strips_traversal_to_basename() {
+        // The defense is that traversal components are stripped, leaving only
+        // the final filename component.
+        assert_eq!(safe_filename("../../../etc/passwd"), Some("passwd".into()));
+    }
+
+    #[test]
+    fn safe_filename_rejects_empty() {
+        assert_eq!(safe_filename(""), None);
+        assert_eq!(safe_filename("   "), None);
+    }
+
+    #[test]
+    fn safe_filename_rejects_dot_dot() {
+        assert_eq!(safe_filename(".."), None);
+        assert_eq!(safe_filename("."), None);
+    }
+
+    // -- validate_http_url --
+
+    #[test]
+    fn validate_accepts_https() {
+        let result = validate_http_url("https://immich.example.com");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().scheme(), "https");
+    }
+
+    #[test]
+    fn validate_accepts_http() {
+        let result = validate_http_url("http://192.168.1.1:2283");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_file_scheme() {
+        let result = validate_http_url("file:///etc/passwd");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("file"));
+    }
+
+    #[test]
+    fn validate_rejects_javascript_scheme() {
+        let result = validate_http_url("javascript:alert(1)");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty() {
+        assert!(validate_http_url("").is_err());
+        assert!(validate_http_url("  ").is_err());
+    }
+
+    #[test]
+    fn validate_trims_whitespace() {
+        let result = validate_http_url("  https://immich.local  ");
+        assert!(result.is_ok());
+    }
+}

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::app_context::AppContext;
-use crate::config::Config;
 use crate::queue_manager::QueueManager;
 use crate::watch_path_display::{display_watch_path, watch_path_subtitle};
 
@@ -82,6 +81,7 @@ pub fn build_settings_window_with_parent(
     let live_watch_paths = ctx.live_watch_paths.clone();
     let sync_now_tx = ctx.sync_now_tx.clone();
     let thumbnail_cache = ctx.thumbnail_cache.clone();
+    let shared_config = ctx.config.clone();
     // Use an application window with a Libadwaita header switcher and two pages.
     let mut window_builder = adw::ApplicationWindow::builder()
         .application(app)
@@ -145,7 +145,7 @@ pub fn build_settings_window_with_parent(
     );
 
     let app_clone = app.clone();
-    let config = Config::new();
+    let config = ctx.config.read().clone();
 
     let status_page = adw::PreferencesPage::builder()
         .title("Status")
@@ -603,24 +603,54 @@ pub fn build_settings_window_with_parent(
         background_sync_state,
         #[strong]
         apply_in_flight,
+        #[strong]
+        shared_config,
         move |include_connectivity: bool, show_success_ack: bool| {
             if apply_in_flight.get() {
                 return;
             }
             apply_in_flight.set(true);
 
-            let existing = Config::new();
-            let mut internal_url_enabled = existing.data.internal_url_enabled;
-            let mut external_url_enabled = existing.data.external_url_enabled;
-            let mut internal_url = existing.data.internal_url.clone();
-            let mut external_url = existing.data.external_url.clone();
-            let mut api_key = existing.get_api_key().unwrap_or_default();
+            let (
+                mut internal_url_enabled,
+                mut external_url_enabled,
+                mut internal_url,
+                mut external_url,
+                mut api_key,
+            ) = {
+                let existing = shared_config.read();
+                (
+                    existing.data.internal_url_enabled,
+                    existing.data.external_url_enabled,
+                    existing.data.internal_url.clone(),
+                    existing.data.external_url.clone(),
+                    existing.get_api_key().unwrap_or_default(),
+                )
+            };
             if include_connectivity {
                 internal_url_enabled = internal_switch.is_active();
                 external_url_enabled = external_switch.is_active();
                 internal_url = internal_entry.text().to_string();
                 external_url = external_entry.text().to_string();
                 api_key = api_key_entry.text().to_string();
+
+                // Reject non-HTTP(S) URL schemes before persisting.
+                if internal_url_enabled
+                    && !internal_url.trim().is_empty()
+                    && let Err(err) = crate::sanitize::validate_http_url(&internal_url)
+                {
+                    show_alert(&window, "Invalid Internal URL", &err);
+                    apply_in_flight.set(false);
+                    return;
+                }
+                if external_url_enabled
+                    && !external_url.trim().is_empty()
+                    && let Err(err) = crate::sanitize::validate_http_url(&external_url)
+                {
+                    show_alert(&window, "Invalid External URL", &err);
+                    apply_in_flight.set(false);
+                    return;
+                }
             }
             let run_on_startup = startup_row.is_active();
             let pause_on_metered_network = metered_row.is_active();
@@ -712,6 +742,8 @@ pub fn build_settings_window_with_parent(
                 background_sync_state,
                 #[strong]
                 apply_in_flight,
+                #[strong]
+                shared_config,
                 async move {
                     if run_on_startup != previous_startup {
                         match autostart::apply(&window, run_on_startup).await {
@@ -737,49 +769,51 @@ pub fn build_settings_window_with_parent(
                         }
                     }
 
-                    let mut new_config = Config::new();
-                    new_config.data.internal_url_enabled = internal_url_enabled;
-                    new_config.data.external_url_enabled = external_url_enabled;
-                    new_config.data.internal_url = internal_url;
-                    new_config.data.external_url = external_url;
-                    new_config.data.watch_paths = watch_paths.clone();
-                    new_config.data.run_on_startup = run_on_startup;
-                    new_config.data.background_sync_enabled = background_sync_enabled;
-                    new_config.data.pause_on_metered_network = pause_on_metered_network;
-                    new_config.data.pause_on_battery_power = pause_on_battery_power;
-                    new_config.data.notifications_enabled = notifications_enabled;
-                    new_config.data.library_view_enabled = library_view_enabled;
-                    new_config.data.library_preview_full_resolution =
-                        library_preview_full_resolution;
-                    new_config.data.library_thumbnail_cache_mb = library_thumbnail_cache_mb;
-                    new_config.data.startup_catchup_mode = catchup_mode;
-                    new_config.data.upload_concurrency = upload_concurrency;
-                    new_config.data.quiet_hours_start = quiet_hours_start;
-                    new_config.data.quiet_hours_end = quiet_hours_end;
-
-                    if include_connectivity
-                        && !api_key.is_empty()
-                        && !new_config.set_api_key(&api_key)
                     {
-                        apply_in_flight.set(false);
+                        let mut new_config = shared_config.write();
+                        new_config.data.internal_url_enabled = internal_url_enabled;
+                        new_config.data.external_url_enabled = external_url_enabled;
+                        new_config.data.internal_url = internal_url;
+                        new_config.data.external_url = external_url;
+                        new_config.data.watch_paths = watch_paths.clone();
+                        new_config.data.run_on_startup = run_on_startup;
+                        new_config.data.background_sync_enabled = background_sync_enabled;
+                        new_config.data.pause_on_metered_network = pause_on_metered_network;
+                        new_config.data.pause_on_battery_power = pause_on_battery_power;
+                        new_config.data.notifications_enabled = notifications_enabled;
+                        new_config.data.library_view_enabled = library_view_enabled;
+                        new_config.data.library_preview_full_resolution =
+                            library_preview_full_resolution;
+                        new_config.data.library_thumbnail_cache_mb = library_thumbnail_cache_mb;
+                        new_config.data.startup_catchup_mode = catchup_mode;
+                        new_config.data.upload_concurrency = upload_concurrency;
+                        new_config.data.quiet_hours_start = quiet_hours_start;
+                        new_config.data.quiet_hours_end = quiet_hours_end;
 
-                        show_alert(
-                            &window,
-                            "Could Not Save API Key",
-                            "Mimick could not store the API key in your desktop keyring.",
-                        );
-                        return;
-                    }
+                        if include_connectivity
+                            && !api_key.is_empty()
+                            && !new_config.set_api_key(&api_key)
+                        {
+                            apply_in_flight.set(false);
 
-                    if !new_config.save() {
-                        apply_in_flight.set(false);
+                            show_alert(
+                                &window,
+                                "Could Not Save API Key",
+                                "Mimick could not store the API key in your desktop keyring.",
+                            );
+                            return;
+                        }
 
-                        show_alert(
-                            &window,
-                            "Could Not Save Settings",
-                            "Mimick could not write the updated configuration to disk.",
-                        );
-                        return;
+                        if !new_config.save() {
+                            apply_in_flight.set(false);
+
+                            show_alert(
+                                &window,
+                                "Could Not Save Settings",
+                                "Mimick could not write the updated configuration to disk.",
+                            );
+                            return;
+                        }
                     }
 
                     *startup_state.borrow_mut() = run_on_startup;
@@ -817,7 +851,7 @@ pub fn build_settings_window_with_parent(
                     crate::notifications::set_enabled(notifications_enabled);
 
                     if previous_background_sync != background_sync_enabled {
-                        let mut state = shared_state.lock().unwrap();
+                        let mut state = shared_state.lock();
                         if !background_sync_enabled && state.status != "uploading" && !state.paused
                         {
                             state.status = "idle".to_string();
@@ -832,7 +866,7 @@ pub fn build_settings_window_with_parent(
                     };
                     monitor_handle.replace_watch_paths(monitor_paths, background_sync_enabled);
 
-                    *live_watch_paths.lock().unwrap() = watch_paths.clone();
+                    *live_watch_paths.lock() = watch_paths.clone();
 
                     if background_sync_enabled
                         && previous_background_sync != background_sync_enabled
@@ -841,7 +875,7 @@ pub fn build_settings_window_with_parent(
                     }
 
                     {
-                        let mut state = shared_state.lock().unwrap();
+                        let mut state = shared_state.lock();
                         state.watched_folder_count = watch_paths.len();
                         let current_paths = watch_paths
                             .iter()
@@ -1066,11 +1100,14 @@ pub fn build_settings_window_with_parent(
         window,
         #[strong]
         shared_state,
+        #[strong]
+        shared_config,
         move |_| {
             let dialog = FileDialog::builder()
                 .title("Choose Diagnostics Export Folder")
                 .build();
             let state = shared_state.clone();
+            let config_ref = shared_config.clone();
             dialog.select_folder(
                 Some(&window),
                 gtk::gio::Cancellable::NONE,
@@ -1081,13 +1118,18 @@ pub fn build_settings_window_with_parent(
                         if let Ok(folder) = res
                             && let Some(path) = folder.path()
                         {
-                            let state_snapshot = state.lock().unwrap().clone();
+                            let state_snapshot = state.lock().clone();
+                            let config_snapshot = config_ref.read().clone();
                             glib::MainContext::default().spawn_local(clone!(
                                 #[weak]
                                 window,
                                 async move {
                                     let export_result = tokio::task::spawn_blocking(move || {
-                                        diagnostics::export_bundle(&path, &state_snapshot)
+                                        diagnostics::export_bundle(
+                                            &path,
+                                            &state_snapshot,
+                                            &config_snapshot,
+                                        )
                                     })
                                     .await;
 
@@ -1363,7 +1405,7 @@ pub fn build_settings_window_with_parent(
                     last_error_guidance,
                     folder_subtitles,
                 ) = {
-                    let s = shared_state.lock().unwrap();
+                    let s = shared_state.lock();
                     let folder_subtitles = tracked_rows
                         .borrow()
                         .iter()

--- a/src/startup_scan.rs
+++ b/src/startup_scan.rs
@@ -7,9 +7,10 @@ use crate::monitor::{compute_sha1_chunked, is_supported_media_path, is_temporary
 use crate::queue_manager::{FileTask, QueueManager};
 use crate::state_manager::AppState;
 use crate::sync_index::{SyncDecision, SyncIndex, SyncTarget};
+use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 /// Scans watch folders at startup and queues new, changed, or retargeted files for upload.
 pub async fn queue_unsynced_files(
@@ -38,7 +39,7 @@ pub async fn queue_unsynced_files(
                 "Startup scan skipped missing watch path: {}",
                 root.display()
             );
-            if let Ok(mut state) = shared_state.lock() {
+            if let Some(mut state) = shared_state.try_lock() {
                 let status = state.folder_statuses.entry(watch_path_str).or_default();
                 status.last_error = Some("Permission lost or folder missing".to_string());
             }
@@ -88,7 +89,6 @@ pub async fn queue_unsynced_files(
                         } else if catchup_mode == StartupCatchupMode::NewFilesOnly {
                             let last_sync = shared_state
                                 .lock()
-                                .unwrap()
                                 .last_successful_sync_at
                                 .unwrap_or_default();
 
@@ -132,19 +132,18 @@ pub async fn queue_unsynced_files(
                             album_id: existing_album_id.clone(),
                         };
 
-                        let decision =
-                            match sync_index.lock().unwrap().sync_decision(&path, &target) {
-                                Ok(decision) => decision,
-                                Err(err) => {
-                                    scan_errors += 1;
-                                    log::warn!(
-                                        "Startup scan could not inspect '{}': {}",
-                                        path.display(),
-                                        err
-                                    );
-                                    continue;
-                                }
-                            };
+                        let decision = match sync_index.lock().sync_decision(&path, &target) {
+                            Ok(decision) => decision,
+                            Err(err) => {
+                                scan_errors += 1;
+                                log::warn!(
+                                    "Startup scan could not inspect '{}': {}",
+                                    path.display(),
+                                    err
+                                );
+                                continue;
+                            }
+                        };
 
                         match decision {
                             SyncDecision::UpToDate => {
@@ -204,8 +203,7 @@ pub async fn queue_unsynced_files(
                                         continue;
                                     }
                                 };
-                                let checksum =
-                                    sync_index.lock().unwrap().stored_checksum(&path_str);
+                                let checksum = sync_index.lock().stored_checksum(&path_str);
                                 match queue_scan_candidate(
                                     &queue_manager,
                                     path_str,
@@ -233,7 +231,7 @@ pub async fn queue_unsynced_files(
         }
     }
 
-    if let Err(err) = sync_index.lock().unwrap().prune_missing(&seen_paths) {
+    if let Err(err) = sync_index.lock().prune_missing(&seen_paths) {
         log::warn!("Failed to prune sync index after startup scan: {}", err);
     }
 

--- a/src/sync_index.rs
+++ b/src/sync_index.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::UNIX_EPOCH;
 
 /// Represents a record stored on disk for a synced file, including the last associated album target.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -168,25 +168,11 @@ impl SyncIndex {
     }
 
     fn save(&self) -> io::Result<()> {
-        if let Some(parent) = self.index_file.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
         let content = serde_json::to_string_pretty(&SyncIndexDataRef {
             files: &self.entries,
         })?;
 
-        let tmp_file = self.index_file.with_extension(format!(
-            "tmp.{}",
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        ));
-
-        fs::write(&tmp_file, content)?;
-        fs::rename(&tmp_file, &self.index_file)?;
-        Ok(())
+        crate::util::atomic_write(&self.index_file, content.as_bytes())
     }
 }
 

--- a/src/tray_icon.rs
+++ b/src/tray_icon.rs
@@ -17,6 +17,8 @@ pub struct MimickTray {
     pub pause_tx: watch::Sender<bool>,
     /// Sender used to request an immediate catch-up scan.
     pub sync_now_tx: watch::Sender<bool>,
+    /// Cached from `Config` at tray construction to avoid disk I/O per menu open.
+    pub library_view_enabled: bool,
 }
 
 impl ksni::Tray for MimickTray {
@@ -34,7 +36,7 @@ impl ksni::Tray for MimickTray {
 
     fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
         use ksni::menu::*;
-        let library_enabled = crate::config::Config::new().data.library_view_enabled;
+        let library_enabled = self.library_view_enabled;
         let mut items: Vec<ksni::MenuItem<Self>> = Vec::new();
         if library_enabled {
             items.push(
@@ -98,7 +100,7 @@ pub struct TrayHandles {
     pub sync_now_rx: watch::Receiver<bool>,
 }
 
-pub async fn build_tray() -> Result<TrayHandles, ksni::Error> {
+pub async fn build_tray(library_view_enabled: bool) -> Result<TrayHandles, ksni::Error> {
     let (settings_tx, settings_rx) = watch::channel(false);
     let (library_tx, library_rx) = watch::channel(false);
     let (quit_tx, quit_rx) = watch::channel(false);
@@ -110,6 +112,7 @@ pub async fn build_tray() -> Result<TrayHandles, ksni::Error> {
         quit_tx,
         pause_tx,
         sync_now_tx,
+        library_view_enabled,
     };
     let handle = if ashpd::is_sandboxed() {
         // Flatpak sessions already broker the item through the watcher, so we avoid owning

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,73 @@
+//! Shared filesystem and I/O utilities.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Atomically replace the contents of `path` with `content`.
+///
+/// Writes to a temporary sibling file first, then renames it into place.
+/// On POSIX systems `rename(2)` is atomic within the same filesystem, so
+/// readers will either see the old content or the new content -- never a
+/// partially written file.
+pub fn atomic_write(path: &Path, content: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let tmp = path.with_extension(format!("tmp.{}", nonce));
+
+    if let Err(err) = fs::write(&tmp, content) {
+        // Best-effort cleanup; the tmp file may not exist yet.
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
+
+    if let Err(err) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn atomic_write_creates_file_and_parent_dirs() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("sub").join("deep").join("config.json");
+        atomic_write(&target, b"{\"ok\": true}").unwrap();
+        assert_eq!(fs::read_to_string(&target).unwrap(), "{\"ok\": true}");
+    }
+
+    #[test]
+    fn atomic_write_replaces_existing_content() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("data.json");
+        fs::write(&target, b"old").unwrap();
+        atomic_write(&target, b"new").unwrap();
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
+    }
+
+    #[test]
+    fn atomic_write_leaves_no_temp_files() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("clean.json");
+        atomic_write(&target, b"data").unwrap();
+        let siblings: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(siblings.len(), 1);
+        assert_eq!(siblings[0].file_name().to_string_lossy(), "clean.json");
+    }
+}


### PR DESCRIPTION
Security:
- Add sanitize module with safe_filename() and validate_http_url()
- Wire safe_filename into all download paths (album sync, library open-in cache, video handoff, bulk downloads) to prevent directory traversal via filenames received from the Immich API
- Enforce http/https URL scheme validation on server URL inputs in settings to reject file:// and other dangerous URI schemes

Utilities:
- Add util module with atomic_write() for crash-safe file persistence
- Adopt parking_lot for all non-async locking (Mutex, RwLock) replacing std::sync equivalents across api_client, queue_manager, sync_index, thumbnail_cache, startup_scan, and library modules

Config centralization:
- Add Arc<RwLock<Config>> to AppContext so all code reads/writes config through a shared lock instead of re-reading JSON from disk
- Eliminate 15 redundant Config::new() calls across main.rs, settings_window.rs, library/mod.rs, diagnostics.rs, and tray_icon.rs
- Derive Clone for Config to support snapshot reads
- Scope all write locks in blocks that drop before any .await points to satisfy clippy::await_holding_lock

Dead code cleanup:
- Remove unused cache_subdir and compute_content_hash helpers
- Move compute_blake3_chunked to test-only scope
- Remove dead delete_album method and AlbumDelete request context variant
- Remove unused orientation field from ExifInfo, trim AssetDetails to only the exif_info field actually consumed
- Remove dead load_local_thumbnail convenience wrapper
- Remove unused size field from LocalAsset, move synthetic_id to tests
- Fix clippy::collapsible_if instances in settings_window
- Zero #[allow(dead_code)] annotations remaining