### PR TITLE
Add graceful upload shutdown, periodic cache prune, central media table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Configurable test-asset generator script for reproducing deduplication and startup scan benchmarks across all supported API asset formats (#101).
+- Graceful shutdown for in-flight uploads. Quitting the app now stops accepting new tasks, waits up to 5 seconds for active uploads to finish cleanly, then cancels anything still in flight via a cancellation token. Uploads cancelled at the deadline are persisted to the retry queue and resumed on the next launch instead of leaving partial assets on the server.
 
 ### Changed
 
+- Disk thumbnail cache is now pruned on a 10-minute background interval instead of only at startup, and its cap was raised from 500 MB to 1 GB so long sessions no longer grow unbounded.
+- Consolidated the three previously hand-maintained extension/MIME tables (file watcher, upload client, library enumerator) into a single `phf` perfect-hash registry. Eliminates table drift and turns the watcher's hot-path extension check from a 68-entry linear scan into an O(1) lookup.
 - Hardened security by adding strict path sanitization against directory traversal on downloads, and enforcing `http`/`https` scheme validation for server URLs (#98).
 - Centralized read/write lock configuration access into `AppContext`, eliminating redundant disk parsing and streamlining context usage across modules (#98).
 - Replaced standard non-async locks (Mutex/RwLock) with `parking_lot` for faster operations, and added `atomic_write()` for crash-safe file persistence (#98).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,7 @@ dependencies = [
  "num_cpus",
  "oo7",
  "parking_lot",
+ "phf",
  "rayon",
  "reqwest",
  "serde",
@@ -1957,6 +1958,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2418,6 +2462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,6 +2657,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ blake3 = "1.8.5"
 url = "2.5.8"
 notify = "8.2.0"
 num_cpus = "1.17.0"
+phf = { version = "0.13.1", features = ["macros"] }
 oo7 = { version = "0.6.0", default-features = false, features = ["tokio", "native_crypto"] }
 rayon = "1.12.0"
 reqwest = { version = "0.13.2", default-features = false, features = ["native-tls", "charset", "http2", "json", "multipart", "stream"] }
-tokio-util = { version = "0.7.18", features = ["codec"] }
+tokio-util = { version = "0.7.18", features = ["codec", "rt"] }
 futures-util = "0.3.32"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -2420,6 +2420,58 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf/phf-0.13.1.crate",
+        "sha256": "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf",
+        "dest": "cargo/vendor/phf-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf\", \"files\": {}}",
+        "dest": "cargo/vendor/phf-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_generator/phf_generator-0.13.1.crate",
+        "sha256": "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737",
+        "dest": "cargo/vendor/phf_generator-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_generator-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_macros/phf_macros-0.13.1.crate",
+        "sha256": "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef",
+        "dest": "cargo/vendor/phf_macros-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_macros-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_shared/phf_shared-0.13.1.crate",
+        "sha256": "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266",
+        "dest": "cargo/vendor/phf_shared-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_shared-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.17.crate",
         "sha256": "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd",
         "dest": "cargo/vendor/pin-project-lite-0.2.17"
@@ -3000,6 +3052,19 @@
         "type": "inline",
         "contents": "{\"package\": \"c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b\", \"files\": {}}",
         "dest": "cargo/vendor/signal-hook-registry-1.4.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/siphasher/siphasher-1.0.3.crate",
+        "sha256": "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649",
+        "dest": "cargo/vendor/siphasher-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649\", \"files\": {}}",
+        "dest": "cargo/vendor/siphasher-1.0.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -1713,72 +1713,7 @@ fn classify_network_issue(context: RequestContext, error: &reqwest::Error) -> Ap
 }
 
 fn mime_for_path(path: &Path) -> &'static str {
-    match path
-        .extension()
-        .map(|e| e.to_string_lossy().to_lowercase())
-        .as_deref()
-    {
-        // Standard image formats
-        Some("avif") => "image/avif",
-        Some("bmp") => "image/bmp",
-        Some("gif") => "image/gif",
-        Some("heic") => "image/heic",
-        Some("heif" | "hif") => "image/heif",
-        Some("insp" | "jpe" | "jpeg" | "jpg") => "image/jpeg",
-        Some("jp2") => "image/jp2",
-        Some("jxl") => "image/jxl",
-        Some("png") => "image/png",
-        Some("mpo") => "image/jpeg",
-        Some("psd") => "image/vnd.adobe.photoshop",
-        Some("svg") => "image/svg+xml",
-        Some("tif" | "tiff") => "image/tiff",
-        Some("webp") => "image/webp",
-        // RAW camera formats — Immich treats most as image/x-<vendor>; fall through to
-        // application/octet-stream is safe but vendor-specific MIME helps the server pick
-        // the right pipeline (libraw vs. dcraw) on older Immich builds.
-        Some("3fr") => "image/x-hasselblad-3fr",
-        Some("ari") => "image/x-arriflex-ari",
-        Some("arw") => "image/x-sony-arw",
-        Some("cap") => "image/x-phaseone-cap",
-        Some("cin") => "image/cineon",
-        Some("cr2") => "image/x-canon-cr2",
-        Some("cr3") => "image/x-canon-cr3",
-        Some("crw") => "image/x-canon-crw",
-        Some("dcr") => "image/x-kodak-dcr",
-        Some("dng") => "image/x-adobe-dng",
-        Some("erf") => "image/x-epson-erf",
-        Some("fff") => "image/x-hasselblad-fff",
-        Some("iiq") => "image/x-phaseone-iiq",
-        Some("k25") => "image/x-kodak-k25",
-        Some("kdc") => "image/x-kodak-kdc",
-        Some("mrw") => "image/x-minolta-mrw",
-        Some("nef") => "image/x-nikon-nef",
-        Some("nrw") => "image/x-nikon-nrw",
-        Some("orf" | "ori") => "image/x-olympus-orf",
-        Some("pef") => "image/x-pentax-pef",
-        Some("raf") => "image/x-fuji-raf",
-        Some("raw") => "image/x-panasonic-raw",
-        Some("rw2") => "image/x-panasonic-rw2",
-        Some("rwl") => "image/x-leica-rwl",
-        Some("sr2" | "srf") => "image/x-sony-sr2",
-        Some("srw") => "image/x-samsung-srw",
-        Some("x3f") => "image/x-sigma-x3f",
-        // Video formats
-        Some("3gp" | "3gpp") => "video/3gpp",
-        Some("avi") => "video/x-msvideo",
-        Some("flv") => "video/x-flv",
-        Some("insv" | "mp4") => "video/mp4",
-        Some("m2t" | "m2ts" | "mts" | "ts") => "video/mp2t",
-        Some("m4v") => "video/x-m4v",
-        Some("mkv") => "video/x-matroska",
-        Some("mpe" | "mpeg" | "mpg") => "video/mpeg",
-        Some("mov") => "video/quicktime",
-        Some("mxf") => "application/mxf",
-        Some("vob") => "video/dvd",
-        Some("webm") => "video/webm",
-        Some("wmv") => "video/x-ms-wmv",
-        _ => "application/octet-stream",
-    }
+    crate::media_kinds::mime_for_path(path)
 }
 
 async fn apply_asset_timezone_fixup(

--- a/src/library/local_source.rs
+++ b/src/library/local_source.rs
@@ -114,11 +114,10 @@ fn build_asset(path: &Path) -> Option<LocalAsset> {
     let filename = path.file_name()?.to_string_lossy().into_owned();
     let metadata = std::fs::metadata(path).ok()?;
     let created_at = format_modified(&metadata);
-    let mime = mime_for_extension(path);
-    let asset_type = if mime.starts_with("video/") {
-        "VIDEO"
-    } else {
-        "IMAGE"
+    let mime = crate::media_kinds::mime_for_path(path);
+    let asset_type = match crate::media_kinds::asset_kind(mime) {
+        crate::media_kinds::AssetKind::Video => "VIDEO",
+        _ => "IMAGE",
     };
     Some(LocalAsset {
         path: path.to_path_buf(),
@@ -127,47 +126,6 @@ fn build_asset(path: &Path) -> Option<LocalAsset> {
         asset_type,
         created_at,
     })
-}
-
-fn mime_for_extension(path: &Path) -> &'static str {
-    // Subset of `api_client::mime_for_path` relevant to local browsing.
-    // Vendor-specific RAW MIMEs are collapsed to "image/x-raw" because the
-    // library view only uses the asset_type bucket; the per-vendor mapping
-    // continues to live in api_client for upload paths.
-    match path
-        .extension()
-        .map(|e| e.to_string_lossy().to_lowercase())
-        .as_deref()
-    {
-        Some("avif") => "image/avif",
-        Some("bmp") => "image/bmp",
-        Some("gif") => "image/gif",
-        Some("heic") => "image/heic",
-        Some("heif" | "hif") => "image/heif",
-        Some("jpe" | "jpeg" | "jpg" | "insp" | "mpo") => "image/jpeg",
-        Some("jp2") => "image/jp2",
-        Some("jxl") => "image/jxl",
-        Some("png") => "image/png",
-        Some("psd") => "image/vnd.adobe.photoshop",
-        Some("svg") => "image/svg+xml",
-        Some("tif" | "tiff") => "image/tiff",
-        Some("webp") => "image/webp",
-        Some("3gp" | "3gpp") => "video/3gpp",
-        Some("avi") => "video/x-msvideo",
-        Some("flv") => "video/x-flv",
-        Some("insv" | "mp4") => "video/mp4",
-        Some("m2t" | "m2ts" | "mts" | "ts") => "video/mp2t",
-        Some("m4v") => "video/x-m4v",
-        Some("mkv") => "video/x-matroska",
-        Some("mpe" | "mpeg" | "mpg") => "video/mpeg",
-        Some("mov") => "video/quicktime",
-        Some("mxf") => "application/mxf",
-        Some("vob") => "video/dvd",
-        Some("webm") => "video/webm",
-        Some("wmv") => "video/x-ms-wmv",
-        Some(_) => "image/x-raw",
-        None => "application/octet-stream",
-    }
 }
 
 fn format_modified(meta: &std::fs::Metadata) -> String {

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
+use std::time::Duration;
 
 use gdk4::Texture;
 use gdk4::prelude::TextureExt;
@@ -106,6 +107,8 @@ pub struct ThumbnailCache {
 
 impl ThumbnailCache {
     const DEFAULT_MAX_BYTES: usize = 80 * 1024 * 1024;
+    const DISK_CAP_BYTES: u64 = 1024 * 1024 * 1024;
+    const DISK_PRUNE_INTERVAL: Duration = Duration::from_secs(600);
 
     pub fn with_capacity_mb(api_client: std::sync::Arc<ImmichApiClient>, mb: u32) -> Self {
         let cache_dir = dirs::cache_dir()
@@ -126,8 +129,29 @@ impl ThumbnailCache {
             load_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_LOADS)),
             inflight: Arc::new(Mutex::new(HashMap::new())),
         };
-        let _ = cache.prune_disk_cache(500 * 1024 * 1024);
+        let _ = cache.prune_disk_cache(Self::DISK_CAP_BYTES);
         cache
+    }
+
+    /// Spawn a background task that prunes the on-disk thumbnail cache on an
+    /// interval. The task holds only a `Weak<Self>` so the cache can drop
+    /// normally; the loop exits as soon as the upgrade fails.
+    pub fn spawn_disk_prune_task(self: &Arc<Self>) {
+        let weak = Arc::downgrade(self);
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(Self::DISK_PRUNE_INTERVAL);
+            ticker.tick().await; // skip the immediate first tick (constructor already pruned)
+            loop {
+                ticker.tick().await;
+                let Some(cache) = Weak::upgrade(&weak) else {
+                    break;
+                };
+                let _ = tokio::task::spawn_blocking(move || {
+                    let _ = cache.prune_disk_cache(Self::DISK_CAP_BYTES);
+                })
+                .await;
+            }
+        });
     }
 
     #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod autostart;
 mod config;
 mod diagnostics;
 mod library;
+mod media_kinds;
 mod monitor;
 mod notifications;
 mod queue_manager;
@@ -291,6 +292,7 @@ async fn main() {
             api_client.clone(),
             config.data.library_thumbnail_cache_mb,
         ));
+        thumbnail_cache.spawn_disk_prune_task();
         let library_state = Arc::new(parking_lot::Mutex::new(LibraryState::new()));
         let shared_config = Arc::new(parking_lot::RwLock::new(config));
         let ctx = Arc::new(AppContext {
@@ -602,6 +604,9 @@ async fn main() {
     // Persist final state and any pending retries on graceful shutdown.
     if is_primary_instance.load(Ordering::SeqCst) {
         if let Some(ctx) = APP_CONTEXT.get() {
+            ctx.queue_manager
+                .shutdown(std::time::Duration::from_secs(5))
+                .await;
             ctx.queue_manager.flush_retries();
         }
         let state = APP_CONTEXT

--- a/src/media_kinds.rs
+++ b/src/media_kinds.rs
@@ -1,0 +1,170 @@
+//! Central registry of supported media extensions, MIME types, and asset kinds.
+//!
+//! All file-extension lookups in the upload, watch, and library-view paths
+//! resolve through this module so the three previously hand-maintained tables
+//! cannot drift apart.
+
+use phf::{phf_map, phf_set};
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssetKind {
+    Image,
+    Video,
+}
+
+pub static SUPPORTED: phf::Set<&'static str> = phf_set! {
+    "3fr", "3gp", "3gpp", "ari", "arw", "avi", "avif", "bmp", "cap", "cin",
+    "cr2", "cr3", "crw", "dcr", "dng", "erf", "fff", "flv", "gif", "heic",
+    "heif", "hif", "iiq", "insp", "insv", "jp2", "jpe", "jpeg", "jpg", "jxl",
+    "k25", "kdc", "m2t", "m2ts", "m4v", "mkv", "mov", "mp4", "mpe", "mpeg",
+    "mpg", "mpo", "mrw", "mts", "mxf", "nef", "nrw", "orf", "ori", "pef",
+    "png", "psd", "raf", "raw", "rw2", "rwl", "sr2", "srf", "srw", "svg",
+    "tif", "tiff", "ts", "vob", "webm", "webp", "wmv", "x3f",
+};
+
+static MIME_BY_EXT: phf::Map<&'static str, &'static str> = phf_map! {
+    "avif" => "image/avif",
+    "bmp" => "image/bmp",
+    "gif" => "image/gif",
+    "heic" => "image/heic",
+    "heif" => "image/heif",
+    "hif" => "image/heif",
+    "insp" => "image/jpeg",
+    "jpe" => "image/jpeg",
+    "jpeg" => "image/jpeg",
+    "jpg" => "image/jpeg",
+    "jp2" => "image/jp2",
+    "jxl" => "image/jxl",
+    "mpo" => "image/jpeg",
+    "png" => "image/png",
+    "psd" => "image/vnd.adobe.photoshop",
+    "svg" => "image/svg+xml",
+    "tif" => "image/tiff",
+    "tiff" => "image/tiff",
+    "webp" => "image/webp",
+    "3fr" => "image/x-hasselblad-3fr",
+    "ari" => "image/x-arriflex-ari",
+    "arw" => "image/x-sony-arw",
+    "cap" => "image/x-phaseone-cap",
+    "cin" => "image/cineon",
+    "cr2" => "image/x-canon-cr2",
+    "cr3" => "image/x-canon-cr3",
+    "crw" => "image/x-canon-crw",
+    "dcr" => "image/x-kodak-dcr",
+    "dng" => "image/x-adobe-dng",
+    "erf" => "image/x-epson-erf",
+    "fff" => "image/x-hasselblad-fff",
+    "iiq" => "image/x-phaseone-iiq",
+    "k25" => "image/x-kodak-k25",
+    "kdc" => "image/x-kodak-kdc",
+    "mrw" => "image/x-minolta-mrw",
+    "nef" => "image/x-nikon-nef",
+    "nrw" => "image/x-nikon-nrw",
+    "orf" => "image/x-olympus-orf",
+    "ori" => "image/x-olympus-orf",
+    "pef" => "image/x-pentax-pef",
+    "raf" => "image/x-fuji-raf",
+    "raw" => "image/x-panasonic-raw",
+    "rw2" => "image/x-panasonic-rw2",
+    "rwl" => "image/x-leica-rwl",
+    "sr2" => "image/x-sony-sr2",
+    "srf" => "image/x-sony-sr2",
+    "srw" => "image/x-samsung-srw",
+    "x3f" => "image/x-sigma-x3f",
+    "3gp" => "video/3gpp",
+    "3gpp" => "video/3gpp",
+    "avi" => "video/x-msvideo",
+    "flv" => "video/x-flv",
+    "insv" => "video/mp4",
+    "mp4" => "video/mp4",
+    "m2t" => "video/mp2t",
+    "m2ts" => "video/mp2t",
+    "mts" => "video/mp2t",
+    "ts" => "video/mp2t",
+    "m4v" => "video/x-m4v",
+    "mkv" => "video/x-matroska",
+    "mpe" => "video/mpeg",
+    "mpeg" => "video/mpeg",
+    "mpg" => "video/mpeg",
+    "mov" => "video/quicktime",
+    "mxf" => "application/mxf",
+    "vob" => "video/dvd",
+    "webm" => "video/webm",
+    "wmv" => "video/x-ms-wmv",
+};
+
+/// Lowercase the path's extension and return whether it is an accepted media file.
+pub fn is_supported_path(path: &Path) -> bool {
+    if path.is_dir() {
+        return false;
+    }
+    extension_lower(path)
+        .map(|ext| SUPPORTED.contains(ext.as_str()))
+        .unwrap_or(false)
+}
+
+pub fn is_supported_ext(ext: &str) -> bool {
+    SUPPORTED.contains(ext)
+}
+
+/// MIME type for a known extension (already lowercased).
+pub fn mime_for(ext: &str) -> Option<&'static str> {
+    MIME_BY_EXT.get(ext).copied()
+}
+
+/// MIME type for any path; falls back to `application/octet-stream` for unknowns.
+pub fn mime_for_path(path: &Path) -> &'static str {
+    extension_lower(path)
+        .and_then(|ext| mime_for(&ext))
+        .unwrap_or("application/octet-stream")
+}
+
+pub fn asset_kind(mime: &str) -> AssetKind {
+    if mime.starts_with("video/") {
+        AssetKind::Video
+    } else {
+        AssetKind::Image
+    }
+}
+
+fn extension_lower(path: &Path) -> Option<String> {
+    path.extension()
+        .map(|ext| ext.to_string_lossy().to_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_supported_extension_has_a_mime() {
+        for ext in SUPPORTED.iter() {
+            assert!(
+                MIME_BY_EXT.contains_key(ext),
+                "extension `.{}` is supported but has no MIME mapping",
+                ext
+            );
+        }
+    }
+
+    #[test]
+    fn mime_for_path_handles_uppercase_and_unknowns() {
+        assert_eq!(mime_for_path(Path::new("photo.PNG")), "image/png");
+        assert_eq!(mime_for_path(Path::new("photo.jpe")), "image/jpeg");
+        assert_eq!(
+            mime_for_path(Path::new("doc.unknown")),
+            "application/octet-stream"
+        );
+        assert_eq!(
+            mime_for_path(Path::new("noext")),
+            "application/octet-stream"
+        );
+    }
+
+    #[test]
+    fn asset_kind_buckets_video_prefix() {
+        assert_eq!(asset_kind("video/mp4"), AssetKind::Video);
+        assert_eq!(asset_kind("image/jpeg"), AssetKind::Image);
+    }
+}

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,6 +1,7 @@
 //! Provides live filesystem monitoring, file-settling checks, and checksum generation for watched paths.
 
 use crate::config::{WatchPathEntry, best_matching_watch_entry};
+use crate::media_kinds;
 use crate::watch_path_display::display_watch_path;
 use notify::{Config as NotifyConfig, EventKind, PollWatcher, RecursiveMode, Watcher};
 use sha1::{Digest, Sha1};
@@ -10,19 +11,6 @@ use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
-
-/// List of allowed media file extensions accepted for upload.
-///
-/// Sorted alphabetically. Includes still-image formats (incl. RAW),
-/// video formats, and high-bit-depth/professional formats supported by Immich.
-pub(crate) const MEDIA_EXTENSIONS: &[&str] = &[
-    "3fr", "3gp", "3gpp", "ari", "arw", "avi", "avif", "bmp", "cap", "cin", "cr2", "cr3", "crw",
-    "dcr", "dng", "erf", "fff", "flv", "gif", "heic", "heif", "hif", "iiq", "insp", "insv", "jp2",
-    "jpe", "jpeg", "jpg", "jxl", "k25", "kdc", "m2t", "m2ts", "m4v", "mkv", "mov", "mp4", "mpe",
-    "mpeg", "mpg", "mpo", "mrw", "mts", "mxf", "nef", "nrw", "orf", "ori", "pef", "png", "psd",
-    "raf", "raw", "rw2", "rwl", "sr2", "srf", "srw", "svg", "tif", "tiff", "ts", "vob", "webm",
-    "webp", "wmv", "x3f",
-];
 
 /// Number of consecutive stable size checks required before a file is considered complete.
 const REQUIRED_STABLE_COUNTS: u32 = 3;
@@ -182,7 +170,7 @@ impl Monitor {
                                     path.extension().map(|e| e.to_string_lossy().to_lowercase());
                                 let ext_str = ext.as_deref().unwrap_or("");
 
-                                if !MEDIA_EXTENSIONS.contains(&ext_str) {
+                                if !media_kinds::is_supported_ext(ext_str) {
                                     continue;
                                 }
 
@@ -370,13 +358,7 @@ pub(crate) fn compute_sha1_chunked(path: &str) -> io::Result<String> {
 
 /// Return whether a path points to a supported media file rather than a directory.
 pub(crate) fn is_supported_media_path(path: &Path) -> bool {
-    if path.is_dir() {
-        return false;
-    }
-
-    let ext = path.extension().map(|e| e.to_string_lossy().to_lowercase());
-    let ext_str = ext.as_deref().unwrap_or("");
-    MEDIA_EXTENSIONS.contains(&ext_str)
+    media_kinds::is_supported_path(path)
 }
 
 pub(crate) fn is_temporary_file(path: &Path) -> bool {

--- a/src/queue_manager.rs
+++ b/src/queue_manager.rs
@@ -10,9 +10,10 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, mpsc};
+use tokio_util::sync::CancellationToken;
 
 fn upload_progress_callback(
     shared_state: &Arc<parking_lot::Mutex<AppState>>,
@@ -72,6 +73,8 @@ pub struct QueueManager {
     policy: Arc<parking_lot::Mutex<EnvironmentPolicy>>,
     worker_limit: Arc<AtomicUsize>,
     batch_notify_state: Arc<parking_lot::Mutex<BatchNotifyState>>,
+    accepting_new: Arc<AtomicBool>,
+    shutdown_token: CancellationToken,
 }
 
 #[derive(Debug, Default)]
@@ -138,6 +141,8 @@ impl QueueManager {
         let batch_notify_state = Arc::new(parking_lot::Mutex::new(BatchNotifyState::default()));
         let connectivity_lost_notified = Arc::new(parking_lot::Mutex::new(false));
         let consecutive_failures = Arc::new(parking_lot::Mutex::new(0usize));
+        let accepting_new = Arc::new(AtomicBool::new(true));
+        let shutdown_token = CancellationToken::new();
 
         let qm = Self {
             sender: tx,
@@ -148,6 +153,8 @@ impl QueueManager {
             policy: policy_ref.clone(),
             worker_limit: worker_limit.clone(),
             batch_notify_state: batch_notify_state.clone(),
+            accepting_new: accepting_new.clone(),
+            shutdown_token: shutdown_token.clone(),
         };
 
         for i in 0..MAX_WORKERS {
@@ -163,17 +170,26 @@ impl QueueManager {
             let consec_fail_ref = consecutive_failures.clone();
             let policy_ref = policy_ref.clone();
             let worker_limit_ref = worker_limit.clone();
+            let cancel = shutdown_token.clone();
 
             tokio::spawn(async move {
                 log::debug!("Worker {} started", i);
                 loop {
                     while i >= worker_limit_ref.load(Ordering::Relaxed) {
+                        if cancel.is_cancelled() {
+                            log::debug!("Worker {} cancelled while throttled, exiting.", i);
+                            return;
+                        }
                         tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
                     }
 
-                    let task = {
-                        let mut receiver = rx_clone.lock().await;
-                        receiver.recv().await
+                    let task = tokio::select! {
+                        biased;
+                        _ = cancel.cancelled() => None,
+                        msg = async {
+                            let mut receiver = rx_clone.lock().await;
+                            receiver.recv().await
+                        } => msg,
                     };
 
                     match task {
@@ -222,12 +238,21 @@ impl QueueManager {
                             );
 
                             let t_start = std::time::Instant::now();
-                            let sync_target = handle_upload(
-                                &api,
-                                &file_task,
-                                upload_progress_callback(&state_ref, file_task.path.clone()),
-                            )
-                            .await;
+                            let sync_target = tokio::select! {
+                                biased;
+                                _ = cancel.cancelled() => {
+                                    log::warn!(
+                                        "Upload cancelled by shutdown: {}",
+                                        file_task.path
+                                    );
+                                    None
+                                }
+                                res = handle_upload(
+                                    &api,
+                                    &file_task,
+                                    upload_progress_callback(&state_ref, file_task.path.clone()),
+                                ) => res,
+                            };
                             let success = sync_target.is_some();
                             let elapsed = t_start.elapsed().as_secs_f32();
                             let active_route = api.active_route_label().await;
@@ -494,6 +519,10 @@ impl QueueManager {
 
     /// Add a file task to the upload queue and return whether it was accepted.
     pub async fn add_to_queue(&self, task: FileTask) -> bool {
+        if !self.accepting_new.load(Ordering::Relaxed) {
+            log::debug!("Refusing new task during shutdown: {}", task.path);
+            return false;
+        }
         log::debug!("Queuing: {}", task.path);
         {
             let mut pending = self.pending_paths.lock();
@@ -637,6 +666,45 @@ impl QueueManager {
         } else {
             false
         }
+    }
+
+    /// Stop accepting new tasks, wait up to `deadline` for active uploads
+    /// to finish, then hard-cancel anything still in flight.
+    ///
+    /// In-flight uploads that get cancelled at the deadline land in the retry
+    /// list (treated as failures) so `flush_retries` will persist them for the
+    /// next session.
+    pub async fn shutdown(&self, deadline: Duration) {
+        self.accepting_new.store(false, Ordering::Relaxed);
+        let active_now = self.shared_state.lock().active_workers;
+        if active_now == 0 {
+            self.shutdown_token.cancel();
+            return;
+        }
+        log::info!(
+            "Draining {} active upload(s); waiting up to {:?}...",
+            active_now,
+            deadline
+        );
+
+        let start = Instant::now();
+        while start.elapsed() < deadline {
+            if self.shared_state.lock().active_workers == 0 {
+                log::info!("All active uploads finished within deadline.");
+                self.shutdown_token.cancel();
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        let stuck = self.shared_state.lock().active_workers;
+        log::warn!(
+            "Shutdown deadline exceeded; cancelling {} in-flight upload(s).",
+            stuck
+        );
+        self.shutdown_token.cancel();
+        // Brief grace so cancelled futures can record themselves as failed before flush.
+        tokio::time::sleep(Duration::from_millis(250)).await;
     }
 
     /// Persist any in-memory retry items so they survive a clean shutdown.
@@ -983,6 +1051,8 @@ mod tests {
                 })),
                 worker_limit: Arc::new(AtomicUsize::new(1)),
                 batch_notify_state: Arc::new(Mutex::new(BatchNotifyState::default())),
+                accepting_new: Arc::new(AtomicBool::new(true)),
+                shutdown_token: CancellationToken::new(),
             },
             rx,
             shared_state,


### PR DESCRIPTION
## Summary

- Graceful shutdown drains active uploads up to a 5 s deadline before quitting; cancelled uploads land in the existing retry queue and resume next session instead of leaving partial assets on the Immich side.
- Thumbnail disk cache is pruned every 10 minutes on a background task (not just at startup); cap raised from 500 MB to 1 GB.
- Three duplicate extension/MIME tables collapsed into a single `phf` perfect-hash registry in `src/media_kinds.rs`; watcher hot-path check is now O(1).

## Implementation notes

- `QueueManager` gains `accepting_new: AtomicBool` and `shutdown_token: CancellationToken`. Worker `recv()` and `handle_upload` are both wrapped in biased `tokio::select!` arms so the cancel branch is checked first each poll. `add_to_queue` short-circuits when not accepting. The cancelled-upload path falls through the existing failure handling, so `flush_retries()` already persists them.
- `ThumbnailCache::spawn_disk_prune_task(self: &Arc<Self>)` holds only `Weak<Self>` so the cache can drop normally and the loop exits via failed upgrade. Prune itself runs inside `spawn_blocking` to keep the readdir/unlink syscalls off the async runtime.
- `tokio-util` gains the `rt` feature flag for `CancellationToken`.
- New module `src/media_kinds.rs` exports `SUPPORTED: phf::Set`, `mime_for(ext)`, `mime_for_path(path)`, `is_supported_path/ext`, `asset_kind(mime)`. `api_client::mime_for_path` and `library::local_source::mime_for_extension` shrink to thin delegators; `monitor::MEDIA_EXTENSIONS` removed entirely.

## Test plan

- [x] `cargo test` — 92 passing, no regressions
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Manual: trigger a large upload, quit the app mid-flight, confirm the file lands in `retries.json` and resumes next launch
- [x] Manual: leave the library window open for >10 min on a heavily-cached account, confirm `~/.cache/mimick/thumbnails` stays under 1 GB