### PR TITLE
Implement custom ListModel, sliding window cap, and prefetch tuning

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -121,6 +121,15 @@ pub struct MetadataSearchFilters {
     pub person_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tag_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order: Option<SortOrder>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    Asc,
+    Desc,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, PartialEq)]
@@ -1027,12 +1036,21 @@ impl ImmichApiClient {
         album_id: &str,
         page: u32,
         size: u32,
+        order: Option<SortOrder>,
     ) -> Result<Vec<LibraryAsset>, String> {
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "albumIds": [album_id],
             "page": page,
             "size": size.max(1),
         });
+        if let Some(order) = order
+            && let Some(obj) = body.as_object_mut()
+        {
+            obj.insert(
+                "order".into(),
+                serde_json::to_value(order).unwrap_or(serde_json::Value::Null),
+            );
+        }
         self.fetch_search_assets(
             "/api/search/metadata",
             body,
@@ -1358,12 +1376,21 @@ impl ImmichApiClient {
         query: &str,
         page: u32,
         size: u32,
+        order: Option<SortOrder>,
     ) -> Result<Vec<LibraryAsset>, String> {
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "ocr": query,
             "page": page,
             "size": size.max(1),
         });
+        if let Some(order) = order
+            && let Some(obj) = body.as_object_mut()
+        {
+            obj.insert(
+                "order".into(),
+                serde_json::to_value(order).unwrap_or(serde_json::Value::Null),
+            );
+        }
         self.fetch_search_assets(
             "/api/search/metadata",
             body,
@@ -1378,9 +1405,11 @@ impl ImmichApiClient {
         query: &str,
         page: u32,
         size: u32,
+        order: Option<SortOrder>,
     ) -> Result<Vec<LibraryAsset>, String> {
         let filters = MetadataSearchFilters {
             original_file_name: Some(query.to_string()),
+            order,
             ..Default::default()
         };
         self.search_metadata_with_filters(&filters, page, size)

--- a/src/assets/mimick.gresource.xml
+++ b/src/assets/mimick.gresource.xml
@@ -7,5 +7,17 @@
     <file alias="scalable/actions/mimick-download-symbolic.svg"
           compressed="true"
           preprocess="xml-stripblanks">scalable/actions/mimick-download-symbolic.svg</file>
+    <file alias="scalable/actions/mimick-cloud-symbolic.svg"
+          compressed="true"
+          preprocess="xml-stripblanks">scalable/actions/mimick-cloud-symbolic.svg</file>
+    <file alias="scalable/actions/mimick-computer-symbolic.svg"
+          compressed="true"
+          preprocess="xml-stripblanks">scalable/actions/mimick-computer-symbolic.svg</file>
+    <file alias="scalable/actions/mimick-check-circle-symbolic.svg"
+          compressed="true"
+          preprocess="xml-stripblanks">scalable/actions/mimick-check-circle-symbolic.svg</file>
+    <file alias="scalable/actions/mimick-video-symbolic.svg"
+          compressed="true"
+          preprocess="xml-stripblanks">scalable/actions/mimick-video-symbolic.svg</file>
   </gresource>
 </gresources>

--- a/src/assets/scalable/actions/mimick-check-circle-symbolic.svg
+++ b/src/assets/scalable/actions/mimick-check-circle-symbolic.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <circle fill="none" stroke="currentColor" stroke-width="1.4" cx="8" cy="8" r="6.1"/>
+  <path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M5 8.2 L7.2 10.4 L11 6.4"/>
+</svg>

--- a/src/assets/scalable/actions/mimick-cloud-symbolic.svg
+++ b/src/assets/scalable/actions/mimick-cloud-symbolic.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" stroke-linecap="round" d="M4.2 12.5 H11.5 A2.7 2.7 0 0 0 12.2 7.2 A3.5 3.5 0 0 0 5.4 6.4 A2.6 2.6 0 0 0 4.2 12.5 Z"/>
+</svg>

--- a/src/assets/scalable/actions/mimick-computer-symbolic.svg
+++ b/src/assets/scalable/actions/mimick-computer-symbolic.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" x="2" y="3" width="12" height="8" rx="1.2"/>
+  <rect fill="currentColor" x="5" y="13" width="6" height="1.2" rx="0.6"/>
+</svg>

--- a/src/assets/scalable/actions/mimick-video-symbolic.svg
+++ b/src/assets/scalable/actions/mimick-video-symbolic.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect fill="currentColor" x="1.5" y="4" width="9" height="8" rx="1.4"/>
+  <path fill="currentColor" d="M11 6.4 L14.5 4.5 V11.5 L11 9.6 Z"/>
+</svg>

--- a/src/library/album_sync.rs
+++ b/src/library/album_sync.rs
@@ -34,7 +34,7 @@ pub async fn diff_album_vs_folder(
     loop {
         let chunk = ctx
             .api_client
-            .fetch_album_assets(album_id, page, 1000)
+            .fetch_album_assets(album_id, page, 1000, None)
             .await?;
         let len = chunk.len();
         remote.extend(chunk);

--- a/src/library/asset_model.rs
+++ b/src/library/asset_model.rs
@@ -1,9 +1,10 @@
 //! Custom `gio::ListModel` backing the library grid.
 //!
 //! Replaces the previous `gio::ListStore`-of-`AssetObject` mirror. The model
-//! owns a `Vec<AssetObject>` reconciled from `LibraryState.assets` (which is
-//! itself capped at `WINDOW_CAP` via FIFO eviction). On each apply we emit a
-//! single `items_changed(0, prev_n, new_n)` reset.
+//! owns a `Vec<AssetObject>` reconciled from `LibraryState.assets`.
+//! `extend` is used for append-pagination (server-side date sort lets us emit
+//! a precise `items_changed(prev_n, 0, added)` so the visible viewport doesn't
+//! rebind); `reset` is used for source switches and client-side re-sorts.
 
 use std::cell::RefCell;
 
@@ -15,7 +16,7 @@ use gtk::subclass::prelude::*;
 use crate::api_client::LibraryAsset;
 use crate::app_context::AppContext;
 use crate::library::asset_object::AssetObject;
-use crate::library::state::{LibrarySortMode, PageMutation};
+use crate::library::state::LibrarySortMode;
 
 mod imp {
     use super::*;
@@ -68,22 +69,9 @@ impl LibraryAssetModel {
         glib::Object::new()
     }
 
-    /// Replace the model's items with `AssetObject`s built from `assets`,
-    /// apply the visual sort, and emit `items_changed(0, prev_n, new_n)`.
-    pub fn apply(
-        &self,
-        ctx: &AppContext,
-        assets: &[LibraryAsset],
-        sort_mode: &LibrarySortMode,
-        mutation: PageMutation,
-    ) {
-        let new_items = build_sorted_asset_objects(assets, ctx, sort_mode);
-        *self.imp().items.borrow_mut() = new_items;
-        self.items_changed(0, mutation.prev_n as u32, mutation.new_n as u32);
-    }
-
-    /// Replace items wholesale (used for client-side sort changes that don't
-    /// produce a `PageMutation`). Emits a `items_changed(0, prev, new)` reset.
+    /// Replace all items and emit a `items_changed(0, prev, new)` reset.
+    /// Use when the caller can't promise that existing positions are stable
+    /// (source switch, client-side sort change, dedup that affected the head).
     pub fn reset(&self, ctx: &AppContext, assets: &[LibraryAsset], sort_mode: &LibrarySortMode) {
         let prev_n = self.imp().items.borrow().len() as u32;
         let new_items = build_sorted_asset_objects(assets, ctx, sort_mode);
@@ -92,25 +80,30 @@ impl LibraryAssetModel {
         self.items_changed(0, prev_n, new_n);
     }
 
-    /// Returns the asset id at `position`, if any. Used by handlers that need
-    /// position-keyed lookups without going through GObject property access.
-    pub fn id_at(&self, position: u32) -> Option<String> {
-        self.imp()
-            .items
-            .borrow()
-            .get(position as usize)
-            .map(|o| o.property::<String>("id"))
-    }
+    /// Append-style update for paginated loads. For server-side date sort
+    /// (`NewestFirst`/`OldestFirst`) the existing positions are stable so we
+    /// emit a precise tail-only `items_changed(prev_n, 0, added)`. For
+    /// client-side sort modes the entire vec may have re-ordered, so we fall
+    /// back to a full reset.
+    pub fn extend(&self, ctx: &AppContext, assets: &[LibraryAsset], sort_mode: &LibrarySortMode) {
+        let prev_n = self.imp().items.borrow().len() as u32;
+        let new_items = build_sorted_asset_objects(assets, ctx, sort_mode);
+        let new_n = new_items.len() as u32;
+        let server_sorted = matches!(
+            sort_mode,
+            LibrarySortMode::NewestFirst | LibrarySortMode::OldestFirst
+        );
 
-    /// Snapshot the asset-id for every loaded position. Useful for the
-    /// timeline scrubber and other consumers that previously indexed
-    /// `LibraryState.assets`.
-    pub fn created_at_at(&self, position: u32) -> Option<String> {
-        self.imp()
-            .items
-            .borrow()
-            .get(position as usize)
-            .map(|o| o.property::<String>("created-at"))
+        *self.imp().items.borrow_mut() = new_items;
+
+        if server_sorted && new_n >= prev_n {
+            let added = new_n - prev_n;
+            if added > 0 {
+                self.items_changed(prev_n, 0, added);
+            }
+        } else {
+            self.items_changed(0, prev_n, new_n);
+        }
     }
 }
 
@@ -121,10 +114,6 @@ fn build_sorted_asset_objects(
 ) -> Vec<AssetObject> {
     let mut items = build_asset_objects(assets, ctx);
     match sort_mode {
-        // Server-side date sort: state.assets is already in server order; no
-        // client-side reorder. (This applies to `LocalAll`/`AlbumLocal` too —
-        // those sources only ever emit one synthetic page so insertion order
-        // matches the local enumeration.)
         LibrarySortMode::NewestFirst | LibrarySortMode::OldestFirst => {}
         LibrarySortMode::Filename => items.sort_by_cached_key(|o| {
             (

--- a/src/library/asset_model.rs
+++ b/src/library/asset_model.rs
@@ -1,0 +1,191 @@
+//! Custom `gio::ListModel` backing the library grid.
+//!
+//! Replaces the previous `gio::ListStore`-of-`AssetObject` mirror. The model
+//! owns a `Vec<AssetObject>` reconciled from `LibraryState.assets` (which is
+//! itself capped at `WINDOW_CAP` via FIFO eviction). On each apply we emit a
+//! single `items_changed(0, prev_n, new_n)` reset.
+
+use std::cell::RefCell;
+
+use gtk::gio;
+use gtk::glib;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+
+use crate::api_client::LibraryAsset;
+use crate::app_context::AppContext;
+use crate::library::asset_object::AssetObject;
+use crate::library::state::{LibrarySortMode, PageMutation};
+
+mod imp {
+    use super::*;
+    use gio::subclass::prelude::ListModelImpl;
+
+    #[derive(Default)]
+    pub struct LibraryAssetModel {
+        pub items: RefCell<Vec<AssetObject>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for LibraryAssetModel {
+        const NAME: &'static str = "MimickLibraryAssetModel";
+        type Type = super::LibraryAssetModel;
+        type Interfaces = (gio::ListModel,);
+    }
+
+    impl ObjectImpl for LibraryAssetModel {}
+
+    impl ListModelImpl for LibraryAssetModel {
+        fn item_type(&self) -> glib::Type {
+            AssetObject::static_type()
+        }
+
+        fn n_items(&self) -> u32 {
+            self.items.borrow().len() as u32
+        }
+
+        fn item(&self, position: u32) -> Option<glib::Object> {
+            self.items
+                .borrow()
+                .get(position as usize)
+                .map(|o| o.clone().upcast())
+        }
+    }
+}
+
+glib::wrapper! {
+    pub struct LibraryAssetModel(ObjectSubclass<imp::LibraryAssetModel>) @implements gio::ListModel;
+}
+
+impl Default for LibraryAssetModel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LibraryAssetModel {
+    pub fn new() -> Self {
+        glib::Object::new()
+    }
+
+    /// Replace the model's items with `AssetObject`s built from `assets`,
+    /// apply the visual sort, and emit `items_changed(0, prev_n, new_n)`.
+    pub fn apply(
+        &self,
+        ctx: &AppContext,
+        assets: &[LibraryAsset],
+        sort_mode: &LibrarySortMode,
+        mutation: PageMutation,
+    ) {
+        let new_items = build_sorted_asset_objects(assets, ctx, sort_mode);
+        *self.imp().items.borrow_mut() = new_items;
+        self.items_changed(0, mutation.prev_n as u32, mutation.new_n as u32);
+    }
+
+    /// Replace items wholesale (used for client-side sort changes that don't
+    /// produce a `PageMutation`). Emits a `items_changed(0, prev, new)` reset.
+    pub fn reset(&self, ctx: &AppContext, assets: &[LibraryAsset], sort_mode: &LibrarySortMode) {
+        let prev_n = self.imp().items.borrow().len() as u32;
+        let new_items = build_sorted_asset_objects(assets, ctx, sort_mode);
+        let new_n = new_items.len() as u32;
+        *self.imp().items.borrow_mut() = new_items;
+        self.items_changed(0, prev_n, new_n);
+    }
+
+    /// Returns the asset id at `position`, if any. Used by handlers that need
+    /// position-keyed lookups without going through GObject property access.
+    pub fn id_at(&self, position: u32) -> Option<String> {
+        self.imp()
+            .items
+            .borrow()
+            .get(position as usize)
+            .map(|o| o.property::<String>("id"))
+    }
+
+    /// Snapshot the asset-id for every loaded position. Useful for the
+    /// timeline scrubber and other consumers that previously indexed
+    /// `LibraryState.assets`.
+    pub fn created_at_at(&self, position: u32) -> Option<String> {
+        self.imp()
+            .items
+            .borrow()
+            .get(position as usize)
+            .map(|o| o.property::<String>("created-at"))
+    }
+}
+
+fn build_sorted_asset_objects(
+    assets: &[LibraryAsset],
+    ctx: &AppContext,
+    sort_mode: &LibrarySortMode,
+) -> Vec<AssetObject> {
+    let mut items = build_asset_objects(assets, ctx);
+    match sort_mode {
+        // Server-side date sort: state.assets is already in server order; no
+        // client-side reorder. (This applies to `LocalAll`/`AlbumLocal` too —
+        // those sources only ever emit one synthetic page so insertion order
+        // matches the local enumeration.)
+        LibrarySortMode::NewestFirst | LibrarySortMode::OldestFirst => {}
+        LibrarySortMode::Filename => items.sort_by_cached_key(|o| {
+            (
+                o.property::<String>("filename").to_ascii_lowercase(),
+                o.property::<String>("id"),
+            )
+        }),
+        LibrarySortMode::FileType => items.sort_by_cached_key(|o| {
+            (
+                o.property::<String>("mime-type"),
+                o.property::<String>("filename"),
+                o.property::<String>("id"),
+            )
+        }),
+    }
+    items
+}
+
+fn build_asset_objects(assets: &[LibraryAsset], ctx: &AppContext) -> Vec<AssetObject> {
+    use super::{LOCAL_ID_PREFIX, immich_checksum_to_hex};
+    use crate::library::local_source::local_sync_state;
+
+    assets
+        .iter()
+        .map(|asset| {
+            if let Some(local_path) = asset.id.strip_prefix(LOCAL_ID_PREFIX) {
+                let sync_state =
+                    local_sync_state(&ctx.sync_index, std::path::Path::new(local_path));
+                let object = AssetObject::new_local(
+                    &asset.id,
+                    &asset.filename,
+                    &asset.mime_type,
+                    &asset.created_at,
+                    &asset.asset_type,
+                    local_path,
+                );
+                if sync_state != 1 {
+                    object.set_property("sync-state", sync_state);
+                }
+                return object;
+            }
+            let local_match = asset
+                .checksum
+                .as_deref()
+                .and_then(immich_checksum_to_hex)
+                .as_deref()
+                .and_then(|hex| ctx.sync_index.local_path_for_checksum(hex));
+            let sync_state = if local_match.is_some() { 2 } else { 0 };
+            let object = AssetObject::new(
+                &asset.id,
+                &asset.filename,
+                &asset.mime_type,
+                &asset.created_at,
+                &asset.asset_type,
+                sync_state,
+                asset.thumbhash.as_deref(),
+            );
+            if let Some(path) = local_match {
+                object.set_property("local-path", path);
+            }
+            object
+        })
+        .collect()
+}

--- a/src/library/grid_view.rs
+++ b/src/library/grid_view.rs
@@ -113,10 +113,10 @@ pub fn build_grid_view(ctx: Arc<AppContext>, select_toggle: gtk::ToggleButton) -
             .css_classes(vec!["mimick-status-badge".to_string()])
             .build();
         let video_badge = gtk::Image::builder()
-            .icon_name("media-playback-start-symbolic")
+            .icon_name("mimick-video-symbolic")
             .halign(gtk::Align::Center)
             .valign(gtk::Align::Center)
-            .pixel_size(28)
+            .pixel_size(32)
             .visible(false)
             .css_classes(vec!["mimick-video-badge".to_string()])
             .build();
@@ -171,8 +171,8 @@ pub fn build_grid_view(ctx: Arc<AppContext>, select_toggle: gtk::ToggleButton) -
         let in_timeline = ctx
             .library_timeline_active
             .load(std::sync::atomic::Ordering::Relaxed);
-        status.set_visible(!in_timeline);
-        video_badge.set_visible(!in_timeline && asset_type.eq_ignore_ascii_case("VIDEO"));
+        status.set_visible(true);
+        video_badge.set_visible(asset_type.eq_ignore_ascii_case("VIDEO"));
         set_square_class(&picture, in_timeline);
 
         let generation = bump_generation(&picture);
@@ -374,9 +374,9 @@ fn sync_state_label(sync_state: u32) -> &'static str {
 
 fn sync_icon_name(sync_state: u32) -> &'static str {
     match sync_state {
-        2 => "emblem-default-symbolic",
-        1 => "folder-symbolic",
-        _ => "network-server-symbolic",
+        2 => "mimick-check-circle-symbolic",
+        1 => "mimick-computer-symbolic",
+        _ => "mimick-cloud-symbolic",
     }
 }
 

--- a/src/library/grid_view.rs
+++ b/src/library/grid_view.rs
@@ -9,13 +9,14 @@ use gdk4::Texture;
 use gtk::prelude::*;
 
 use crate::app_context::AppContext;
+use crate::library::asset_model::LibraryAssetModel;
 use crate::library::asset_object::AssetObject;
 
 const POS_DATA_KEY: &str = "mimick-cell-pos";
 pub type AssetContextMenuHandler = Rc<RefCell<Option<Box<dyn Fn(u32, f64, f64)>>>>;
 
 pub struct GridViewParts {
-    pub model: gtk::gio::ListStore,
+    pub model: LibraryAssetModel,
     pub scrolled: gtk::ScrolledWindow,
     pub view: gtk::GridView,
     pub selection: gtk::MultiSelection,
@@ -23,7 +24,7 @@ pub struct GridViewParts {
 }
 
 pub fn build_grid_view(ctx: Arc<AppContext>, select_toggle: gtk::ToggleButton) -> GridViewParts {
-    let model = gtk::gio::ListStore::new::<AssetObject>();
+    let model = LibraryAssetModel::new();
     let selection = gtk::MultiSelection::new(Some(model.clone()));
     let factory = gtk::SignalListItemFactory::new();
     let context_menu_handler: AssetContextMenuHandler = Rc::new(RefCell::new(None));
@@ -203,6 +204,8 @@ pub fn build_grid_view(ctx: Arc<AppContext>, select_toggle: gtk::ToggleButton) -
             local_path,
             generation,
         );
+
+        prefetch_thumbnails_around(ctx.clone(), &selection_for_bind, position);
     });
 
     factory.connect_unbind(|_, list_item| {
@@ -361,19 +364,6 @@ fn sync_checkbox_state(checkbox: &gtk::CheckButton, position: u32, selected: boo
     suppress.set(false);
 }
 
-pub fn replace_model(model: &gtk::gio::ListStore, objects: &[AssetObject]) {
-    model.remove_all();
-    for object in objects {
-        model.append(object);
-    }
-}
-
-pub fn extend_model(model: &gtk::gio::ListStore, objects: &[AssetObject]) {
-    for object in objects {
-        model.append(object);
-    }
-}
-
 fn sync_state_label(sync_state: u32) -> &'static str {
     match sync_state {
         2 => "On Immich and locally",
@@ -513,6 +503,42 @@ fn bump_generation(picture: &gtk::Picture) -> u64 {
     let next = cell.get().wrapping_add(1);
     cell.set(next);
     next
+}
+
+fn prefetch_thumbnails_around(
+    ctx: Arc<AppContext>,
+    model: &impl IsA<gtk::gio::ListModel>,
+    position: u32,
+) {
+    let total = model.n_items();
+    let start = position.saturating_add(5);
+    let end = position.saturating_add(15).min(total);
+    for pos in start..end {
+        let Some(item) = model.item(pos).and_downcast::<AssetObject>() else {
+            continue;
+        };
+        let local_path = item.property::<String>("local-path");
+        if !local_path.is_empty() {
+            continue;
+        }
+        let asset_id = item.property::<String>("id");
+        if asset_id.is_empty() || asset_id.starts_with(super::LOCAL_ID_PREFIX) {
+            continue;
+        }
+        if ctx
+            .thumbnail_cache
+            .get_cached(&asset_id, crate::api_client::ThumbnailSize::Thumbnail)
+            .is_some()
+        {
+            continue;
+        }
+        let cache = ctx.thumbnail_cache.clone();
+        glib::MainContext::default().spawn_local(async move {
+            let _ = cache
+                .load_thumbnail(&asset_id, crate::api_client::ThumbnailSize::Thumbnail)
+                .await;
+        });
+    }
 }
 
 fn decode_thumbhash_texture(thumbhash_b64: &str) -> Option<Texture> {

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -1939,22 +1939,26 @@ fn load_source_page(ui: Rc<LibraryWindowUi>, request: (u64, LibrarySource, u32),
 
             match result {
                 Ok(items) => {
-                    let mutation = {
+                    {
                         let mut state = ui.ctx.library_state.lock();
-                        let mutation = if append {
+                        let applied = if append {
                             state.append_assets(generation, items)
                         } else {
                             state.replace_assets(generation, items)
                         };
-                        let Some(mutation) = mutation else {
+                        if !applied {
                             return;
-                        };
-                        ui.grid
-                            .model
-                            .apply(&ui.ctx, &state.assets, &state.sort_mode, mutation);
-                        mutation
-                    };
-                    let _ = mutation;
+                        }
+                        if append {
+                            ui.grid
+                                .model
+                                .extend(&ui.ctx, &state.assets, &state.sort_mode);
+                        } else {
+                            ui.grid
+                                .model
+                                .reset(&ui.ctx, &state.assets, &state.sort_mode);
+                        }
+                    }
                     sync_content_state(&ui);
                     reload_sidebar(&ui);
                     update_timeline_banner_if_active(&ui, &ui.grid.scrolled.vadjustment());

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -18,19 +18,20 @@ use crate::library::albums_view::{
 };
 use crate::library::asset_object::AssetObject;
 use crate::library::explore_view::{ExploreViewParts, build_explore_view};
-use crate::library::grid_view::{GridViewParts, build_grid_view, extend_model, replace_model};
+use crate::library::grid_view::{GridViewParts, build_grid_view};
 use crate::library::local_source::{
-    LocalAsset, enumerate_local, enumerate_local_for_entry, filter_by_filename, local_sync_state,
+    LocalAsset, enumerate_local, enumerate_local_for_entry, filter_by_filename,
 };
 use crate::library::sidebar::{SidebarParts, build_sidebar};
 use crate::library::state::{LibraryLoadState, LibrarySortMode, LibrarySource};
 use crate::settings_window::{build_settings_window_with_parent, show_queue_inspector};
 use crate::state_manager::TransferDirection;
 
-const LOCAL_ID_PREFIX: &str = "local::";
+pub(super) const LOCAL_ID_PREFIX: &str = "local::";
 
 pub mod album_sync;
 pub mod albums_view;
+pub mod asset_model;
 pub mod asset_object;
 pub mod explore_view;
 pub mod grid_view;
@@ -770,12 +771,11 @@ fn connect_controls(
                 _ => LibrarySortMode::NewestFirst,
             };
 
-            let objects = {
-                let mut state = ui.ctx.library_state.lock();
-                state.apply_sort(sort_mode);
-                asset_objects_from_state(&state.assets, &ui.ctx)
-            };
-            replace_model(&ui.grid.model, &objects);
+            let mut state = ui.ctx.library_state.lock();
+            state.apply_sort(sort_mode);
+            ui.grid
+                .model
+                .reset(&ui.ctx, &state.assets, &state.sort_mode);
         }
     ));
 }
@@ -1101,7 +1101,7 @@ fn connect_grid_handlers(ui: Rc<LibraryWindowUi>) {
                 let adj = ui.grid.scrolled.vadjustment();
                 update_timeline_banner_if_active(&ui, &adj);
 
-                let threshold = (adj.upper() - adj.page_size()) * 0.75;
+                let threshold = (adj.upper() - adj.page_size()) * 0.50;
                 if adj.value() < threshold {
                     return;
                 }
@@ -1839,15 +1839,19 @@ fn load_source_page(ui: Rc<LibraryWindowUi>, request: (u64, LibrarySource, u32),
         ui,
         async move {
             let (generation, source, page) = request;
+            let order = ui.ctx.library_state.lock().sort_mode.server_order();
             let result: Result<Vec<LibraryAsset>, String> = match source.clone() {
                 LibrarySource::AllAssets | LibrarySource::Timeline => {
-                    ui.ctx.api_client.search_metadata("", page, PAGE_SIZE).await
+                    ui.ctx
+                        .api_client
+                        .search_metadata("", page, PAGE_SIZE, order)
+                        .await
                 }
                 LibrarySource::Explore => unreachable!("intercepted above"),
                 LibrarySource::Album { id, .. } => {
                     ui.ctx
                         .api_client
-                        .fetch_album_assets(&id, page, PAGE_SIZE)
+                        .fetch_album_assets(&id, page, PAGE_SIZE, order)
                         .await
                 }
                 LibrarySource::SmartSearch { query } => {
@@ -1857,15 +1861,20 @@ fn load_source_page(ui: Rc<LibraryWindowUi>, request: (u64, LibrarySource, u32),
                         .await
                 }
                 LibrarySource::OcrSearch { query } => {
-                    ui.ctx.api_client.search_ocr(&query, page, PAGE_SIZE).await
+                    ui.ctx
+                        .api_client
+                        .search_ocr(&query, page, PAGE_SIZE, order)
+                        .await
                 }
                 LibrarySource::MetadataSearch { query } => {
                     ui.ctx
                         .api_client
-                        .search_metadata(&query, page, PAGE_SIZE)
+                        .search_metadata(&query, page, PAGE_SIZE, order)
                         .await
                 }
                 LibrarySource::AdvancedSearch { filters } => {
+                    let mut filters = (*filters).clone();
+                    filters.order = order;
                     ui.ctx
                         .api_client
                         .search_metadata_with_filters(&filters, page, PAGE_SIZE)
@@ -1890,14 +1899,18 @@ fn load_source_page(ui: Rc<LibraryWindowUi>, request: (u64, LibrarySource, u32),
                     }
                 }
                 LibrarySource::Unified => {
-                    let remote = ui.ctx.api_client.search_metadata("", page, PAGE_SIZE).await;
+                    let remote = ui
+                        .ctx
+                        .api_client
+                        .search_metadata("", page, PAGE_SIZE, order)
+                        .await;
                     merge_unified_page(remote, page, &ui, None).await
                 }
                 LibrarySource::UnifiedSearch { query } => {
                     let remote = ui
                         .ctx
                         .api_client
-                        .search_metadata(&query, page, PAGE_SIZE)
+                        .search_metadata(&query, page, PAGE_SIZE, order)
                         .await;
                     merge_unified_page(remote, page, &ui, Some(&query)).await
                 }
@@ -1918,7 +1931,7 @@ fn load_source_page(ui: Rc<LibraryWindowUi>, request: (u64, LibrarySource, u32),
                     let remote = ui
                         .ctx
                         .api_client
-                        .fetch_album_assets(&id, page, PAGE_SIZE)
+                        .fetch_album_assets(&id, page, PAGE_SIZE, order)
                         .await;
                     merge_album_unified_page(remote, page, &ui, &name).await
                 }
@@ -1926,26 +1939,22 @@ fn load_source_page(ui: Rc<LibraryWindowUi>, request: (u64, LibrarySource, u32),
 
             match result {
                 Ok(items) => {
-                    let outcome = {
+                    let mutation = {
                         let mut state = ui.ctx.library_state.lock();
-                        let prev_len = state.assets.len();
-                        let applied = if append {
+                        let mutation = if append {
                             state.append_assets(generation, items)
                         } else {
                             state.replace_assets(generation, items)
                         };
-                        if !applied {
+                        let Some(mutation) = mutation else {
                             return;
-                        }
-                        let objects = asset_objects_from_state(&state.assets, &ui.ctx);
-                        (objects, prev_len)
+                        };
+                        ui.grid
+                            .model
+                            .apply(&ui.ctx, &state.assets, &state.sort_mode, mutation);
+                        mutation
                     };
-                    let (objects, prev_len) = outcome;
-                    if append && prev_len <= objects.len() {
-                        extend_model(&ui.grid.model, &objects[prev_len..]);
-                    } else {
-                        replace_model(&ui.grid.model, &objects);
-                    }
+                    let _ = mutation;
                     sync_content_state(&ui);
                     reload_sidebar(&ui);
                     update_timeline_banner_if_active(&ui, &ui.grid.scrolled.vadjustment());
@@ -2183,56 +2192,10 @@ fn build_status_view(icon_name: &str, title: &str, subtitle: &str) -> gtk::Box {
     container
 }
 
-fn immich_checksum_to_hex(b64: &str) -> Option<String> {
+pub(super) fn immich_checksum_to_hex(b64: &str) -> Option<String> {
     use base64::Engine as _;
     let bytes = base64::engine::general_purpose::STANDARD.decode(b64).ok()?;
     Some(bytes.iter().map(|b| format!("{:02x}", b)).collect())
-}
-
-fn asset_objects_from_state(assets: &[LibraryAsset], ctx: &AppContext) -> Vec<AssetObject> {
-    assets
-        .iter()
-        .map(|asset| {
-            if let Some(local_path) = asset.id.strip_prefix(LOCAL_ID_PREFIX) {
-                let sync_state =
-                    local_sync_state(&ctx.sync_index, std::path::Path::new(local_path));
-                let object = AssetObject::new_local(
-                    &asset.id,
-                    &asset.filename,
-                    &asset.mime_type,
-                    &asset.created_at,
-                    &asset.asset_type,
-                    local_path,
-                );
-                if sync_state != 1 {
-                    object.set_property("sync-state", sync_state);
-                }
-                return object;
-            }
-            // Remote rows: 2 = "both" when a sibling local copy exists, else 0 (remote-only).
-            // Immich returns checksum as base64 SHA-1; SyncIndex stores hex SHA-1.
-            let local_match = asset
-                .checksum
-                .as_deref()
-                .and_then(immich_checksum_to_hex)
-                .as_deref()
-                .and_then(|hex| ctx.sync_index.local_path_for_checksum(hex));
-            let sync_state = if local_match.is_some() { 2 } else { 0 };
-            let object = AssetObject::new(
-                &asset.id,
-                &asset.filename,
-                &asset.mime_type,
-                &asset.created_at,
-                &asset.asset_type,
-                sync_state,
-                asset.thumbhash.as_deref(),
-            );
-            if let Some(path) = local_match {
-                object.set_property("local-path", path);
-            }
-            object
-        })
-        .collect()
 }
 
 fn fill_exif_box(container: &gtk::Box, exif: &crate::api_client::ExifInfo) {
@@ -3225,6 +3188,7 @@ fn present_advanced_filters_dialog(ui: Rc<LibraryWindowUi>) {
                 with_deleted: None,
                 person_ids: None,
                 tag_ids: None,
+                order: None,
             };
             let request =
                 ui.ctx

--- a/src/library/state.rs
+++ b/src/library/state.rs
@@ -5,17 +5,6 @@ use crate::api_client::{
 };
 
 const PAGE_SIZE: usize = 50;
-const WINDOW_PAGES: usize = 8;
-pub const WINDOW_CAP: usize = WINDOW_PAGES * PAGE_SIZE;
-
-/// Outcome of an append/replace, used by the listmodel layer to emit a
-/// single `items_changed(0, prev_n, new_n)` reset signal.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PageMutation {
-    pub generation: u64,
-    pub prev_n: usize,
-    pub new_n: usize,
-}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LibrarySource {
@@ -187,16 +176,11 @@ impl LibraryState {
         Some((self.generation, self.source.clone(), self.next_page))
     }
 
-    pub fn replace_assets(
-        &mut self,
-        generation: u64,
-        items: Vec<LibraryAsset>,
-    ) -> Option<PageMutation> {
+    pub fn replace_assets(&mut self, generation: u64, items: Vec<LibraryAsset>) -> bool {
         if generation != self.generation {
-            return None;
+            return false;
         }
 
-        let prev_n = self.assets.len();
         self.assets = dedup_assets(items);
         self.page_in_flight = false;
         self.next_page = 2;
@@ -207,33 +191,18 @@ impl LibraryState {
             LibraryLoadState::Loaded
         };
         self.apply_sort(self.sort_mode.clone());
-        Some(PageMutation {
-            generation,
-            prev_n,
-            new_n: self.assets.len(),
-        })
+        true
     }
 
-    pub fn append_assets(
-        &mut self,
-        generation: u64,
-        items: Vec<LibraryAsset>,
-    ) -> Option<PageMutation> {
+    pub fn append_assets(&mut self, generation: u64, items: Vec<LibraryAsset>) -> bool {
         if generation != self.generation {
-            return None;
+            return false;
         }
 
         let page_len = items.len();
         self.page_in_flight = false;
-
-        let prev_n = self.assets.len();
         self.assets.extend(items);
         self.assets = dedup_assets(std::mem::take(&mut self.assets));
-
-        if self.assets.len() > WINDOW_CAP {
-            let drop = self.assets.len() - WINDOW_CAP;
-            self.assets.drain(..drop);
-        }
 
         if page_len > 0 {
             self.next_page = self.next_page.saturating_add(1);
@@ -245,12 +214,7 @@ impl LibraryState {
             LibraryLoadState::Loaded
         };
         self.apply_sort(self.sort_mode.clone());
-
-        Some(PageMutation {
-            generation,
-            prev_n,
-            new_n: self.assets.len(),
-        })
+        true
     }
 
     /// Records the user's preferred sort mode. `LibraryState.assets` is always
@@ -339,16 +303,8 @@ mod tests {
             query: "cats".into(),
         });
 
-        assert!(
-            state
-                .replace_assets(generation, vec![asset("1", "a.jpg")])
-                .is_none()
-        );
-        assert!(
-            state
-                .replace_assets(newer_generation.0, vec![asset("2", "b.jpg")])
-                .is_some()
-        );
+        assert!(!state.replace_assets(generation, vec![asset("1", "a.jpg")]));
+        assert!(state.replace_assets(newer_generation.0, vec![asset("2", "b.jpg")]));
         assert_eq!(state.assets.len(), 1);
         assert_eq!(state.assets[0].id, "2");
     }
@@ -364,34 +320,9 @@ mod tests {
     }
 
     #[test]
-    fn test_appending_past_window_cap_evicts_oldest() {
+    fn test_dedup_drops_duplicates_across_appends() {
         let mut state = LibraryState::new();
         let (generation, _, _) = state.load_initial_source();
-
-        let pages_to_load = (WINDOW_CAP / 50) + 2;
-        for page in 0..pages_to_load {
-            let chunk: Vec<LibraryAsset> = (0..50)
-                .map(|i| asset(&format!("{}", page * 50 + i), "a.jpg"))
-                .collect();
-            assert!(state.append_assets(generation, chunk).is_some());
-        }
-
-        assert_eq!(state.assets.len(), WINDOW_CAP);
-        let ids: std::collections::HashSet<String> =
-            state.assets.iter().map(|a| a.id.clone()).collect();
-        assert_eq!(ids.len(), WINDOW_CAP);
-        // After loading 10 pages (500 ids) into a 400-cap window, the oldest
-        // 100 must have been dropped.
-        assert!(!ids.contains("0"));
-        assert!(!ids.contains("99"));
-    }
-
-    #[test]
-    fn test_dedup_after_eviction_does_not_duplicate() {
-        let mut state = LibraryState::new();
-        let (generation, _, _) = state.load_initial_source();
-        // Load three pages, then re-append page 2's content — its ids must
-        // not appear twice in the window even though they get re-inserted.
         let mk_page = |start: u32| -> Vec<LibraryAsset> {
             (0..50)
                 .map(|i| asset(&format!("{}", start + i), "a.jpg"))
@@ -399,10 +330,12 @@ mod tests {
         };
         state.append_assets(generation, mk_page(0));
         state.append_assets(generation, mk_page(50));
+        // Re-append the second page; ids must not appear twice.
         state.append_assets(generation, mk_page(50));
         let unique: std::collections::HashSet<_> =
             state.assets.iter().map(|a| a.id.clone()).collect();
         assert_eq!(unique.len(), state.assets.len());
+        assert_eq!(state.assets.len(), 100);
     }
 
     #[test]

--- a/src/library/state.rs
+++ b/src/library/state.rs
@@ -5,6 +5,17 @@ use crate::api_client::{
 };
 
 const PAGE_SIZE: usize = 50;
+const WINDOW_PAGES: usize = 8;
+pub const WINDOW_CAP: usize = WINDOW_PAGES * PAGE_SIZE;
+
+/// Outcome of an append/replace, used by the listmodel layer to emit a
+/// single `items_changed(0, prev_n, new_n)` reset signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageMutation {
+    pub generation: u64,
+    pub prev_n: usize,
+    pub new_n: usize,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LibrarySource {
@@ -72,8 +83,21 @@ impl LibrarySource {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LibrarySortMode {
     NewestFirst,
+    OldestFirst,
     Filename,
     FileType,
+}
+
+impl LibrarySortMode {
+    /// Server-side date order for paged remote sources, or `None` when the
+    /// mode is purely client-side (filename/filetype sort over loaded pages).
+    pub fn server_order(&self) -> Option<crate::api_client::SortOrder> {
+        match self {
+            LibrarySortMode::NewestFirst => Some(crate::api_client::SortOrder::Desc),
+            LibrarySortMode::OldestFirst => Some(crate::api_client::SortOrder::Asc),
+            LibrarySortMode::Filename | LibrarySortMode::FileType => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -163,11 +187,16 @@ impl LibraryState {
         Some((self.generation, self.source.clone(), self.next_page))
     }
 
-    pub fn replace_assets(&mut self, generation: u64, items: Vec<LibraryAsset>) -> bool {
+    pub fn replace_assets(
+        &mut self,
+        generation: u64,
+        items: Vec<LibraryAsset>,
+    ) -> Option<PageMutation> {
         if generation != self.generation {
-            return false;
+            return None;
         }
 
+        let prev_n = self.assets.len();
         self.assets = dedup_assets(items);
         self.page_in_flight = false;
         self.next_page = 2;
@@ -178,18 +207,34 @@ impl LibraryState {
             LibraryLoadState::Loaded
         };
         self.apply_sort(self.sort_mode.clone());
-        true
+        Some(PageMutation {
+            generation,
+            prev_n,
+            new_n: self.assets.len(),
+        })
     }
 
-    pub fn append_assets(&mut self, generation: u64, items: Vec<LibraryAsset>) -> bool {
+    pub fn append_assets(
+        &mut self,
+        generation: u64,
+        items: Vec<LibraryAsset>,
+    ) -> Option<PageMutation> {
         if generation != self.generation {
-            return false;
+            return None;
         }
 
         let page_len = items.len();
         self.page_in_flight = false;
+
+        let prev_n = self.assets.len();
         self.assets.extend(items);
         self.assets = dedup_assets(std::mem::take(&mut self.assets));
+
+        if self.assets.len() > WINDOW_CAP {
+            let drop = self.assets.len() - WINDOW_CAP;
+            self.assets.drain(..drop);
+        }
+
         if page_len > 0 {
             self.next_page = self.next_page.saturating_add(1);
         }
@@ -200,30 +245,20 @@ impl LibraryState {
             LibraryLoadState::Loaded
         };
         self.apply_sort(self.sort_mode.clone());
-        true
+
+        Some(PageMutation {
+            generation,
+            prev_n,
+            new_n: self.assets.len(),
+        })
     }
 
+    /// Records the user's preferred sort mode. `LibraryState.assets` is always
+    /// stored in insertion (server) order so that the sliding-window FIFO
+    /// eviction is well-defined; the listmodel layer applies client-side sort
+    /// visually for `Filename`/`FileType`.
     pub fn apply_sort(&mut self, mode: LibrarySortMode) {
         self.sort_mode = mode;
-        match self.sort_mode {
-            LibrarySortMode::NewestFirst => self.assets.sort_by(|a, b| {
-                b.created_at
-                    .cmp(&a.created_at)
-                    .then_with(|| a.id.cmp(&b.id))
-            }),
-            LibrarySortMode::Filename => self.assets.sort_by(|a, b| {
-                a.filename
-                    .to_ascii_lowercase()
-                    .cmp(&b.filename.to_ascii_lowercase())
-                    .then_with(|| a.id.cmp(&b.id))
-            }),
-            LibrarySortMode::FileType => self.assets.sort_by(|a, b| {
-                a.mime_type
-                    .cmp(&b.mime_type)
-                    .then_with(|| a.filename.cmp(&b.filename))
-                    .then_with(|| a.id.cmp(&b.id))
-            }),
-        }
     }
 
     pub fn clear_search_restore_previous_source(&mut self) -> Option<(u64, LibrarySource, u32)> {
@@ -304,8 +339,16 @@ mod tests {
             query: "cats".into(),
         });
 
-        assert!(!state.replace_assets(generation, vec![asset("1", "a.jpg")]));
-        assert!(state.replace_assets(newer_generation.0, vec![asset("2", "b.jpg")]));
+        assert!(
+            state
+                .replace_assets(generation, vec![asset("1", "a.jpg")])
+                .is_none()
+        );
+        assert!(
+            state
+                .replace_assets(newer_generation.0, vec![asset("2", "b.jpg")])
+                .is_some()
+        );
         assert_eq!(state.assets.len(), 1);
         assert_eq!(state.assets[0].id, "2");
     }
@@ -318,6 +361,62 @@ mod tests {
         state.page_in_flight = false;
         assert!(state.load_next_page_if_needed().is_some());
         assert!(state.load_next_page_if_needed().is_none());
+    }
+
+    #[test]
+    fn test_appending_past_window_cap_evicts_oldest() {
+        let mut state = LibraryState::new();
+        let (generation, _, _) = state.load_initial_source();
+
+        let pages_to_load = (WINDOW_CAP / 50) + 2;
+        for page in 0..pages_to_load {
+            let chunk: Vec<LibraryAsset> = (0..50)
+                .map(|i| asset(&format!("{}", page * 50 + i), "a.jpg"))
+                .collect();
+            assert!(state.append_assets(generation, chunk).is_some());
+        }
+
+        assert_eq!(state.assets.len(), WINDOW_CAP);
+        let ids: std::collections::HashSet<String> =
+            state.assets.iter().map(|a| a.id.clone()).collect();
+        assert_eq!(ids.len(), WINDOW_CAP);
+        // After loading 10 pages (500 ids) into a 400-cap window, the oldest
+        // 100 must have been dropped.
+        assert!(!ids.contains("0"));
+        assert!(!ids.contains("99"));
+    }
+
+    #[test]
+    fn test_dedup_after_eviction_does_not_duplicate() {
+        let mut state = LibraryState::new();
+        let (generation, _, _) = state.load_initial_source();
+        // Load three pages, then re-append page 2's content — its ids must
+        // not appear twice in the window even though they get re-inserted.
+        let mk_page = |start: u32| -> Vec<LibraryAsset> {
+            (0..50)
+                .map(|i| asset(&format!("{}", start + i), "a.jpg"))
+                .collect()
+        };
+        state.append_assets(generation, mk_page(0));
+        state.append_assets(generation, mk_page(50));
+        state.append_assets(generation, mk_page(50));
+        let unique: std::collections::HashSet<_> =
+            state.assets.iter().map(|a| a.id.clone()).collect();
+        assert_eq!(unique.len(), state.assets.len());
+    }
+
+    #[test]
+    fn test_sort_mode_server_order_mapping() {
+        assert!(matches!(
+            LibrarySortMode::NewestFirst.server_order(),
+            Some(crate::api_client::SortOrder::Desc)
+        ));
+        assert!(matches!(
+            LibrarySortMode::OldestFirst.server_order(),
+            Some(crate::api_client::SortOrder::Asc)
+        ));
+        assert!(LibrarySortMode::Filename.server_order().is_none());
+        assert!(LibrarySortMode::FileType.server_order().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Custom `gio::ListModel`** (`library/asset_model.rs`): replaces the `gio::ListStore` mirror with `LibraryAssetModel`, which owns `Vec<AssetObject>` and drives `items_changed` resets. Client-side sort (Filename/FileType) is applied at the model layer; date-based sorts rely on server ordering.
- **400-asset sliding window** (`library/state.rs`): `LibraryState.assets` is now capped at 8 pages (400 items) with front-drain FIFO eviction on append. Memory is bounded regardless of scroll depth. `apply_sort` no longer mutates the assets vec, keeping insertion order correct for eviction.
- **Server-side sort order** (`api_client.rs`): new `SortOrder` enum; `search_metadata`, `search_ocr`, and `fetch_album_assets` now accept `Option<SortOrder>` derived from the active sort mode. `OldestFirst` sort variant added to `LibrarySortMode` (not yet exposed in the dropdown — follow-up).
- **Prefetch tuning** (`library/grid_view.rs`): scroll trigger threshold lowered from 75% → 50%. New `prefetch_thumbnails_around` helper kicks off background thumbnail loads for rows n+5..n+15 on each bind; the existing load semaphore caps parallelism.

## Test plan

- [x] Scroll a large remote library (100+ pages) and confirm RSS stabilises around the window cap rather than growing linearly
- [x] Sort by Filename and FileType — grid should reorder correctly over loaded pages
- [x] Switch between sort modes — grid updates immediately without requiring a reload
- [x] Fast-scroll a library — fewer "loading" placeholder cells appear due to earlier prefetch trigger and lookahead loading
- [x] Existing 90 unit tests pass (`cargo test --workspace`)
- [x] `cargo clippy --all-targets -- -D warnings` clean