### PR TITLE
Fix concurrency races, sync index durability, and signal handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
 - Configurable test-asset generator script for reproducing deduplication and startup scan benchmarks across all supported API asset formats (#101).
 - Graceful shutdown for in-flight uploads. Quitting the app now stops accepting new tasks, waits up to 5 seconds for active uploads to finish cleanly, then cancels anything still in flight via a cancellation token. Uploads cancelled at the deadline are persisted to the retry queue and resumed on the next launch instead of leaving partial assets on the server.
 - Profile switcher for development and testing via the `MIMICK_PROFILE` environment variable. Each named profile (`MIMICK_PROFILE=dev`) gets fully isolated state: its own config file, sync index, retry queue, thumbnail cache, and keyring entry. The GTK application id is varied per profile so multiple profiles can run simultaneously without activating each other's windows. Portal folder grants are shared across profiles since they are scoped to the Flatpak app-id.
@@ -35,6 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Concurrent workers racing to create the same album on first run now serialize via a per-album-name lock with double-checked cache lookup, preventing N duplicate albums being created simultaneously (one per queued file).
+- `fetch_all_albums` now collapses concurrent callers into a single network request via a fetch lock with double-checked `albums_fetched` flag. Previously, concurrent startup-scan workers each fired an independent `GET /api/albums`, then re-inserted the same entries and reported every album as a false-positive duplicate.
+- Duplicate album detection now compares IDs within a single server response (built into a fresh map before replacing the cache), so "same name, same ID" entries from a re-fetch are ignored silently while genuine server-side duplicates (same name, different ID) still warn and keep the first.
+- `refresh_album_cache` now holds the fetch lock across its clear → reset → refetch sequence, closing a race where a concurrent in-flight fetch could populate the cache after the clear but before the reset, leaving the cache empty with the flag set to true.
+- Sync index state is now flushed to disk when the upload queue goes idle, ensuring a clean restart never re-queues already-uploaded files even after an immediate exit following a fast batch.
+- Sync index is now flushed on graceful shutdown (tray quit, window close) so records written since the last 10-second periodic flush are not lost.
+- SIGINT and SIGTERM signals now route through the GTK graceful shutdown path instead of killing the process immediately, so uploads drain, retries persist, and the sync index flushes before exit.
+- `flush()` in the sync index now clears dirty bits only after a successful write. Previously, a failed `atomic_write` (e.g. disk full) would silently mark shards clean, causing subsequent flush calls to skip them and permanently lose the unwritten records.
+- Removed a broken auto-flush trigger in `record_synced` that fired when `shard.entries.len()` was a multiple of 50 — this checked total entry count, not dirty-since-last-flush count, so it fired unpredictably and never for small datasets. Flush scheduling is now handled solely by the 10-second timer and idle-queue flush.
+- Concurrent `check_connection` callers (queue workers, library ping loop, main loop) now serialize via a single-flight lock. Callers that arrive while a probe is already in flight coalesce onto its result within a 1-second window, eliminating redundant LAN/WAN ping bursts at startup without suppressing the 5-second library re-check.
 - Escape key and Clear button now properly exit selection mode entirely instead of just clearing selected items.
 - Asset sync status in the lightbox details pane and thumbnail hover now reflects the asset's true state (local only, remote only, or both) instead of being implied by the active view. Root cause: Immich returns SHA-1 checksums as base64 in API responses while the sync index stores them as lowercase hex; the representations are now normalised on read so checksum-to-path reverse lookups resolve correctly across all views including unified and album-unified.
 - In-app symbolic icons (`mimick-upload-symbolic`, `mimick-download-symbolic`) are now compiled into the binary via `glib-build-tools::compile_resources` and registered at startup with `gtk::IconTheme::add_resource_path("/dev/nicx/mimick/icons")`, replacing a `theme.add_search_path(env!("CARGO_MANIFEST_DIR"))` call that resolved to a nonexistent path in all non-`cargo run` environments.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = "0.3.32"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha1 = "0.11.0" 
-tokio = { version = "1.52.1", features = ["rt-multi-thread", "sync", "time", "fs", "macros", "io-util", "process"] }
+tokio = { version = "1.52.1", features = ["rt-multi-thread", "sync", "time", "fs", "macros", "io-util", "process", "signal"] }
 flexi_logger = "0.31.8"
 thumbhash = "0.1"
 base64 = "0.22"

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -7,7 +7,7 @@ use reqwest::Client;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, Semaphore};
 
 pub type TransferProgressCallback = Arc<dyn Fn(u64, Option<u64>) + Send + Sync>;
@@ -249,6 +249,18 @@ pub struct ImmichApiClient {
     last_issue: Mutex<Option<ApiIssue>>,
     /// Caches album names to album IDs to avoid repeated list/create API calls.
     album_cache: Mutex<HashMap<String, String>>,
+    /// Per-album-name async locks that serialize concurrent get-or-create calls
+    /// for the *same* name, preventing duplicate-album creation under load.
+    album_create_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+    /// Serializes `fetch_all_albums` so concurrent callers don't all hit the
+    /// network and race writes into the cache.
+    album_fetch_lock: Mutex<()>,
+    /// Serializes `check_connection` so concurrent callers collapse into one
+    /// connectivity probe instead of each issuing their own LAN+WAN pings.
+    connection_check_lock: Mutex<()>,
+    /// Timestamp of the most recent successful connectivity probe. Used to
+    /// coalesce concurrent burst callers without suppressing periodic re-checks.
+    last_successful_check: Mutex<Option<Instant>>,
     albums_fetched: Mutex<bool>,
     thumbnail_semaphore: Arc<Semaphore>,
 }
@@ -281,6 +293,10 @@ impl ImmichApiClient {
             active_url: Mutex::new(None),
             last_issue: Mutex::new(None),
             album_cache: Mutex::new(HashMap::new()),
+            album_create_locks: Mutex::new(HashMap::new()),
+            album_fetch_lock: Mutex::new(()),
+            connection_check_lock: Mutex::new(()),
+            last_successful_check: Mutex::new(None),
             albums_fetched: Mutex::new(false),
             thumbnail_semaphore: Arc::new(Semaphore::new(8)),
         }
@@ -339,6 +355,18 @@ impl ImmichApiClient {
 
     /// Determine which base URL to use, preferring the internal address when reachable.
     pub async fn check_connection(&self) -> bool {
+        let _check_guard = self.connection_check_lock.lock().await;
+
+        // Coalesce burst callers: if another caller probed successfully within
+        // the last second, reuse that result. Periodic re-checks (e.g. the 5s
+        // library ping loop) still re-probe because their gap exceeds 1s.
+        if self.active_url.lock().await.is_some()
+            && let Some(when) = *self.last_successful_check.lock().await
+            && when.elapsed() < Duration::from_secs(1)
+        {
+            return true;
+        }
+
         log::debug!("Checking connectivity...");
         let settings = self.settings.read().clone();
         let was_active = self.active_url.lock().await.clone();
@@ -347,6 +375,7 @@ impl ImmichApiClient {
             let mut active = self.active_url.lock().await;
             let was_offline = was_active.is_none();
             *active = Some(settings.internal_url.clone());
+            *self.last_successful_check.lock().await = Some(Instant::now());
             self.clear_issue().await;
             if was_offline {
                 log::info!("Connected via LAN: {}", settings.internal_url);
@@ -360,6 +389,7 @@ impl ImmichApiClient {
             let mut active = self.active_url.lock().await;
             let was_offline = was_active.is_none();
             *active = Some(settings.external_url.clone());
+            *self.last_successful_check.lock().await = Some(Instant::now());
             self.clear_issue().await;
             if was_offline {
                 log::info!("Connected via WAN: {}", settings.external_url);
@@ -693,7 +723,18 @@ impl ImmichApiClient {
     }
 
     /// Get all albums from Immich, populating the local cache.
+    /// Acquires `album_fetch_lock`; do not call while already holding it.
     async fn fetch_all_albums(&self) {
+        let _fetch_guard = self.album_fetch_lock.lock().await;
+        if *self.albums_fetched.lock().await {
+            return;
+        }
+        self.fetch_all_albums_locked().await;
+    }
+
+    /// Inner fetch implementation. Assumes `album_fetch_lock` is held by the
+    /// caller and `albums_fetched` is already known to be false.
+    async fn fetch_all_albums_locked(&self) {
         let base_url = match self.get_active_url().await {
             Some(u) => u,
             None => {
@@ -723,13 +764,41 @@ impl ImmichApiClient {
         {
             Ok(resp) if resp.status().is_success() => {
                 if let Ok(albums) = resp.json::<Vec<AlbumSummary>>().await {
-                    let mut cache = self.album_cache.lock().await;
+                    let total = albums.len();
+                    let mut fresh: HashMap<String, String> = HashMap::with_capacity(total);
+                    let mut duplicates = 0usize;
                     for album in albums {
-                        cache.insert(album.album_name, album.id);
+                        match fresh.get(&album.album_name) {
+                            Some(existing_id) if existing_id != &album.id => {
+                                duplicates += 1;
+                                log::warn!(
+                                    "Duplicate album on server: '{}' has both id {} and {} (keeping first). Future syncs will use the first.",
+                                    album.album_name,
+                                    existing_id,
+                                    album.id
+                                );
+                            }
+                            Some(_) => {
+                                // Same name + same id: server returned an entry twice; ignore silently.
+                            }
+                            None => {
+                                fresh.insert(album.album_name, album.id);
+                            }
+                        }
+                    }
+                    let unique = fresh.len();
+                    {
+                        let mut cache = self.album_cache.lock().await;
+                        *cache = fresh;
                     }
                     *self.albums_fetched.lock().await = true;
                     self.clear_issue().await;
-                    log::info!("Cached {} albums.", cache.len());
+                    log::info!(
+                        "Cached {} unique album(s) from {} server entries ({} duplicate(s) ignored).",
+                        unique,
+                        total,
+                        duplicates
+                    );
                 }
             }
             Ok(resp) => {
@@ -752,12 +821,13 @@ impl ImmichApiClient {
     }
 
     pub async fn refresh_album_cache(&self) {
+        let _fetch_guard = self.album_fetch_lock.lock().await;
         {
             let mut cache = self.album_cache.lock().await;
             cache.clear();
         }
         *self.albums_fetched.lock().await = false;
-        self.fetch_all_albums().await;
+        self.fetch_all_albums_locked().await;
     }
 
     /// Return a snapshot of all cached albums as a list of (albumName, id)
@@ -848,10 +918,25 @@ impl ImmichApiClient {
             }
         }
         if !*self.albums_fetched.lock().await {
-            // Cannot fetch albums, so we shouldn't attempt to create one blindly, nor should we return Ok(None)
-            // which implies the album doesn't exist and can't be created. It's a network error.
             return Err("Cannot fetch albums to verify existence".to_string());
         }
+
+        let create_lock = {
+            let mut locks = self.album_create_locks.lock().await;
+            locks
+                .entry(album_name.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        let _guard = create_lock.lock().await;
+
+        {
+            let cache = self.album_cache.lock().await;
+            if let Some(id) = cache.get(album_name) {
+                return Ok(Some(id.clone()));
+            }
+        }
+
         self.create_album(album_name).await
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -607,6 +607,45 @@ async fn main() {
     });
 
     log::info!("GTK application starting up");
+
+    if is_primary_instance.load(Ordering::SeqCst) {
+        let quit_requested = Arc::new(AtomicBool::new(false));
+        let qr_signal = quit_requested.clone();
+        tokio::spawn(async move {
+            let mut sigterm =
+                match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                    Ok(s) => s,
+                    Err(err) => {
+                        log::warn!("Could not install SIGTERM handler: {}", err);
+                        return;
+                    }
+                };
+            tokio::select! {
+                res = tokio::signal::ctrl_c() => {
+                    if let Err(err) = res {
+                        log::warn!("SIGINT handler error: {}", err);
+                        return;
+                    }
+                    log::info!("Received SIGINT; requesting graceful shutdown.");
+                }
+                _ = sigterm.recv() => {
+                    log::info!("Received SIGTERM; requesting graceful shutdown.");
+                }
+            }
+            qr_signal.store(true, Ordering::SeqCst);
+        });
+
+        let app_for_quit = app.clone();
+        glib::timeout_add_local(std::time::Duration::from_millis(200), move || {
+            if quit_requested.load(Ordering::SeqCst) {
+                app_for_quit.quit();
+                glib::ControlFlow::Break
+            } else {
+                glib::ControlFlow::Continue
+            }
+        });
+    }
+
     app.run();
 
     // Persist final state and any pending retries on graceful shutdown.
@@ -616,6 +655,9 @@ async fn main() {
                 .shutdown(std::time::Duration::from_secs(5))
                 .await;
             ctx.queue_manager.flush_retries();
+            if let Err(err) = ctx.sync_index.flush() {
+                log::warn!("Failed to flush sync index on shutdown: {}", err);
+            }
         }
         let state = APP_CONTEXT
             .get()

--- a/src/queue_manager.rs
+++ b/src/queue_manager.rs
@@ -412,6 +412,9 @@ impl QueueManager {
                                     };
                                     s.progress = 100;
                                     log::info!("All {} file(s) processed. Idle.", s.total_queued);
+                                    if let Err(err) = sync_index_ref.flush() {
+                                        log::warn!("Failed to flush sync index on idle: {}", err);
+                                    }
                                     let mut batch_state = batch_notify_ref.lock();
                                     if batch_state.active
                                         && batch_state.current_batch_id

--- a/src/sync_index.rs
+++ b/src/sync_index.rs
@@ -155,15 +155,7 @@ impl ShardedSyncIndex {
             .checksum_to_path
             .insert(checksum.to_string(), path.to_string());
         shard.dirty = true;
-
-        // Auto-flush when any shard accumulates enough changes.
-        let dirty_count = shard.entries.len();
-        drop(shard);
-        if dirty_count.is_multiple_of(50) {
-            self.flush()
-        } else {
-            Ok(())
-        }
+        Ok(())
     }
 
     /// Drop records for files that no longer exist under any configured watch path.
@@ -210,23 +202,28 @@ impl ShardedSyncIndex {
     }
 
     /// Force a flush to disk if there are unwritten changes.
+    /// Dirty markers are only cleared after a successful write, so a failed
+    /// write leaves the data marked dirty for the next flush attempt.
     pub fn flush(&self) -> io::Result<()> {
         let mut merged = HashMap::new();
         let mut any_dirty = false;
         for lock in &self.shards {
-            let mut shard = lock.write().unwrap();
+            let shard = lock.read().unwrap();
             if shard.dirty {
                 any_dirty = true;
-                shard.dirty = false;
             }
             merged.extend(shard.entries.iter().map(|(k, v)| (k.clone(), v.clone())));
         }
-        if any_dirty {
-            let content = serde_json::to_string_pretty(&SyncIndexDataRef { files: &merged })?;
-            crate::util::atomic_write(&self.index_file, content.as_bytes())
-        } else {
-            Ok(())
+        if !any_dirty {
+            return Ok(());
         }
+        let content = serde_json::to_string_pretty(&SyncIndexDataRef { files: &merged })?;
+        crate::util::atomic_write(&self.index_file, content.as_bytes())?;
+        for lock in &self.shards {
+            let mut shard = lock.write().unwrap();
+            shard.dirty = false;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

- **Duplicate album race**: per-name lock in `get_or_create_album` serializes concurrent workers so only one album is ever created per name, regardless of how many files queue simultaneously
- **Album fetch single-flight**: `fetch_all_albums` now collapses concurrent callers (startup scan + queue workers + library) into a single `GET /api/albums`; eliminates false-positive "Duplicate album on server" warnings caused by multiple fetches populating the same cache
- **refresh_album_cache atomicity**: clear → reset → refetch now held under the fetch lock so a concurrent in-flight fetch can't leave the cache empty with the flag set true
- **Sync index durability**: flushed on queue idle, on graceful shutdown, and on SIGINT/SIGTERM — state now survives an immediate exit after a fast batch without re-queueing already-uploaded files on next launch
- **Signal handling**: SIGINT/SIGTERM route through GTK's `app.quit()` via an `AtomicBool` + `glib::timeout_add_local` poller, so shutdown drain + flush runs on Ctrl+C and `kill` (compatible with Flatpak's `bwrap` signal forwarding)
- **flush() correctness**: dirty bits cleared only after successful `atomic_write`; previously a disk-full or temp-write failure silently marked shards clean and permanently skipped those records
- **Removed broken auto-flush**: `is_multiple_of(50)` in `record_synced` checked total shard entry count, not dirty-since-last-flush; never fired for small datasets, fired unpredictably for large ones
- **check_connection single-flight**: 1-second coalescing window collapses startup ping bursts without suppressing the library's 5-second periodic re-check

## Test plan

- [x] Full scan with 9+ assets: confirm exactly **one** "Creating album" log line (no duplicate albums)
- [x] Restart immediately after fast batch completes: expect "no unsynced files found" not "queued N unsynced"
- [x] `Ctrl+C` mid-batch in terminal: confirm graceful drain log + clean restart with correct sync state
- [x] Start app, confirm single "Fetching album list..." line and zero "Duplicate album on server" warnings
- [x] All 97 unit tests pass (`cargo test`)