### PR TITLE
Add MIMICK_PROFILE dev profile switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Configurable test-asset generator script for reproducing deduplication and startup scan benchmarks across all supported API asset formats (#101).
 - Graceful shutdown for in-flight uploads. Quitting the app now stops accepting new tasks, waits up to 5 seconds for active uploads to finish cleanly, then cancels anything still in flight via a cancellation token. Uploads cancelled at the deadline are persisted to the retry queue and resumed on the next launch instead of leaving partial assets on the server.
+- Profile switcher for development and testing via the `MIMICK_PROFILE` environment variable. Each named profile (`MIMICK_PROFILE=dev`) gets fully isolated state: its own config file, sync index, retry queue, thumbnail cache, and keyring entry. The GTK application id is varied per profile so multiple profiles can run simultaneously without activating each other's windows. Portal folder grants are shared across profiles since they are scoped to the Flatpak app-id.
 
 ### Changed
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -226,9 +226,8 @@ pub struct Config {
 impl Config {
     /// Load the config from the standard Mimick config path, creating a default file if missing.
     pub fn new() -> Self {
-        let config_dir = dirs::config_dir()
-            .unwrap_or_else(|| PathBuf::from("~/.config"))
-            .join("mimick");
+        let config_dir = crate::profile::config_dir()
+            .unwrap_or_else(|| PathBuf::from("~/.config").join(crate::profile::dir_segment()));
 
         let config_file = config_dir.join("config.json");
 
@@ -292,7 +291,9 @@ impl Config {
         let result = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 let keyring = oo7::Keyring::new().await?;
-                let attributes = vec![("service", "mimick"), ("account", "api_key")];
+                let account = crate::profile::keyring_account();
+                let attributes: Vec<(&str, &str)> =
+                    vec![("service", "mimick"), ("account", account.as_str())];
                 let items = keyring.search_items(&attributes).await?;
                 if let Some(item) = items.first() {
                     let secret = item.secret().await?;
@@ -325,9 +326,15 @@ impl Config {
         let result = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
                 let keyring = oo7::Keyring::new().await?;
-                let attributes = vec![("service", "mimick"), ("account", "api_key")];
+                let account = crate::profile::keyring_account();
+                let attributes: Vec<(&str, &str)> =
+                    vec![("service", "mimick"), ("account", account.as_str())];
+                let label = match crate::profile::name() {
+                    Some(profile) => format!("Mimick API Key ({})", profile),
+                    None => "Mimick API Key".to_string(),
+                };
                 keyring
-                    .create_item("Mimick API Key", &attributes, secret.as_bytes(), true)
+                    .create_item(&label, &attributes, secret.as_bytes(), true)
                     .await?;
                 Ok::<(), oo7::Error>(())
             })

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -14,12 +14,10 @@ pub fn export_bundle(
     state: &AppState,
     config: &Config,
 ) -> io::Result<PathBuf> {
-    let cache_root = dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("mimick");
-    let data_root = dirs::data_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("mimick");
+    let cache_root = crate::profile::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp").join(crate::profile::dir_segment()));
+    let data_root = crate::profile::data_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp").join(crate::profile::dir_segment()));
     export_bundle_with_paths(destination_root, state, config, &cache_root, &data_root)
 }
 

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -1299,9 +1299,8 @@ async fn ensure_original_asset_path(
     } else {
         asset_id
     };
-    let cache_dir = dirs::cache_dir()
+    let cache_dir = crate::profile::cache_dir()
         .ok_or_else(|| "Could not locate a cache directory.".to_string())?
-        .join("mimick")
         .join("open-in");
     let _ = std::fs::create_dir_all(&cache_dir);
     let safe_name =
@@ -2437,8 +2436,7 @@ fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
                     return;
                 }
                 if full_res {
-                    if let Some(cache_dir) =
-                        dirs::cache_dir().map(|p| p.join("mimick").join("preview"))
+                    if let Some(cache_dir) = crate::profile::cache_dir().map(|p| p.join("preview"))
                     {
                         let _ = std::fs::create_dir_all(&cache_dir);
                         let temp = cache_dir.join(format!("{}.bin", asset_id));
@@ -2710,7 +2708,7 @@ fn open_local_with_default_app(path: &str) {
 
 fn spawn_video_handoff(ui: Rc<LibraryWindowUi>, asset_id: String, filename: String) {
     glib::MainContext::default().spawn_local(async move {
-        let Some(cache_dir) = dirs::cache_dir().map(|p| p.join("mimick").join("video")) else {
+        let Some(cache_dir) = crate::profile::cache_dir().map(|p| p.join("video")) else {
             return;
         };
         let _ = std::fs::create_dir_all(&cache_dir);

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -111,9 +111,8 @@ impl ThumbnailCache {
     const DISK_PRUNE_INTERVAL: Duration = Duration::from_secs(600);
 
     pub fn with_capacity_mb(api_client: std::sync::Arc<ImmichApiClient>, mb: u32) -> Self {
-        let cache_dir = dirs::cache_dir()
-            .unwrap_or_else(|| PathBuf::from("/tmp"))
-            .join("mimick")
+        let cache_dir = crate::profile::cache_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp").join(crate::profile::dir_segment()))
             .join("thumbnails");
 
         let max_bytes = if mb == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod library;
 mod media_kinds;
 mod monitor;
 mod notifications;
+mod profile;
 mod queue_manager;
 mod runtime_env;
 mod sanitize;
@@ -91,9 +92,8 @@ fn detailed_colored_format(
 #[tokio::main]
 async fn main() {
     // Mirror logs to stdout and to a rotating cache file for easier support/debugging.
-    let log_dir = dirs::cache_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-        .join("mimick");
+    let log_dir = profile::cache_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp").join(profile::dir_segment()));
 
     let _logger = Logger::try_with_env_or_str("info")
         .expect("Failed to parse log level")
@@ -117,11 +117,19 @@ async fn main() {
         .start()
         .expect("Failed to initialize logger");
 
+    if let Some(name) = profile::name() {
+        log::info!(
+            "Active profile: {} (state dirs use segment '{}')",
+            name,
+            profile::dir_segment()
+        );
+    }
+
     gtk::gio::resources_register_include!("mimick.gresource")
         .expect("Failed to register bundled GResource");
 
     let app = adw::Application::builder()
-        .application_id("dev.nicx.mimick")
+        .application_id(profile::application_id())
         .flags(gtk::gio::ApplicationFlags::HANDLES_COMMAND_LINE)
         .build();
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,0 +1,155 @@
+//! Per-profile state isolation driven by the `MIMICK_PROFILE` env var.
+//!
+//! When unset (the default), every state directory uses the literal
+//! `mimick` segment under the user's XDG config / data / cache roots.
+//! When set to e.g. `dev`, the segment becomes `mimick-dev`, isolating
+//! config, the sharded SyncIndex, retries, and the thumbnail cache from
+//! the default profile.
+//!
+//! Names are restricted to `[A-Za-z][A-Za-z0-9_-]{0,31}` so they remain valid
+//! both as filesystem path segments (no traversal) and as D-Bus / GTK
+//! application-id segments (must start with a letter). Invalid values are
+//! logged and ignored.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+const PROFILE_ENV_VAR: &str = "MIMICK_PROFILE";
+const MAX_PROFILE_LEN: usize = 32;
+
+static PROFILE: OnceLock<Option<String>> = OnceLock::new();
+static DIR_SEGMENT: OnceLock<String> = OnceLock::new();
+
+/// Active profile name, or `None` when the default profile is in use.
+pub fn name() -> Option<&'static str> {
+    profile().as_deref()
+}
+
+/// Directory segment to use inside `dirs::*_dir()` paths.
+///
+/// Returns `"mimick"` for the default profile and `"mimick-{name}"`
+/// for a named profile.
+pub fn dir_segment() -> &'static str {
+    DIR_SEGMENT
+        .get_or_init(|| match profile() {
+            Some(name) => format!("mimick-{}", name),
+            None => "mimick".to_string(),
+        })
+        .as_str()
+}
+
+pub fn config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join(dir_segment()))
+}
+
+pub fn data_dir() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| d.join(dir_segment()))
+}
+
+pub fn cache_dir() -> Option<PathBuf> {
+    dirs::cache_dir().map(|d| d.join(dir_segment()))
+}
+
+/// GTK / D-Bus application id. Varies by profile so multiple profiles can
+/// run as independent GTK instances. Always remains a valid D-Bus name
+/// because `name()` is sanitised to start with a letter.
+pub fn application_id() -> String {
+    match name() {
+        Some(profile) => format!("dev.nicx.mimick.{}", profile),
+        None => "dev.nicx.mimick".to_string(),
+    }
+}
+
+/// Value for the keyring `account` attribute, scoping the API key per
+/// profile so switching profiles doesn't overwrite the default's secret.
+/// The default profile keeps the historical `"api_key"` value so existing
+/// installations continue to find their stored key.
+pub fn keyring_account() -> String {
+    match name() {
+        Some(profile) => format!("api_key-{}", profile),
+        None => "api_key".to_string(),
+    }
+}
+
+fn profile() -> &'static Option<String> {
+    PROFILE.get_or_init(|| match std::env::var(PROFILE_ENV_VAR) {
+        Ok(raw) => sanitise(&raw),
+        Err(_) => None,
+    })
+}
+
+fn sanitise(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.len() > MAX_PROFILE_LEN {
+        log::warn!(
+            "Ignoring {}: name longer than {} characters",
+            PROFILE_ENV_VAR,
+            MAX_PROFILE_LEN
+        );
+        return None;
+    }
+    if !trimmed
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic())
+    {
+        log::warn!("Ignoring {}: must start with a letter", PROFILE_ENV_VAR);
+        return None;
+    }
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        log::warn!(
+            "Ignoring {}: only [A-Za-z0-9_-] are allowed",
+            PROFILE_ENV_VAR
+        );
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitise;
+
+    #[test]
+    fn sanitise_accepts_typical_names() {
+        assert_eq!(sanitise("dev"), Some("dev".to_string()));
+        assert_eq!(sanitise("staging-2"), Some("staging-2".to_string()));
+        assert_eq!(
+            sanitise("personal_local"),
+            Some("personal_local".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitise_rejects_path_traversal() {
+        assert_eq!(sanitise("../etc"), None);
+        assert_eq!(sanitise("foo/bar"), None);
+        assert_eq!(sanitise(".."), None);
+    }
+
+    #[test]
+    fn sanitise_requires_letter_start_for_dbus_validity() {
+        assert_eq!(sanitise("2024test"), None);
+        assert_eq!(sanitise("-leading-dash"), None);
+        assert_eq!(sanitise("_underscore"), None);
+        assert_eq!(sanitise("a2024"), Some("a2024".to_string()));
+    }
+
+    #[test]
+    fn sanitise_rejects_empty_and_oversized() {
+        assert_eq!(sanitise(""), None);
+        assert_eq!(sanitise("   "), None);
+        assert_eq!(sanitise(&"a".repeat(33)), None);
+    }
+
+    #[test]
+    fn sanitise_trims_whitespace() {
+        assert_eq!(sanitise("  dev  "), Some("dev".to_string()));
+    }
+}

--- a/src/queue_manager.rs
+++ b/src/queue_manager.rs
@@ -110,9 +110,8 @@ impl QueueManager {
         let rx = Arc::new(Mutex::new(rx));
 
         let retry_path = {
-            let mut p = dirs::cache_dir()
-                .unwrap_or_else(|| PathBuf::from("~/.cache"))
-                .join("mimick");
+            let mut p = crate::profile::cache_dir()
+                .unwrap_or_else(|| PathBuf::from("~/.cache").join(crate::profile::dir_segment()));
             p.push("retries.json");
             p
         };

--- a/src/state_manager.rs
+++ b/src/state_manager.rs
@@ -440,10 +440,9 @@ pub struct StateManager {
 impl StateManager {
     /// Point at the standard `status.json` cache path used by Mimick.
     pub fn new() -> Self {
-        // Match Python: ~/.cache/mimick/status.json
-        let cache_dir = dirs::cache_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("~/.cache"))
-            .join("mimick");
+        let cache_dir = crate::profile::cache_dir().unwrap_or_else(|| {
+            std::path::PathBuf::from("~/.cache").join(crate::profile::dir_segment())
+        });
 
         let state_file = cache_dir.join("status.json");
         Self { state_file }

--- a/src/sync_index.rs
+++ b/src/sync_index.rs
@@ -89,9 +89,8 @@ impl ShardedSyncIndex {
     /// from the old cache location on first run so users who clear the
     /// system cache don't lose sync state and trigger a full re-upload.
     pub fn new() -> Self {
-        let index_file = dirs::data_dir()
-            .unwrap_or_else(|| PathBuf::from("/tmp"))
-            .join("mimick")
+        let index_file = crate::profile::data_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp").join(crate::profile::dir_segment()))
             .join("synced_index.json");
 
         migrate_from_cache_dir(&index_file);
@@ -239,8 +238,7 @@ fn migrate_from_cache_dir(new_path: &Path) {
     if new_path.exists() {
         return;
     }
-    let Some(old_path) = dirs::cache_dir().map(|d| d.join("mimick").join("synced_index.json"))
-    else {
+    let Some(old_path) = crate::profile::cache_dir().map(|d| d.join("synced_index.json")) else {
         return;
     };
     if !old_path.exists() {

--- a/wiki/Development.md
+++ b/wiki/Development.md
@@ -40,12 +40,71 @@ cargo run
 cargo run -- --settings
 ```
 
+## Profile Switcher
+
+Mimick supports isolated runtime profiles via the `MIMICK_PROFILE` environment
+variable. Each profile gets its own config, sync index, retry queue, thumbnail
+cache, and keyring entry — letting you run a dev Immich instance without
+touching your personal library.
+
+### Rules
+
+| Rule | Detail |
+|---|---|
+| **Name format** | `[A-Za-z][A-Za-z0-9_-]{0,31}` — must start with a letter (D-Bus name requirement) |
+| **Default** | No env var → uses `mimick/` dirs and `api_key` keyring entry |
+| **Named** | `MIMICK_PROFILE=dev` → uses `mimick-dev/` dirs and `api_key-dev` keyring entry |
+
+### State isolation
+
+| State | Default path | Named-profile path |
+|---|---|---|
+| Config | `~/.config/mimick/config.json` | `~/.config/mimick-dev/config.json` |
+| Sync index | `~/.local/share/mimick/synced_index.json` | `~/.local/share/mimick-dev/synced_index.json` |
+| Retries | `~/.cache/mimick/retries.json` | `~/.cache/mimick-dev/retries.json` |
+| Logs | `~/.cache/mimick/mimick.log` | `~/.cache/mimick-dev/mimick.log` |
+| Thumbnails | `~/.cache/mimick/thumbnails/` | `~/.cache/mimick-dev/thumbnails/` |
+| Keyring entry | `account=api_key` | `account=api_key-dev` |
+
+Inside the Flatpak all paths sit under `~/.var/app/dev.nicx.mimick/` — the
+table above shows relative structure within that root.
+
+### Running a named profile
+
+```bash
+# Local build
+MIMICK_PROFILE=dev cargo run
+
+# Installed Flatpak
+flatpak run --env=MIMICK_PROFILE=dev dev.nicx.mimick
+```
+
+Both profiles can run simultaneously. The GTK `application_id` is set to
+`dev.nicx.mimick.{profile}` for named profiles, so they register as separate
+D-Bus instances and don't activate each other's windows.
+
+### What is NOT isolated
+
+| Resource | Behaviour |
+|---|---|
+| **Portal folder grants** | Shared by Flatpak app-id (`dev.nicx.mimick`). A folder granted to prod is accessible to dev — convenient, not a security boundary. |
+| **XDG autostart entry** | Always refers to the default profile's launch command. |
+| **Installed icons / resources** | Both profiles read from the same Flatpak `/app/` mount. |
+
+A startup log line confirms the active profile:
+
+```
+Active profile: dev (state dirs use segment 'mimick-dev')
+```
+
+---
+
 ## Logging
 
 Mimick uses `flexi_logger` and writes logs to both:
 
 - stdout
-- `~/.cache/mimick/mimick.log`
+- `~/.cache/mimick/mimick.log` (or `~/.cache/mimick-{profile}/mimick.log` for named profiles)
 
 Detailed timestamps are enabled for both outputs.
 Console logs are colorized by level (error/warn/info/debug/trace).

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -54,7 +54,9 @@ Tests in Rust are written inline within identical files to the logic they test, 
 | `src/library/state.rs` | `mod tests` | Tests pagination reset rules, search clearing behaviors, and duplicate request suppression. |
 | `src/library/thumbnail_cache.rs` | `mod tests` | Tests ThumbHash hit/miss logic, memory eviction budgets, and disk removal. |
 | `src/main.rs` | `mod tests` | Tests live-queue watch-path selection so nested folders use the most specific configured target. |
+| `src/media_kinds.rs` | `mod tests` | Tests that every supported extension maps to a MIME entry, that uppercase extensions normalise correctly, and that unknown extensions fall back to `application/octet-stream`. |
 | `src/monitor.rs` | `mod tests` | Tests monitor-side filtering such as temporary-file detection, media extension matching, and SHA-1 checksum computation. |
+| `src/profile.rs` | `mod tests` | Tests profile name sanitisation: valid names, path-traversal rejection, D-Bus letter-start requirement, length cap, and whitespace trimming. |
 | `src/queue_manager.rs` | `mod tests` | Tests duplicate queue prevention, retry persistence, failed-queue clearing, and manual retry requeueing. |
 | `src/runtime_env.rs` | `mod tests` | Tests metered-network parsing and battery-power decision logic without depending on the host system. |
 | `src/settings_window.rs` | `mod tests` | Tests pure-logic helpers used by the settings UI such as config field validation. |


### PR DESCRIPTION
## Summary

- `MIMICK_PROFILE=dev` routes all persistent state into isolated `mimick-dev/` subdirectories: config, sync index, retry queue, logs, and thumbnail cache.
- Named profiles get a distinct GTK `application_id` (`dev.nicx.mimick.dev`) so multiple profiles run as independent instances without activating each other's windows.
- Keyring API key entry is scoped per profile (`account=api_key-dev`); default profile keeps `account=api_key` for backwards compat.
- Profile names are sanitised to `[A-Za-z][A-Za-z0-9_-]{0,31}` — must start with a letter to remain a valid D-Bus name segment.

## Usage

```bash
# cargo run
MIMICK_PROFILE=dev cargo run

# Installed Flatpak
flatpak run --env=MIMICK_PROFILE=dev dev.nicx.mimick
```

## What is and isn't isolated

| Isolated | Shared |
|---|---|
| Config, sync index, retries, logs, thumbnails, keyring entry | Portal folder grants (Flatpak app-id scoped), autostart entry, installed icons |

## Test plan

- [x] `cargo test` — 97 passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Manual: launch with `MIMICK_PROFILE=dev`, confirm separate config dir created and a second window opens alongside the default profile
- [x] Manual: save an API key in dev profile, confirm it does not overwrite the prod keyring entry