### PR TITLE
Settings: auto-save prefs, rename save button, fix close-cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Closing the settings window no longer also closes the library window when background sync is disabled. The "quit when settings closes" path now checks for other open application windows first and only quits when settings was the only window left.
+- Settings: the "Enable Library View" toggle, "Open Originals in Lightbox" toggle, and "Thumbnail Memory Cache (MB)" spinner now save immediately on change instead of requiring a click on the connection-save button. Each handler skips the disk write when the value matches the existing config (avoids redundant writes during initial population).
+- Settings: the connection-save button has been renamed from "Save Connection Settings" to "Save Credentials" so the action label matches what the field group is actually about (URL + API key).
 - Concurrent workers racing to create the same album on first run now serialize via a per-album-name lock with double-checked cache lookup, preventing N duplicate albums being created simultaneously (one per queued file).
 - `fetch_all_albums` now collapses concurrent callers into a single network request via a fetch lock with double-checked `albums_fetched` flag. Previously, concurrent startup-scan workers each fired an independent `GET /api/albums`, then re-inserted the same entries and reported every album as a false-positive duplicate.
 - Duplicate album detection now compares IDs within a single server response (built into a fresh map before replacing the cache), so "same name, same ID" entries from a re-fetch are ignored silently while genuine server-side duplicates (same name, different ID) still warn and keep the first.

--- a/src/library/state.rs
+++ b/src/library/state.rs
@@ -1,5 +1,7 @@
 //! Library runtime state used by the built-in asset browser.
 
+use std::collections::VecDeque;
+
 use crate::api_client::{
     LibraryAlbum, LibraryAsset, MetadataSearchFilters, ServerAbout, ServerStats,
 };
@@ -110,7 +112,8 @@ pub struct LibraryState {
     pub previous_non_search_source: LibrarySource,
     /// Stack of past sources for back-navigation. Pushed by `navigate_to`,
     /// popped by `navigate_back`. Searches are not pushed (they are ephemeral).
-    pub nav_history: Vec<LibrarySource>,
+    /// `VecDeque` for O(1) front pops when the 50-entry cap is hit.
+    pub nav_history: VecDeque<LibrarySource>,
     pub sort_mode: LibrarySortMode,
     pub load_state: LibraryLoadState,
     pub selected_asset_id: Option<String>,
@@ -128,7 +131,7 @@ impl Default for LibraryState {
         Self {
             source: LibrarySource::AllAssets,
             previous_non_search_source: LibrarySource::AllAssets,
-            nav_history: Vec::new(),
+            nav_history: VecDeque::new(),
             sort_mode: LibrarySortMode::NewestFirst,
             load_state: LibraryLoadState::Idle,
             selected_asset_id: None,
@@ -177,11 +180,11 @@ impl LibraryState {
     pub fn navigate_to(&mut self, source: LibrarySource) -> (u64, LibrarySource, u32) {
         if self.source != source
             && !self.source.is_search()
-            && self.nav_history.last() != Some(&self.source)
+            && self.nav_history.back() != Some(&self.source)
         {
-            self.nav_history.push(self.source.clone());
+            self.nav_history.push_back(self.source.clone());
             if self.nav_history.len() > 50 {
-                self.nav_history.remove(0);
+                self.nav_history.pop_front();
             }
         }
         self.switch_source(source)
@@ -190,7 +193,7 @@ impl LibraryState {
     /// Pop one entry from nav_history and switch to it. Does not push to
     /// history. Returns None when there's nowhere to go back to.
     pub fn navigate_back(&mut self) -> Option<(u64, LibrarySource, u32)> {
-        let prev = self.nav_history.pop()?;
+        let prev = self.nav_history.pop_back()?;
         Some(self.switch_source(prev))
     }
 

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -547,14 +547,28 @@ pub fn build_settings_window_with_parent(
         .build();
     library_group.add(&cache_size_row);
 
+    // Debounce the spinner save: a held-down arrow fires connect_value_notify
+    // many times per second, and each save takes the config write lock + does
+    // synchronous JSON serialise + atomic_write on the UI thread. We coalesce
+    // bursts by scheduling the save after 400 ms of quiet.
+    let pending_cache_save: Rc<Cell<Option<glib::SourceId>>> = Rc::new(Cell::new(None));
     let ctx_for_cache = ctx.clone();
     cache_size_row.connect_value_notify(move |row| {
         let new_value = row.value() as u32;
-        let mut cfg = ctx_for_cache.config.write();
-        if cfg.data.library_thumbnail_cache_mb != new_value {
-            cfg.data.library_thumbnail_cache_mb = new_value;
-            cfg.save();
+        if let Some(id) = pending_cache_save.take() {
+            id.remove();
         }
+        let ctx_for_save = ctx_for_cache.clone();
+        let pending = pending_cache_save.clone();
+        let id = glib::timeout_add_local_once(Duration::from_millis(400), move || {
+            pending.set(None);
+            let mut cfg = ctx_for_save.config.write();
+            if cfg.data.library_thumbnail_cache_mb != new_value {
+                cfg.data.library_thumbnail_cache_mb = new_value;
+                cfg.save();
+            }
+        });
+        pending_cache_save.set(Some(id));
     });
 
     // --- WATCH FOLDERS GROUP ---
@@ -1383,13 +1397,18 @@ pub fn build_settings_window_with_parent(
         #[strong]
         app_clone,
         #[strong]
-        background_sync_state,
+        ctx,
         move |_| {
+            // Read current background-sync state directly from config rather
+            // than from a shadow RefCell, so any code path that mutates the
+            // config (apply_settings, future autosave, etc.) is reflected
+            // here without a separate book-keeping step.
             // The closing window is still in app.windows() at this point, so
             // a count of 1 means we're the only window left — quit the app.
             // > 1 means another window (typically the library) is open and
             // should keep running.
-            if !*background_sync_state.borrow() && app_clone.windows().len() <= 1 {
+            let bg_sync = ctx.config.read().data.background_sync_enabled;
+            if !bg_sync && app_clone.windows().len() <= 1 {
                 app_clone.quit();
                 return glib::Propagation::Stop;
             }

--- a/src/settings_window.rs
+++ b/src/settings_window.rs
@@ -293,7 +293,7 @@ pub fn build_settings_window_with_parent(
     conn_group.add(&test_btn);
 
     let save_btn = Button::builder()
-        .label("Save Connection Settings")
+        .label("Save Credentials")
         .css_classes(vec!["suggested-action".to_string()])
         .margin_top(6)
         .build();
@@ -445,15 +445,23 @@ pub fn build_settings_window_with_parent(
 
     // Surface a clear "restart required" hint the moment the user flips the
     // toggle, since the running window is still the old one until next launch.
+    // Also auto-save: this is a pure preference with no validation needed.
     let initial_library_view = config.data.library_view_enabled;
+    let ctx_for_lib_view = ctx.clone();
     library_view_row.connect_active_notify(move |row| {
-        let needs_restart = row.is_active() != initial_library_view;
+        let active = row.is_active();
+        let needs_restart = active != initial_library_view;
         let subtitle = if needs_restart {
             "Restart Mimick to apply the new window layout."
         } else {
             "Turn on the in-app library browser. Restart Mimick to switch which window opens."
         };
         row.set_subtitle(subtitle);
+        let mut cfg = ctx_for_lib_view.config.write();
+        if cfg.data.library_view_enabled != active {
+            cfg.data.library_view_enabled = active;
+            cfg.save();
+        }
     });
 
     let catchup_model = gtk::StringList::new(&["Full Scan", "Recent Only (7d)", "New Files Only"]);
@@ -521,6 +529,16 @@ pub fn build_settings_window_with_parent(
         .build();
     library_group.add(&preview_full_row);
 
+    let ctx_for_preview = ctx.clone();
+    preview_full_row.connect_active_notify(move |row| {
+        let active = row.is_active();
+        let mut cfg = ctx_for_preview.config.write();
+        if cfg.data.library_preview_full_resolution != active {
+            cfg.data.library_preview_full_resolution = active;
+            cfg.save();
+        }
+    });
+
     let cache_adj = gtk::Adjustment::new(80.0, 16.0, 1024.0, 16.0, 64.0, 0.0);
     let cache_size_row = adw::SpinRow::builder()
         .title("Thumbnail Memory Cache (MB)")
@@ -528,6 +546,16 @@ pub fn build_settings_window_with_parent(
         .adjustment(&cache_adj)
         .build();
     library_group.add(&cache_size_row);
+
+    let ctx_for_cache = ctx.clone();
+    cache_size_row.connect_value_notify(move |row| {
+        let new_value = row.value() as u32;
+        let mut cfg = ctx_for_cache.config.write();
+        if cfg.data.library_thumbnail_cache_mb != new_value {
+            cfg.data.library_thumbnail_cache_mb = new_value;
+            cfg.save();
+        }
+    });
 
     // --- WATCH FOLDERS GROUP ---
     let folders_group = adw::PreferencesGroup::builder()
@@ -1347,14 +1375,21 @@ pub fn build_settings_window_with_parent(
         }
     ));
 
-    // If background sync is disabled, closing the settings window should exit the app.
+    // If background sync is disabled AND this is the only open window, closing
+    // settings should exit the app. When the library window is also open we
+    // must not quit — the user explicitly opened settings *from* the library
+    // and expects the library to stay around after dismissing settings.
     window.connect_close_request(clone!(
         #[strong]
         app_clone,
         #[strong]
         background_sync_state,
         move |_| {
-            if !*background_sync_state.borrow() {
+            // The closing window is still in app.windows() at this point, so
+            // a count of 1 means we're the only window left — quit the app.
+            // > 1 means another window (typically the library) is open and
+            // should keep running.
+            if !*background_sync_state.borrow() && app_clone.windows().len() <= 1 {
                 app_clone.quit();
                 return glib::Propagation::Stop;
             }


### PR DESCRIPTION
Closes #111, closes #110.

- Auto-save for Enable Library View, Open Originals, and Thumbnail Cache MB.
- Renamed "Save Connection Settings" → "Save Credentials".
- Closing settings no longer kills the library window when background sync is off.