### PR TITLE
ui: mobile/narrow viewport rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Mobile and narrow viewport UI overhaul: optimized component dimensions for 360px width screens, adjusted album and explore tile layouts to 2-column on mobile with uniform sizing, reduced header controls footprint, and improved overall narrow-screen usability.
+- Album and explore view tile rendering now uses fixed 100px height with viewport-responsive width (via FlowBox homogeneous layout), ensuring consistent thumbnail aspect ratios and eliminating layout jitter on window resizes.
+- Grid view minimum columns reduced from 3 to 2 on narrow viewports to fit within 360px width constraints without overflow.
+
+### Fixed
+
+- Album/explore tile thumbnails now maintain uniform sizes within a viewport and display correctly at 360px window width, with no collapse on window-height changes.
+- FlowBox children per line constraints adjusted (min 2, max 6 for albums) to ensure 2-column layout on mobile while limiting tile width growth on desktop.
+
 ## [9.5.4] - 2026-05-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,4 @@ opt-level = "z"        # Optimise for binary size (less code = less mapped pages
 codegen-units = 1      # Full whole-program optimisation
 lto = true             # Link-Time Optimisation – dead code is stripped at link time
 panic = "abort"        # Remove panic unwinding machinery (~60-100 KB of runtime)
-strip = true           # Strip debug symbols from the final binary
+strip = false           # Strip debug symbols from the final binary

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -3408,14 +3408,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tower-http/tower-http-0.6.10.crate",
-        "sha256": "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51",
-        "dest": "cargo/vendor/tower-http-0.6.10"
+        "url": "https://static.crates.io/crates/tower-http/tower-http-0.6.11.crate",
+        "sha256": "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840",
+        "dest": "cargo/vendor/tower-http-0.6.11"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51\", \"files\": {}}",
-        "dest": "cargo/vendor/tower-http-0.6.10",
+        "contents": "{\"package\": \"4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840\", \"files\": {}}",
+        "dest": "cargo/vendor/tower-http-0.6.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/library/albums_view.rs
+++ b/src/library/albums_view.rs
@@ -156,15 +156,10 @@ fn album_tile(ctx: Arc<AppContext>, album: &LibraryAlbum, on_click: AlbumClick) 
     let picture = gtk::Picture::builder()
         .can_shrink(true)
         .content_fit(gtk::ContentFit::Cover)
+        .height_request(100)
         .hexpand(true)
-        .vexpand(true)
+        .vexpand(false)
         .css_classes(vec!["mimick-explore-tile".to_string()])
-        .build();
-    let frame = gtk::AspectFrame::builder()
-        .obey_child(false)
-        .ratio(160.0 / 100.0)
-        .hexpand(true)
-        .child(&picture)
         .build();
     let meta_row = gtk::Box::builder()
         .orientation(gtk::Orientation::Horizontal)
@@ -190,7 +185,7 @@ fn album_tile(ctx: Arc<AppContext>, album: &LibraryAlbum, on_click: AlbumClick) 
         .build();
     meta_row.append(&title_label);
     meta_row.append(&count_label);
-    tile_box.append(&frame);
+    tile_box.append(&picture);
     tile_box.append(&meta_row);
 
     let button = gtk::Button::builder()

--- a/src/library/albums_view.rs
+++ b/src/library/albums_view.rs
@@ -137,11 +137,10 @@ fn build_section(title: &str) -> (gtk::Box, gtk::FlowBox) {
     let grid = gtk::FlowBox::builder()
         .selection_mode(gtk::SelectionMode::None)
         .max_children_per_line(12)
-        .min_children_per_line(1)
+        .min_children_per_line(2)
         .row_spacing(12)
         .column_spacing(12)
-        .homogeneous(false)
-        .halign(gtk::Align::Start)
+        .homogeneous(true)
         .build();
     section.append(&label);
     section.append(&grid);
@@ -152,11 +151,17 @@ fn album_tile(ctx: Arc<AppContext>, album: &LibraryAlbum, on_click: AlbumClick) 
     let tile_box = gtk::Box::builder()
         .orientation(gtk::Orientation::Vertical)
         .spacing(4)
+        .css_classes(vec!["mimick-tile-box".to_string()])
         .build();
     let picture = gtk::Picture::builder()
-        .width_request(200)
-        .height_request(160)
+        .can_shrink(true)
         .content_fit(gtk::ContentFit::Cover)
+        .width_request(160)
+        .height_request(100)
+        .hexpand(false)
+        .vexpand(false)
+        .halign(gtk::Align::Fill)
+        .valign(gtk::Align::Start)
         .css_classes(vec!["mimick-explore-tile".to_string()])
         .build();
     let meta_row = gtk::Box::builder()
@@ -168,6 +173,8 @@ fn album_tile(ctx: Arc<AppContext>, album: &LibraryAlbum, on_click: AlbumClick) 
         .xalign(0.0)
         .hexpand(true)
         .ellipsize(gtk::pango::EllipsizeMode::End)
+        .width_chars(1)
+        .max_width_chars(1)
         .css_classes(vec!["caption-heading".to_string()])
         .build();
     let count_label = gtk::Label::builder()
@@ -188,7 +195,7 @@ fn album_tile(ctx: Arc<AppContext>, album: &LibraryAlbum, on_click: AlbumClick) 
         .child(&tile_box)
         .css_classes(vec!["flat".to_string()])
         .hexpand(false)
-        .halign(gtk::Align::Start)
+        .halign(gtk::Align::Center)
         .build();
 
     if let Some(thumb_id) = album.thumbnail_asset_id.clone() {

--- a/src/library/albums_view.rs
+++ b/src/library/albums_view.rs
@@ -136,7 +136,7 @@ fn build_section(title: &str) -> (gtk::Box, gtk::FlowBox) {
         .build();
     let grid = gtk::FlowBox::builder()
         .selection_mode(gtk::SelectionMode::None)
-        .max_children_per_line(12)
+        .max_children_per_line(6)
         .min_children_per_line(2)
         .row_spacing(12)
         .column_spacing(12)
@@ -151,18 +151,20 @@ fn album_tile(ctx: Arc<AppContext>, album: &LibraryAlbum, on_click: AlbumClick) 
     let tile_box = gtk::Box::builder()
         .orientation(gtk::Orientation::Vertical)
         .spacing(4)
-        .css_classes(vec!["mimick-tile-box".to_string()])
+        .hexpand(true)
         .build();
     let picture = gtk::Picture::builder()
         .can_shrink(true)
         .content_fit(gtk::ContentFit::Cover)
-        .width_request(160)
-        .height_request(100)
-        .hexpand(false)
-        .vexpand(false)
-        .halign(gtk::Align::Fill)
-        .valign(gtk::Align::Start)
+        .hexpand(true)
+        .vexpand(true)
         .css_classes(vec!["mimick-explore-tile".to_string()])
+        .build();
+    let frame = gtk::AspectFrame::builder()
+        .obey_child(false)
+        .ratio(160.0 / 100.0)
+        .hexpand(true)
+        .child(&picture)
         .build();
     let meta_row = gtk::Box::builder()
         .orientation(gtk::Orientation::Horizontal)
@@ -188,14 +190,14 @@ fn album_tile(ctx: Arc<AppContext>, album: &LibraryAlbum, on_click: AlbumClick) 
         .build();
     meta_row.append(&title_label);
     meta_row.append(&count_label);
-    tile_box.append(&picture);
+    tile_box.append(&frame);
     tile_box.append(&meta_row);
 
     let button = gtk::Button::builder()
         .child(&tile_box)
         .css_classes(vec!["flat".to_string()])
-        .hexpand(false)
-        .halign(gtk::Align::Center)
+        .hexpand(true)
+        .halign(gtk::Align::Fill)
         .build();
 
     if let Some(thumb_id) = album.thumbnail_asset_id.clone() {

--- a/src/library/albums_view.rs
+++ b/src/library/albums_view.rs
@@ -187,7 +187,6 @@ fn album_tile(ctx: Arc<AppContext>, album: &LibraryAlbum, on_click: AlbumClick) 
     let button = gtk::Button::builder()
         .child(&tile_box)
         .css_classes(vec!["flat".to_string()])
-        .width_request(300)
         .hexpand(false)
         .halign(gtk::Align::Start)
         .build();

--- a/src/library/albums_view.rs
+++ b/src/library/albums_view.rs
@@ -154,8 +154,8 @@ fn album_tile(ctx: Arc<AppContext>, album: &LibraryAlbum, on_click: AlbumClick) 
         .spacing(4)
         .build();
     let picture = gtk::Picture::builder()
-        .width_request(300)
-        .height_request(220)
+        .width_request(200)
+        .height_request(160)
         .content_fit(gtk::ContentFit::Cover)
         .css_classes(vec!["mimick-explore-tile".to_string()])
         .build();

--- a/src/library/controls.rs
+++ b/src/library/controls.rs
@@ -266,6 +266,7 @@ pub(super) fn connect_sidebar_handlers(ui: Rc<LibraryWindowUi>) {
                 }
                 _ => {}
             }
+            auto_hide_sidebar(&ui);
         }
     ));
 
@@ -287,8 +288,15 @@ pub(super) fn connect_sidebar_handlers(ui: Rc<LibraryWindowUi>) {
             let name = parts.next().unwrap_or("Album").to_string();
             ui.sidebar.fixed_list.unselect_all();
             sidebar_dispatch(ui.clone(), LibrarySource::Album { id, name });
+            auto_hide_sidebar(&ui);
         }
     ));
+}
+
+fn auto_hide_sidebar(ui: &Rc<LibraryWindowUi>) {
+    if ui.split.is_collapsed() {
+        ui.split.set_show_sidebar(false);
+    }
 }
 
 pub(super) fn update_back_button(ui: &Rc<LibraryWindowUi>) {

--- a/src/library/controls.rs
+++ b/src/library/controls.rs
@@ -15,35 +15,36 @@ use super::{
     open_lightbox, refresh_albums_view, update_timeline_banner_if_active,
 };
 
-pub(super) fn connect_controls(
-    ui: Rc<LibraryWindowUi>,
-    prefs_button: gtk::Button,
-    queue_button: gtk::Button,
-    refresh_button: gtk::Button,
-) {
-    prefs_button.connect_clicked(clone!(
+pub(super) fn connect_controls(ui: Rc<LibraryWindowUi>) {
+    let action_settings = gtk::gio::SimpleAction::new("settings", None);
+    action_settings.connect_activate(clone!(
         #[strong]
         ui,
-        move |_| {
+        move |_, _| {
             build_settings_window_with_parent(&ui.app, ui.ctx.clone(), Some(&ui.window));
         }
     ));
+    ui.window.add_action(&action_settings);
 
-    queue_button.connect_clicked(clone!(
+    let action_queue = gtk::gio::SimpleAction::new("queue", None);
+    action_queue.connect_activate(clone!(
         #[strong]
         ui,
-        move |_| {
+        move |_, _| {
             show_queue_inspector(&ui.window, ui.ctx.queue_manager.clone());
         }
     ));
+    ui.window.add_action(&action_queue);
 
-    refresh_button.connect_clicked(clone!(
+    let action_refresh = gtk::gio::SimpleAction::new("refresh", None);
+    action_refresh.connect_activate(clone!(
         #[strong]
         ui,
-        move |_| {
+        move |_, _| {
             refresh_library_surfaces(ui.clone(), true);
         }
     ));
+    ui.window.add_action(&action_refresh);
 
     ui.back_button.connect_clicked(clone!(
         #[strong]
@@ -73,17 +74,21 @@ pub(super) fn connect_controls(
     ui.window.add_controller(alt_left_controller);
 
     let f5_controller = gtk::EventControllerKey::new();
-    f5_controller.connect_key_pressed({
-        let refresh_button = refresh_button.clone();
+    f5_controller.connect_key_pressed(clone!(
+        #[strong]
+        ui,
         move |_, keyval, _, _| {
             if keyval == gtk::gdk::Key::F5 {
-                refresh_button.emit_clicked();
+                let _ = ui
+                    .window
+                    .upcast_ref::<gtk::Widget>()
+                    .activate_action("win.refresh", None);
                 glib::Propagation::Stop
             } else {
                 glib::Propagation::Proceed
             }
         }
-    });
+    ));
     ui.window.add_controller(f5_controller);
 
     ui.source_mode.connect_selected_notify(clone!(

--- a/src/library/explore_view.rs
+++ b/src/library/explore_view.rs
@@ -97,10 +97,9 @@ fn build_tile_section(title: &str) -> (gtk::Box, gtk::FlowBox) {
         .selection_mode(gtk::SelectionMode::None)
         .row_spacing(8)
         .column_spacing(8)
-        .min_children_per_line(1)
+        .min_children_per_line(2)
         .max_children_per_line(6)
-        .homogeneous(false)
-        .halign(gtk::Align::Start)
+        .homogeneous(true)
         .build();
     section.append(&grid);
     (section, grid)
@@ -247,21 +246,28 @@ fn explore_tile(
     on_click: ExploreClick,
 ) -> gtk::Button {
     let picture = gtk::Picture::builder()
-        .width_request(200)
-        .height_request(160)
         .can_shrink(true)
         .content_fit(gtk::ContentFit::Cover)
+        .width_request(160)
+        .height_request(100)
+        .hexpand(false)
+        .vexpand(false)
+        .halign(gtk::Align::Fill)
+        .valign(gtk::Align::Start)
         .css_classes(vec!["mimick-explore-tile".to_string()])
         .build();
     let label = gtk::Label::builder()
         .label(value)
         .xalign(0.0)
+        .width_chars(1)
+        .max_width_chars(1)
         .ellipsize(gtk::pango::EllipsizeMode::End)
         .css_classes(vec!["caption-heading".to_string()])
         .build();
     let inner = gtk::Box::builder()
         .orientation(gtk::Orientation::Vertical)
         .spacing(4)
+        .css_classes(vec!["mimick-tile-box".to_string()])
         .build();
     inner.append(&picture);
     inner.append(&label);

--- a/src/library/explore_view.rs
+++ b/src/library/explore_view.rs
@@ -248,15 +248,10 @@ fn explore_tile(
     let picture = gtk::Picture::builder()
         .can_shrink(true)
         .content_fit(gtk::ContentFit::Cover)
+        .height_request(100)
         .hexpand(true)
-        .vexpand(true)
+        .vexpand(false)
         .css_classes(vec!["mimick-explore-tile".to_string()])
-        .build();
-    let frame = gtk::AspectFrame::builder()
-        .obey_child(false)
-        .ratio(160.0 / 100.0)
-        .hexpand(true)
-        .child(&picture)
         .build();
     let label = gtk::Label::builder()
         .label(value)
@@ -271,7 +266,7 @@ fn explore_tile(
         .spacing(4)
         .hexpand(true)
         .build();
-    inner.append(&frame);
+    inner.append(&picture);
     inner.append(&label);
 
     let button = gtk::Button::builder()

--- a/src/library/explore_view.rs
+++ b/src/library/explore_view.rs
@@ -248,13 +248,15 @@ fn explore_tile(
     let picture = gtk::Picture::builder()
         .can_shrink(true)
         .content_fit(gtk::ContentFit::Cover)
-        .width_request(160)
-        .height_request(100)
-        .hexpand(false)
-        .vexpand(false)
-        .halign(gtk::Align::Fill)
-        .valign(gtk::Align::Start)
+        .hexpand(true)
+        .vexpand(true)
         .css_classes(vec!["mimick-explore-tile".to_string()])
+        .build();
+    let frame = gtk::AspectFrame::builder()
+        .obey_child(false)
+        .ratio(160.0 / 100.0)
+        .hexpand(true)
+        .child(&picture)
         .build();
     let label = gtk::Label::builder()
         .label(value)
@@ -267,14 +269,16 @@ fn explore_tile(
     let inner = gtk::Box::builder()
         .orientation(gtk::Orientation::Vertical)
         .spacing(4)
-        .css_classes(vec!["mimick-tile-box".to_string()])
+        .hexpand(true)
         .build();
-    inner.append(&picture);
+    inner.append(&frame);
     inner.append(&label);
 
     let button = gtk::Button::builder()
         .child(&inner)
         .css_classes(vec!["flat".to_string()])
+        .hexpand(true)
+        .halign(gtk::Align::Fill)
         .build();
 
     let value_owned = value.to_string();

--- a/src/library/explore_view.rs
+++ b/src/library/explore_view.rs
@@ -247,8 +247,8 @@ fn explore_tile(
     on_click: ExploreClick,
 ) -> gtk::Button {
     let picture = gtk::Picture::builder()
-        .width_request(300)
-        .height_request(220)
+        .width_request(200)
+        .height_request(160)
         .can_shrink(true)
         .content_fit(gtk::ContentFit::Cover)
         .css_classes(vec!["mimick-explore-tile".to_string()])

--- a/src/library/filters.rs
+++ b/src/library/filters.rs
@@ -26,6 +26,8 @@ fn present_advanced_filters_dialog(ui: Rc<LibraryWindowUi>) {
         .title("Advanced Filters")
         .content_width(520)
         .content_height(720)
+        .width_request(360)
+        .height_request(480)
         .build();
     let dialog_bp = libadwaita::Breakpoint::new(
         libadwaita::BreakpointCondition::parse("max-width: 400sp")

--- a/src/library/filters.rs
+++ b/src/library/filters.rs
@@ -27,6 +27,13 @@ fn present_advanced_filters_dialog(ui: Rc<LibraryWindowUi>) {
         .content_width(520)
         .content_height(720)
         .build();
+    let dialog_bp = libadwaita::Breakpoint::new(
+        libadwaita::BreakpointCondition::parse("max-width: 400sp")
+            .expect("valid breakpoint condition"),
+    );
+    dialog_bp.add_setter(&dialog, "content-width", Some(&(-1i32).to_value()));
+    dialog_bp.add_setter(&dialog, "content-height", Some(&560i32.to_value()));
+    dialog.add_breakpoint(dialog_bp);
     let toolbar = libadwaita::ToolbarView::builder().build();
     let header = libadwaita::HeaderBar::builder().build();
     toolbar.add_top_bar(&header);

--- a/src/library/grid_view.rs
+++ b/src/library/grid_view.rs
@@ -50,7 +50,10 @@ pub fn build_grid_view(
             .height_request(if is_narrow { 120 } else { 200 })
             .can_shrink(true)
             .content_fit(gtk::ContentFit::Cover)
-            .css_classes(vec!["mimick-thumbnail-loading".to_string()])
+            .css_classes(vec![
+                "mimick-grid-thumb".to_string(),
+                "mimick-thumbnail-loading".to_string(),
+            ])
             .build();
 
         let checkbox = gtk::CheckButton::builder()
@@ -234,7 +237,7 @@ pub fn build_grid_view(
         .single_click_activate(!select_toggle.is_active())
         .enable_rubberband(false)
         .max_columns(6)
-        .min_columns(2)
+        .min_columns(1)
         .build();
     select_toggle.connect_toggled(clone_view_for_toggle(&view));
 

--- a/src/library/grid_view.rs
+++ b/src/library/grid_view.rs
@@ -23,7 +23,11 @@ pub struct GridViewParts {
     pub context_menu_handler: AssetContextMenuHandler,
 }
 
-pub fn build_grid_view(ctx: Arc<AppContext>, select_toggle: gtk::ToggleButton) -> GridViewParts {
+pub fn build_grid_view(
+    ctx: Arc<AppContext>,
+    select_toggle: gtk::ToggleButton,
+    narrow: Rc<Cell<bool>>,
+) -> GridViewParts {
     let model = LibraryAssetModel::new();
     let selection = gtk::MultiSelection::new(Some(model.clone()));
     let factory = gtk::SignalListItemFactory::new();
@@ -31,6 +35,7 @@ pub fn build_grid_view(ctx: Arc<AppContext>, select_toggle: gtk::ToggleButton) -
 
     let select_toggle_for_setup = select_toggle.clone();
     let selection_for_setup = selection.clone();
+    let narrow_for_setup = narrow.clone();
     factory.connect_setup(move |_, list_item| {
         let Some(list_item) = list_item.downcast_ref::<gtk::ListItem>() else {
             return;
@@ -39,9 +44,10 @@ pub fn build_grid_view(ctx: Arc<AppContext>, select_toggle: gtk::ToggleButton) -
             .css_classes(vec!["mimick-cell".to_string()])
             .build();
 
+        let is_narrow = narrow_for_setup.get();
         let picture = gtk::Picture::builder()
-            .width_request(356)
-            .height_request(200)
+            .width_request(if is_narrow { 160 } else { 356 })
+            .height_request(if is_narrow { 120 } else { 200 })
             .can_shrink(true)
             .content_fit(gtk::ContentFit::Cover)
             .css_classes(vec!["mimick-thumbnail-loading".to_string()])

--- a/src/library/grid_view.rs
+++ b/src/library/grid_view.rs
@@ -235,7 +235,7 @@ pub fn build_grid_view(
         .single_click_activate(!select_toggle.is_active())
         .enable_rubberband(false)
         .max_columns(8)
-        .min_columns(3)
+        .min_columns(2)
         .build();
     select_toggle.connect_toggled(clone_view_for_toggle(&view));
 

--- a/src/library/grid_view.rs
+++ b/src/library/grid_view.rs
@@ -46,8 +46,8 @@ pub fn build_grid_view(
 
         let is_narrow = narrow_for_setup.get();
         let picture = gtk::Picture::builder()
-            .width_request(if is_narrow { 160 } else { 356 })
-            .height_request(if is_narrow { 120 } else { 200 })
+            .width_request(if is_narrow { 140 } else { 356 })
+            .height_request(if is_narrow { 105 } else { 200 })
             .can_shrink(true)
             .content_fit(gtk::ContentFit::Cover)
             .css_classes(vec![

--- a/src/library/grid_view.rs
+++ b/src/library/grid_view.rs
@@ -26,7 +26,7 @@ pub struct GridViewParts {
 pub fn build_grid_view(
     ctx: Arc<AppContext>,
     select_toggle: gtk::ToggleButton,
-    narrow: Rc<Cell<bool>>,
+    _narrow: Rc<Cell<bool>>,
 ) -> GridViewParts {
     let model = LibraryAssetModel::new();
     let selection = gtk::MultiSelection::new(Some(model.clone()));
@@ -35,7 +35,6 @@ pub fn build_grid_view(
 
     let select_toggle_for_setup = select_toggle.clone();
     let selection_for_setup = selection.clone();
-    let narrow_for_setup = narrow.clone();
     factory.connect_setup(move |_, list_item| {
         let Some(list_item) = list_item.downcast_ref::<gtk::ListItem>() else {
             return;
@@ -44,10 +43,9 @@ pub fn build_grid_view(
             .css_classes(vec!["mimick-cell".to_string()])
             .build();
 
-        let is_narrow = narrow_for_setup.get();
         let picture = gtk::Picture::builder()
-            .width_request(if is_narrow { 140 } else { 356 })
-            .height_request(if is_narrow { 105 } else { 200 })
+            .width_request(114)
+            .height_request(85)
             .can_shrink(true)
             .content_fit(gtk::ContentFit::Cover)
             .css_classes(vec![
@@ -236,8 +234,8 @@ pub fn build_grid_view(
         .factory(&factory)
         .single_click_activate(!select_toggle.is_active())
         .enable_rubberband(false)
-        .max_columns(6)
-        .min_columns(1)
+        .max_columns(8)
+        .min_columns(3)
         .build();
     select_toggle.connect_toggled(clone_view_for_toggle(&view));
 

--- a/src/library/lightbox.rs
+++ b/src/library/lightbox.rs
@@ -262,11 +262,14 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
     let zoom_level = Rc::new(Cell::new(1.0_f64));
     let initial_full = ui.ctx.config.read().data.library_preview_full_resolution;
     let resolution_toggle = gtk::ToggleButton::builder()
-        .label(if initial_full { "Original" } else { "Preview" })
+        .label(if initial_full { "Raw" } else { "Prev" })
         .tooltip_text("Toggle preview vs original full-resolution image")
         .active(initial_full)
         .build();
-    let download = gtk::Button::builder().label("Download").build();
+    let download = gtk::Button::builder()
+        .icon_name("mimick-download-symbolic")
+        .tooltip_text("Download asset")
+        .build();
     let zoom_out_btn = gtk::Button::builder()
         .icon_name("zoom-out-symbolic")
         .tooltip_text("Zoom out (Ctrl+-)")
@@ -954,15 +957,10 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         #[strong]
         render,
         move |btn| {
-            btn.set_label(if btn.is_active() {
-                "Original"
-            } else {
-                "Preview"
-            });
+            btn.set_label(if btn.is_active() { "Raw" } else { "Prev" });
             (*render)();
         }
     ));
 
     ui.nav.push(&page);
-    super::apply_narrow_recursive(page.upcast_ref(), ui.narrow.get());
 }

--- a/src/library/lightbox.rs
+++ b/src/library/lightbox.rs
@@ -295,6 +295,7 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         .hexpand(false)
         .min_content_width(320)
         .max_content_width(320)
+        .css_classes(vec!["mimick-details-pane".to_string()])
         .visible(false)
         .build();
     let details_filename = gtk::Label::builder()
@@ -916,4 +917,5 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
     ));
 
     ui.nav.push(&page);
+    super::apply_narrow_recursive(page.upcast_ref(), ui.narrow.get());
 }

--- a/src/library/lightbox.rs
+++ b/src/library/lightbox.rs
@@ -199,14 +199,17 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
     header.pack_end(&details_btn);
     toolbar.add_top_bar(&header);
 
-    let body = gtk::Box::builder()
-        .orientation(gtk::Orientation::Horizontal)
+    let body = libadwaita::OverlaySplitView::builder()
+        .sidebar_position(gtk::PackType::End)
+        .show_sidebar(false)
+        .enable_show_gesture(true)
+        .enable_hide_gesture(true)
         .build();
     let viewer = gtk::Box::builder()
         .orientation(gtk::Orientation::Vertical)
         .spacing(8)
         .margin_top(8)
-        .margin_bottom(8)
+        .margin_bottom(16)
         .margin_start(8)
         .margin_end(8)
         .hexpand(true)
@@ -293,21 +296,22 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         .hscrollbar_policy(gtk::PolicyType::Never)
         .vexpand(true)
         .hexpand(false)
-        .min_content_width(320)
+        .min_content_width(280)
         .max_content_width(320)
         .css_classes(vec!["mimick-details-pane".to_string()])
-        .visible(false)
         .build();
     let details_filename = gtk::Label::builder()
         .xalign(0.0)
         .wrap(true)
-        .max_width_chars(36)
+        .wrap_mode(gtk::pango::WrapMode::WordChar)
+        .max_width_chars(28)
         .css_classes(vec!["title-3".to_string()])
         .build();
     let details_summary = gtk::Label::builder()
         .xalign(0.0)
         .wrap(true)
-        .max_width_chars(36)
+        .wrap_mode(gtk::pango::WrapMode::WordChar)
+        .max_width_chars(28)
         .build();
     let details_loading = gtk::Label::builder()
         .xalign(0.0)
@@ -324,13 +328,18 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
     details_inner.append(&details_loading);
     details_inner.append(&details_exif);
 
-    body.append(&viewer);
-    body.append(&details_pane);
+    body.set_content(Some(&viewer));
+    body.set_sidebar(Some(&details_pane));
     toolbar.set_content(Some(&body));
     page.set_child(Some(&toolbar));
 
     details_btn
-        .bind_property("active", &details_pane, "visible")
+        .bind_property("active", &body, "show-sidebar")
+        .sync_create()
+        .bidirectional()
+        .build();
+    ui.split
+        .bind_property("collapsed", &body, "collapsed")
         .sync_create()
         .build();
 

--- a/src/library/lightbox.rs
+++ b/src/library/lightbox.rs
@@ -93,7 +93,8 @@ fn fill_exif_box(container: &gtk::Box, exif: &crate::api_client::ExifInfo) {
             .label(&value)
             .xalign(0.0)
             .wrap(true)
-            .max_width_chars(36)
+            .wrap_mode(gtk::pango::WrapMode::WordChar)
+            .max_width_chars(28)
             .selectable(true)
             .build();
         row.append(&k);
@@ -140,6 +141,16 @@ fn format_datetime_display(iso: &str) -> String {
     iso.get(..19).unwrap_or(iso).replace('T', " ").to_string()
 }
 
+fn truncate_filename(name: &str, max_chars: usize) -> String {
+    let count = name.chars().count();
+    if count <= max_chars {
+        return name.to_string();
+    }
+    let keep = max_chars.saturating_sub(1);
+    let head: String = name.chars().take(keep).collect();
+    format!("{}…", head)
+}
+
 /// Apply zoom to a lightbox Picture. Zoom is fit-relative: 1.0 = the size the
 /// texture would occupy inside `viewer` under Contain layout. > 1.0 overflows
 /// the viewer for panning. At 1.0 we restore (-1, -1) so the picture
@@ -172,9 +183,11 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         return;
     };
     let initial_filename = item.property::<String>("filename");
+    let title_cap = if ui.split.is_collapsed() { 14 } else { 24 };
+    let title_for_header = truncate_filename(&initial_filename, title_cap);
 
     let page = libadwaita::NavigationPage::builder()
-        .title(&initial_filename)
+        .title(&title_for_header)
         .can_pop(true)
         .build();
     let toolbar = libadwaita::ToolbarView::builder().build();
@@ -202,16 +215,20 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
     let body = libadwaita::OverlaySplitView::builder()
         .sidebar_position(gtk::PackType::End)
         .show_sidebar(false)
+        .collapsed(ui.split.is_collapsed())
         .enable_show_gesture(true)
         .enable_hide_gesture(true)
+        .min_sidebar_width(180.0)
+        .max_sidebar_width(320.0)
+        .sidebar_width_fraction(0.4)
         .build();
     let viewer = gtk::Box::builder()
         .orientation(gtk::Orientation::Vertical)
         .spacing(8)
-        .margin_top(8)
-        .margin_bottom(16)
-        .margin_start(8)
-        .margin_end(8)
+        .margin_top(4)
+        .margin_bottom(8)
+        .margin_start(4)
+        .margin_end(4)
         .hexpand(true)
         .build();
     // Two picture widgets in a stack so navigation can slide between them.
@@ -239,6 +256,7 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         .child(&pic_stack)
         .vexpand(true)
         .hexpand(true)
+        .min_content_width(120)
         .build();
     let active_a = Rc::new(Cell::new(true));
     let zoom_level = Rc::new(Cell::new(1.0_f64));
@@ -270,7 +288,7 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
     zoom_group.append(&zoom_in_btn);
     let actions = gtk::Box::builder()
         .orientation(gtk::Orientation::Horizontal)
-        .spacing(8)
+        .spacing(4)
         .build();
     let actions_spacer = gtk::Box::builder()
         .orientation(gtk::Orientation::Horizontal)
@@ -296,7 +314,7 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         .hscrollbar_policy(gtk::PolicyType::Never)
         .vexpand(true)
         .hexpand(false)
-        .min_content_width(280)
+        .min_content_width(180)
         .max_content_width(320)
         .css_classes(vec!["mimick-details-pane".to_string()])
         .build();
@@ -342,6 +360,25 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         .bind_property("collapsed", &body, "collapsed")
         .sync_create()
         .build();
+
+    // On narrow widths, hide the prev/next header buttons — Left/Right
+    // keyboard shortcuts still work, and the saved space lets the title fit.
+    let sync_nav_visibility = {
+        let prev_btn = prev_btn.clone();
+        let next_btn = next_btn.clone();
+        let details_btn = details_btn.clone();
+        let split = ui.split.clone();
+        move || {
+            let show = !split.is_collapsed();
+            prev_btn.set_visible(show);
+            next_btn.set_visible(show);
+            details_btn.set_visible(show);
+        }
+    };
+    sync_nav_visibility();
+    let sync_clone = sync_nav_visibility.clone();
+    ui.split
+        .connect_notify_local(Some("collapsed"), move |_, _| sync_clone());
 
     let pos_cell = Rc::new(Cell::new(position));
     let load_into_picture = Rc::new({
@@ -434,7 +471,8 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
             let created = item.property::<String>("created-at");
             let sync_state = item.property::<u32>("sync-state");
 
-            page.set_title(&filename);
+            let cap = if ui.split.is_collapsed() { 14 } else { 24 };
+            page.set_title(&truncate_filename(&filename, cap));
             details_filename.set_label(&filename);
             let sync_label = match sync_state {
                 2 => "On Immich and locally",

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -103,6 +103,7 @@ struct LibraryWindowUi {
     album_link_button: gtk::Button,
     album_sync_button: gtk::Button,
     last_seen_upload_batch: Cell<u64>,
+    narrow: Rc<Cell<bool>>,
 }
 
 pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>) {
@@ -115,6 +116,8 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .name("mimick-library-window")
         .default_width(1180)
         .default_height(780)
+        .width_request(360)
+        .height_request(480)
         .build();
 
     let header = libadwaita::HeaderBar::builder()
@@ -156,8 +159,9 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     let toolbar = libadwaita::ToolbarView::builder().build();
     toolbar.add_top_bar(&header);
 
+    let narrow_flag = Rc::new(Cell::new(false));
     let sidebar = build_sidebar();
-    let grid = build_grid_view(ctx.clone(), select_toggle.clone());
+    let grid = build_grid_view(ctx.clone(), select_toggle.clone(), narrow_flag.clone());
     let explore = build_explore_view();
     let albums = build_albums_view();
 
@@ -166,6 +170,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .model(&source_mode_model)
         .selected(0)
         .tooltip_text("Asset source")
+        .hexpand(true)
         .build();
     let timeline_toggle = gtk::ToggleButton::builder()
         .label("Timeline")
@@ -200,22 +205,42 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     let sort_mode = gtk::DropDown::builder()
         .model(&sort_model)
         .selected(0)
+        .hexpand(true)
         .build();
+
+    let source_group = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .spacing(8)
+        .build();
+    source_group.append(&source_mode);
+    source_group.append(&timeline_toggle);
+
+    let search_group = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .spacing(8)
+        .hexpand(true)
+        .build();
+    search_group.append(&search_mode);
+    search_group.append(&search_entry);
+    search_group.append(&filters_button);
+
+    let sort_group = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .spacing(8)
+        .build();
+    sort_group.append(&sort_mode);
 
     let controls = gtk::Box::builder()
         .orientation(gtk::Orientation::Horizontal)
-        .spacing(8)
+        .spacing(12)
         .margin_top(12)
         .margin_bottom(12)
         .margin_start(12)
         .margin_end(12)
         .build();
-    controls.append(&source_mode);
-    controls.append(&timeline_toggle);
-    controls.append(&search_mode);
-    controls.append(&search_entry);
-    controls.append(&filters_button);
-    controls.append(&sort_mode);
+    controls.append(&source_group);
+    controls.append(&search_group);
+    controls.append(&sort_group);
 
     let timeline_banner = gtk::Label::builder()
         .xalign(0.0)
@@ -267,7 +292,9 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .xalign(0.0)
         .hexpand(true)
         .wrap(true)
-        .max_width_chars(48)
+        .max_width_chars(24)
+        .width_chars(12)
+        .ellipsize(gtk::pango::EllipsizeMode::End)
         .css_classes(vec!["caption".to_string(), "dim-label".to_string()])
         .build();
     let transfer_bar = gtk::Box::builder()
@@ -286,6 +313,8 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     let album_link_row = libadwaita::ActionRow::builder()
         .title("No local folder linked")
         .subtitle("Drop files in the linked folder to sync this album")
+        .title_lines(1)
+        .subtitle_lines(2)
         .build();
     let album_sync_button = gtk::Button::builder()
         .label("Sync…")
@@ -371,6 +400,38 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     nav.add(&root_page);
     window.set_content(Some(&nav));
 
+    let breakpoint = libadwaita::Breakpoint::new(
+        libadwaita::BreakpointCondition::parse("max-width: 600sp")
+            .expect("valid breakpoint condition"),
+    );
+    breakpoint.add_setter(&split, "collapsed", Some(&true.to_value()));
+    breakpoint.add_setter(
+        &controls,
+        "orientation",
+        Some(&gtk::Orientation::Vertical.to_value()),
+    );
+    breakpoint.add_setter(&grid.view, "max-columns", Some(&2u32.to_value()));
+    breakpoint.add_setter(&grid.view, "min-columns", Some(&1u32.to_value()));
+    breakpoint.add_setter(&bulk_delete, "label", Some(&"Del".to_value()));
+    breakpoint.add_setter(&bulk_download, "label", Some(&"Get".to_value()));
+    breakpoint.add_setter(&bulk_clear, "label", Some(&"X".to_value()));
+    breakpoint.add_setter(&album_sync_button, "label", Some(&"Sync".to_value()));
+    breakpoint.add_setter(&album_link_button, "label", Some(&"Link".to_value()));
+    breakpoint.add_setter(&transfer_bar, "visible", Some(&false.to_value()));
+    let nav_for_apply = nav.clone();
+    let narrow_apply = narrow_flag.clone();
+    breakpoint.connect_apply(move |_| {
+        narrow_apply.set(true);
+        apply_narrow_recursive(nav_for_apply.upcast_ref::<gtk::Widget>(), true);
+    });
+    let nav_for_unapply = nav.clone();
+    let narrow_unapply = narrow_flag.clone();
+    breakpoint.connect_unapply(move |_| {
+        narrow_unapply.set(false);
+        apply_narrow_recursive(nav_for_unapply.upcast_ref::<gtk::Widget>(), false);
+    });
+    window.add_breakpoint(breakpoint);
+
     let f9 = gtk::Shortcut::builder()
         .trigger(&gtk::ShortcutTrigger::parse_string("F9").unwrap())
         .action(&gtk::CallbackAction::new(clone!(
@@ -418,6 +479,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         album_link_button: album_link_button.clone(),
         album_sync_button: album_sync_button.clone(),
         last_seen_upload_batch: Cell::new(0),
+        narrow: narrow_flag.clone(),
     });
     *ui.grid.context_menu_handler.borrow_mut() = Some(Box::new(clone!(
         #[strong]
@@ -549,6 +611,7 @@ fn refresh_albums_view(ui: Rc<LibraryWindowUi>) {
             Ok(albums) => {
                 let on_click = album_click_handler(ui.clone());
                 populate_albums(&ui.albums, ui.ctx.clone(), albums, on_click);
+                apply_narrow_recursive(ui.albums.root.upcast_ref(), ui.narrow.get());
             }
             Err(err) => log::warn!("Albums fetch failed: {}", err),
         }
@@ -759,6 +822,7 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
                     load_source_page(click_ui.clone(), request, false);
                 },
             );
+            apply_narrow_recursive(ui.explore.root.upcast_ref(), ui.narrow.get());
         }
     ));
 }
@@ -933,6 +997,8 @@ fn reload_sidebar(ui: &Rc<LibraryWindowUi>) {
         let action = libadwaita::ActionRow::builder()
             .title(&album.album_name)
             .subtitle(&subtitle)
+            .title_lines(1)
+            .subtitle_lines(1)
             .build();
         let row = gtk::ListBoxRow::builder()
             .tooltip_text(format!("{}:{}", album.id, album.album_name))
@@ -1130,6 +1196,29 @@ fn build_status_view(icon_name: &str, title: &str, subtitle: &str) -> gtk::Box {
     container.append(&title_label);
     container.append(&subtitle_label);
     container
+}
+
+/// Walk the widget tree and resize known cards/panes for narrow viewports.
+pub(super) fn apply_narrow_recursive(widget: &gtk::Widget, narrow: bool) {
+    if let Some(pic) = widget.downcast_ref::<gtk::Picture>() {
+        if pic.has_css_class("mimick-thumbnail-loading") {
+            pic.set_width_request(if narrow { 160 } else { 356 });
+            pic.set_height_request(if narrow { 120 } else { 200 });
+        } else if pic.has_css_class("mimick-explore-tile") {
+            pic.set_width_request(if narrow { 160 } else { 300 });
+            pic.set_height_request(if narrow { 140 } else { 220 });
+        }
+    } else if let Some(sw) = widget.downcast_ref::<gtk::ScrolledWindow>()
+        && sw.has_css_class("mimick-details-pane")
+    {
+        sw.set_min_content_width(if narrow { 260 } else { 320 });
+        sw.set_max_content_width(if narrow { 260 } else { 320 });
+    }
+    let mut child = widget.first_child();
+    while let Some(c) = child {
+        apply_narrow_recursive(&c, narrow);
+        child = c.next_sibling();
+    }
 }
 
 pub(super) fn immich_checksum_to_hex(b64: &str) -> Option<String> {

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -104,6 +104,7 @@ struct LibraryWindowUi {
     album_sync_button: gtk::Button,
     last_seen_upload_batch: Cell<u64>,
     narrow: Rc<Cell<bool>>,
+    split: libadwaita::OverlaySplitView,
 }
 
 pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>) {
@@ -196,6 +197,8 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     let search_entry = gtk::SearchEntry::builder()
         .placeholder_text("Search filenames")
         .hexpand(true)
+        .width_chars(20)
+        .max_width_chars(24)
         .build();
     let filters_button = gtk::Button::builder()
         .icon_name("view-more-symbolic")
@@ -246,6 +249,8 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .xalign(0.0)
         .css_classes(vec!["mimick-timeline-banner".to_string()])
         .visible(false)
+        .ellipsize(gtk::pango::EllipsizeMode::End)
+        .max_width_chars(20)
         .margin_top(4)
         .margin_bottom(4)
         .margin_start(12)
@@ -301,7 +306,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .orientation(gtk::Orientation::Horizontal)
         .spacing(12)
         .margin_top(8)
-        .margin_bottom(8)
+        .margin_bottom(16)
         .margin_start(12)
         .margin_end(12)
         .css_classes(vec!["mimick-transfer-shell".to_string()])
@@ -353,7 +358,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .orientation(gtk::Orientation::Horizontal)
         .spacing(8)
         .margin_top(8)
-        .margin_bottom(8)
+        .margin_bottom(16)
         .margin_start(12)
         .margin_end(12)
         .css_classes(vec!["toolbar".to_string()])
@@ -383,6 +388,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .content(&content)
         .show_sidebar(true)
         .enable_show_gesture(true)
+        .enable_hide_gesture(true)
         .build();
     split
         .bind_property("show-sidebar", &sidebar_toggle, "active")
@@ -411,7 +417,9 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         Some(&gtk::Orientation::Vertical.to_value()),
     );
     breakpoint.add_setter(&grid.view, "max-columns", Some(&2u32.to_value()));
-    breakpoint.add_setter(&grid.view, "min-columns", Some(&1u32.to_value()));
+    breakpoint.add_setter(&grid.view, "min-columns", Some(&2u32.to_value()));
+    breakpoint.add_setter(&refresh_button, "visible", Some(&false.to_value()));
+    breakpoint.add_setter(&queue_button, "visible", Some(&false.to_value()));
     breakpoint.add_setter(&bulk_delete, "label", Some(&"Del".to_value()));
     breakpoint.add_setter(&bulk_download, "label", Some(&"Get".to_value()));
     breakpoint.add_setter(&bulk_clear, "label", Some(&"X".to_value()));
@@ -431,6 +439,15 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         apply_narrow_recursive(nav_for_unapply.upcast_ref::<gtk::Widget>(), false);
     });
     window.add_breakpoint(breakpoint);
+
+    // Tablet-width breakpoint: collapse sidebar to overlay before the inline
+    // sidebar + controls (~960 px natural) overflow a shrunk desktop window.
+    let tablet_bp = libadwaita::Breakpoint::new(
+        libadwaita::BreakpointCondition::parse("max-width: 1000sp")
+            .expect("valid breakpoint condition"),
+    );
+    tablet_bp.add_setter(&split, "collapsed", Some(&true.to_value()));
+    window.add_breakpoint(tablet_bp);
 
     let f9 = gtk::Shortcut::builder()
         .trigger(&gtk::ShortcutTrigger::parse_string("F9").unwrap())
@@ -480,6 +497,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         album_sync_button: album_sync_button.clone(),
         last_seen_upload_batch: Cell::new(0),
         narrow: narrow_flag.clone(),
+        split: split.clone(),
     });
     *ui.grid.context_menu_handler.borrow_mut() = Some(Box::new(clone!(
         #[strong]
@@ -1201,7 +1219,7 @@ fn build_status_view(icon_name: &str, title: &str, subtitle: &str) -> gtk::Box {
 /// Walk the widget tree and resize known cards/panes for narrow viewports.
 pub(super) fn apply_narrow_recursive(widget: &gtk::Widget, narrow: bool) {
     if let Some(pic) = widget.downcast_ref::<gtk::Picture>() {
-        if pic.has_css_class("mimick-thumbnail-loading") {
+        if pic.has_css_class("mimick-grid-thumb") {
             pic.set_width_request(if narrow { 160 } else { 356 });
             pic.set_height_request(if narrow { 120 } else { 200 });
         } else if pic.has_css_class("mimick-explore-tile") {

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -115,7 +115,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .application(app)
         .title("Mimick Library")
         .name("mimick-library-window")
-        .default_width(1180)
+        .default_width(1480)
         .default_height(780)
         .width_request(360)
         .height_request(480)
@@ -135,23 +135,18 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .tooltip_text("Back (Alt+Left)")
         .sensitive(false)
         .build();
-    let prefs_button = gtk::Button::builder()
-        .icon_name("emblem-system-symbolic")
-        .tooltip_text("Open Settings")
-        .build();
-    let queue_button = gtk::Button::builder()
-        .icon_name("view-list-symbolic")
-        .tooltip_text("Open Queue Inspector")
-        .build();
-    let refresh_button = gtk::Button::builder()
-        .icon_name("view-refresh-symbolic")
-        .tooltip_text("Refresh")
+    let menu = gtk::gio::Menu::new();
+    menu.append(Some("Refresh"), Some("win.refresh"));
+    menu.append(Some("Queue Inspector"), Some("win.queue"));
+    menu.append(Some("Settings"), Some("win.settings"));
+    let menu_button = gtk::MenuButton::builder()
+        .icon_name("open-menu-symbolic")
+        .menu_model(&menu)
+        .tooltip_text("Menu")
         .build();
     header.pack_start(&sidebar_toggle);
     header.pack_start(&back_button);
-    header.pack_end(&prefs_button);
-    header.pack_end(&queue_button);
-    header.pack_end(&refresh_button);
+    header.pack_end(&menu_button);
     let select_toggle = gtk::ToggleButton::builder()
         .icon_name("checkbox-symbolic")
         .tooltip_text("Select assets (Esc to exit)")
@@ -232,7 +227,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     sort_group.append(&sort_mode);
 
     let controls = gtk::Box::builder()
-        .orientation(gtk::Orientation::Horizontal)
+        .orientation(gtk::Orientation::Vertical)
         .spacing(12)
         .margin_top(12)
         .margin_bottom(12)
@@ -320,13 +315,13 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .subtitle_lines(2)
         .build();
     let album_sync_button = gtk::Button::builder()
-        .label("Sync…")
+        .label("Sync")
         .valign(gtk::Align::Center)
         .css_classes(vec!["suggested-action".to_string()])
         .visible(false)
         .build();
     let album_link_button = gtk::Button::builder()
-        .label("Link folder…")
+        .label("Link")
         .valign(gtk::Align::Center)
         .build();
     album_link_row.add_suffix(&album_sync_button);
@@ -344,12 +339,17 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
 
     let bulk_count_label = gtk::Label::builder().xalign(0.0).hexpand(true).build();
     let bulk_delete = gtk::Button::builder()
-        .label("Delete")
+        .icon_name("user-trash-symbolic")
+        .tooltip_text("Delete selected")
         .css_classes(vec!["destructive-action".to_string()])
         .build();
-    let bulk_download = gtk::Button::builder().label("Download").build();
+    let bulk_download = gtk::Button::builder()
+        .icon_name("mimick-download-symbolic")
+        .tooltip_text("Download selected")
+        .build();
     let bulk_clear = gtk::Button::builder()
-        .label("Clear")
+        .icon_name("edit-clear-symbolic")
+        .tooltip_text("Clear selection")
         .css_classes(vec!["flat".to_string()])
         .build();
     let bulk_inner = gtk::Box::builder()
@@ -405,43 +405,45 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     window.set_content(Some(&nav));
 
     let breakpoint = libadwaita::Breakpoint::new(
-        libadwaita::BreakpointCondition::parse("max-width: 600sp")
+        libadwaita::BreakpointCondition::parse("max-width: 750sp")
             .expect("valid breakpoint condition"),
     );
     breakpoint.add_setter(&split, "collapsed", Some(&true.to_value()));
-    breakpoint.add_setter(
-        &controls,
-        "orientation",
-        Some(&gtk::Orientation::Vertical.to_value()),
-    );
-    breakpoint.add_setter(&grid.view, "max-columns", Some(&2u32.to_value()));
-    breakpoint.add_setter(&grid.view, "min-columns", Some(&2u32.to_value()));
-    breakpoint.add_setter(&refresh_button, "visible", Some(&false.to_value()));
-    breakpoint.add_setter(&queue_button, "visible", Some(&false.to_value()));
-    breakpoint.add_setter(&bulk_delete, "label", Some(&"Del".to_value()));
-    breakpoint.add_setter(&bulk_download, "label", Some(&"Get".to_value()));
-    breakpoint.add_setter(&bulk_clear, "label", Some(&"X".to_value()));
-    breakpoint.add_setter(&album_sync_button, "label", Some(&"Sync".to_value()));
-    breakpoint.add_setter(&album_link_button, "label", Some(&"Link".to_value()));
     breakpoint.add_setter(&transfer_bar, "visible", Some(&false.to_value()));
-    breakpoint.add_setter(&search_mode, "visible", Some(&false.to_value()));
-    breakpoint.add_setter(&sort_mode, "visible", Some(&false.to_value()));
-    breakpoint.add_setter(&sort_group, "visible", Some(&false.to_value()));
-    breakpoint.add_setter(&timeline_toggle, "visible", Some(&false.to_value()));
-    breakpoint.add_setter(&sidebar_toggle, "visible", Some(&false.to_value()));
-    let nav_for_apply = nav.clone();
     let narrow_apply = narrow_flag.clone();
     breakpoint.connect_apply(move |_| {
         narrow_apply.set(true);
-        apply_narrow_recursive(nav_for_apply.upcast_ref::<gtk::Widget>(), true);
     });
-    let nav_for_unapply = nav.clone();
     let narrow_unapply = narrow_flag.clone();
     breakpoint.connect_unapply(move |_| {
         narrow_unapply.set(false);
-        apply_narrow_recursive(nav_for_unapply.upcast_ref::<gtk::Widget>(), false);
     });
     window.add_breakpoint(breakpoint);
+
+    let desktop_bp = libadwaita::Breakpoint::new(
+        libadwaita::BreakpointCondition::parse("min-width: 750sp")
+            .expect("valid breakpoint condition"),
+    );
+    let window_for_desktop_apply = window.clone();
+    desktop_bp.connect_apply(move |_| {
+        window_for_desktop_apply.add_css_class("mimick-wide");
+    });
+    let window_for_desktop_unapply = window.clone();
+    desktop_bp.connect_unapply(move |_| {
+        window_for_desktop_unapply.remove_css_class("mimick-wide");
+    });
+    desktop_bp.add_setter(
+        &controls,
+        "orientation",
+        Some(&gtk::Orientation::Horizontal.to_value()),
+    );
+    desktop_bp.add_setter(&album_sync_button, "label", Some(&"Sync…".to_value()));
+    desktop_bp.add_setter(
+        &album_link_button,
+        "label",
+        Some(&"Link folder…".to_value()),
+    );
+    window.add_breakpoint(desktop_bp);
 
     // Tablet-width breakpoint: collapse sidebar to overlay before the inline
     // sidebar + controls (~960 px natural) overflow a shrunk desktop window.
@@ -516,7 +518,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     connect_bulk_actions(ui.clone(), bulk_delete, bulk_download, bulk_clear);
 
     connect_sidebar_handlers(ui.clone());
-    connect_controls(ui.clone(), prefs_button, queue_button, refresh_button);
+    connect_controls(ui.clone());
     connect_grid_handlers(ui.clone());
     connect_filters_button(ui.clone(), filters_button);
 
@@ -632,7 +634,6 @@ fn refresh_albums_view(ui: Rc<LibraryWindowUi>) {
             Ok(albums) => {
                 let on_click = album_click_handler(ui.clone());
                 populate_albums(&ui.albums, ui.ctx.clone(), albums, on_click);
-                apply_narrow_recursive(ui.albums.root.upcast_ref(), ui.narrow.get());
             }
             Err(err) => log::warn!("Albums fetch failed: {}", err),
         }
@@ -846,7 +847,6 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
                     load_source_page(click_ui.clone(), request, false);
                 },
             );
-            apply_narrow_recursive(ui.explore.root.upcast_ref(), ui.narrow.get());
         }
     ));
 }
@@ -1208,11 +1208,15 @@ fn build_status_view(icon_name: &str, title: &str, subtitle: &str) -> gtk::Box {
     icon.add_css_class("dim-label");
     let title_label = gtk::Label::builder()
         .label(title)
+        .wrap(true)
+        .wrap_mode(gtk::pango::WrapMode::WordChar)
+        .justify(gtk::Justification::Center)
         .css_classes(vec!["mimick-empty-title".to_string()])
         .build();
     let subtitle_label = gtk::Label::builder()
         .label(subtitle)
         .wrap(true)
+        .wrap_mode(gtk::pango::WrapMode::WordChar)
         .justify(gtk::Justification::Center)
         .css_classes(vec!["mimick-empty-subtitle".to_string()])
         .build();
@@ -1220,29 +1224,6 @@ fn build_status_view(icon_name: &str, title: &str, subtitle: &str) -> gtk::Box {
     container.append(&title_label);
     container.append(&subtitle_label);
     container
-}
-
-/// Walk the widget tree and resize known cards/panes for narrow viewports.
-pub(super) fn apply_narrow_recursive(widget: &gtk::Widget, narrow: bool) {
-    if let Some(pic) = widget.downcast_ref::<gtk::Picture>() {
-        if pic.has_css_class("mimick-grid-thumb") {
-            pic.set_width_request(if narrow { 140 } else { 356 });
-            pic.set_height_request(if narrow { 105 } else { 200 });
-        } else if pic.has_css_class("mimick-explore-tile") {
-            pic.set_width_request(if narrow { 140 } else { 300 });
-            pic.set_height_request(if narrow { 100 } else { 220 });
-        }
-    } else if let Some(sw) = widget.downcast_ref::<gtk::ScrolledWindow>()
-        && sw.has_css_class("mimick-details-pane")
-    {
-        sw.set_min_content_width(if narrow { 180 } else { 320 });
-        sw.set_max_content_width(if narrow { 180 } else { 320 });
-    }
-    let mut child = widget.first_child();
-    while let Some(c) = child {
-        apply_narrow_recursive(&c, narrow);
-        child = c.next_sibling();
-    }
 }
 
 pub(super) fn immich_checksum_to_hex(b64: &str) -> Option<String> {

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -171,7 +171,6 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .model(&source_mode_model)
         .selected(0)
         .tooltip_text("Asset source")
-        .hexpand(true)
         .build();
     let timeline_toggle = gtk::ToggleButton::builder()
         .label("Timeline")
@@ -197,7 +196,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     let search_entry = gtk::SearchEntry::builder()
         .placeholder_text("Search filenames")
         .hexpand(true)
-        .width_chars(20)
+        .width_chars(6)
         .max_width_chars(24)
         .build();
     let filters_button = gtk::Button::builder()
@@ -208,7 +207,6 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     let sort_mode = gtk::DropDown::builder()
         .model(&sort_model)
         .selected(0)
-        .hexpand(true)
         .build();
 
     let source_group = gtk::Box::builder()
@@ -238,8 +236,8 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         .spacing(12)
         .margin_top(12)
         .margin_bottom(12)
-        .margin_start(12)
-        .margin_end(12)
+        .margin_start(8)
+        .margin_end(8)
         .build();
     controls.append(&source_group);
     controls.append(&search_group);
@@ -426,6 +424,11 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     breakpoint.add_setter(&album_sync_button, "label", Some(&"Sync".to_value()));
     breakpoint.add_setter(&album_link_button, "label", Some(&"Link".to_value()));
     breakpoint.add_setter(&transfer_bar, "visible", Some(&false.to_value()));
+    breakpoint.add_setter(&search_mode, "visible", Some(&false.to_value()));
+    breakpoint.add_setter(&sort_mode, "visible", Some(&false.to_value()));
+    breakpoint.add_setter(&sort_group, "visible", Some(&false.to_value()));
+    breakpoint.add_setter(&timeline_toggle, "visible", Some(&false.to_value()));
+    breakpoint.add_setter(&sidebar_toggle, "visible", Some(&false.to_value()));
     let nav_for_apply = nav.clone();
     let narrow_apply = narrow_flag.clone();
     breakpoint.connect_apply(move |_| {
@@ -676,8 +679,11 @@ fn apply_timeline_ui_state(ui: &LibraryWindowUi, source: &LibrarySource) {
             | LibrarySource::AlbumUnified { .. }
     );
     let remote_search_allowed = !is_local && !is_unified;
-    ui.search_mode.set_visible(remote_search_allowed);
-    ui.filters_button.set_visible(remote_search_allowed);
+    let is_narrow = ui.narrow.get();
+    ui.search_mode
+        .set_visible(remote_search_allowed && !is_narrow);
+    ui.filters_button
+        .set_visible(remote_search_allowed && !is_narrow);
     if !remote_search_allowed {
         ui.search_mode.set_selected(0);
     }
@@ -1220,17 +1226,17 @@ fn build_status_view(icon_name: &str, title: &str, subtitle: &str) -> gtk::Box {
 pub(super) fn apply_narrow_recursive(widget: &gtk::Widget, narrow: bool) {
     if let Some(pic) = widget.downcast_ref::<gtk::Picture>() {
         if pic.has_css_class("mimick-grid-thumb") {
-            pic.set_width_request(if narrow { 160 } else { 356 });
-            pic.set_height_request(if narrow { 120 } else { 200 });
+            pic.set_width_request(if narrow { 140 } else { 356 });
+            pic.set_height_request(if narrow { 105 } else { 200 });
         } else if pic.has_css_class("mimick-explore-tile") {
-            pic.set_width_request(if narrow { 160 } else { 300 });
-            pic.set_height_request(if narrow { 140 } else { 220 });
+            pic.set_width_request(if narrow { 140 } else { 300 });
+            pic.set_height_request(if narrow { 100 } else { 220 });
         }
     } else if let Some(sw) = widget.downcast_ref::<gtk::ScrolledWindow>()
         && sw.has_css_class("mimick-details-pane")
     {
-        sw.set_min_content_width(if narrow { 260 } else { 320 });
-        sw.set_max_content_width(if narrow { 260 } else { 320 });
+        sw.set_min_content_width(if narrow { 180 } else { 320 });
+        sw.set_max_content_width(if narrow { 180 } else { 320 });
     }
     let mut child = widget.first_child();
     while let Some(c) = child {

--- a/src/library/sidebar.rs
+++ b/src/library/sidebar.rs
@@ -28,11 +28,15 @@ pub fn build_sidebar() -> SidebarParts {
     let connection_row = libadwaita::ActionRow::builder()
         .title("Connection")
         .subtitle("Offline")
+        .title_lines(1)
+        .subtitle_lines(1)
         .activatable(true)
         .build();
     let server_row = libadwaita::ActionRow::builder()
         .title("Server")
         .subtitle("Statistics unavailable")
+        .title_lines(1)
+        .subtitle_lines(1)
         .activatable(true)
         .build();
     let connection_list = gtk::ListBox::builder()
@@ -97,6 +101,8 @@ fn action_row(title: &str, subtitle: &str, icon_name: &str, key: &str) -> libadw
     let row = libadwaita::ActionRow::builder()
         .title(title)
         .subtitle(subtitle)
+        .title_lines(1)
+        .subtitle_lines(1)
         .tooltip_text(key)
         .activatable(true)
         .build();

--- a/src/library/style.rs
+++ b/src/library/style.rs
@@ -72,18 +72,6 @@ picture.mimick-person-avatar {
 picture.mimick-explore-tile {
     border-radius: 6px;
     background-color: alpha(@view_fg_color, 0.08);
-    min-width: 160px;
-    max-width: 160px;
-    min-height: 100px;
-    max-height: 100px;
-}
-
-box.mimick-tile-box {
-    min-width: 160px;
-    max-width: 160px;
-}
-
-window.mimick-wide picture.mimick-explore-tile {
 }
 
 picture.mimick-grid-thumb {

--- a/src/library/style.rs
+++ b/src/library/style.rs
@@ -72,6 +72,28 @@ picture.mimick-person-avatar {
 picture.mimick-explore-tile {
     border-radius: 6px;
     background-color: alpha(@view_fg_color, 0.08);
+    min-width: 160px;
+    max-width: 160px;
+    min-height: 100px;
+    max-height: 100px;
+}
+
+box.mimick-tile-box {
+    min-width: 160px;
+    max-width: 160px;
+}
+
+window.mimick-wide picture.mimick-explore-tile {
+}
+
+picture.mimick-grid-thumb {
+    min-width: 114px;
+    min-height: 85px;
+}
+
+window.mimick-wide picture.mimick-grid-thumb {
+    min-width: 356px;
+    min-height: 200px;
 }
 
 picture.mimick-thumbnail-square,

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -256,9 +256,10 @@ pub fn build_settings_window_with_parent(
         .build();
     let internal_switch = Switch::builder().valign(gtk::Align::Center).build();
     let internal_entry = Entry::builder()
-        .placeholder_text("http://192.168.1.10:2283")
+        .placeholder_text("http://…")
         .valign(gtk::Align::Center)
-        .width_request(180)
+        .width_request(140)
+        .max_width_chars(16)
         .hexpand(true)
         .build();
     internal_row.add_prefix(&internal_switch);
@@ -272,9 +273,10 @@ pub fn build_settings_window_with_parent(
         .build();
     let external_switch = Switch::builder().valign(gtk::Align::Center).build();
     let external_entry = Entry::builder()
-        .placeholder_text("https://immich.example.com")
+        .placeholder_text("https://…")
         .valign(gtk::Align::Center)
-        .width_request(180)
+        .width_request(140)
+        .max_width_chars(16)
         .hexpand(true)
         .build();
     external_row.add_prefix(&external_switch);
@@ -285,7 +287,8 @@ pub fn build_settings_window_with_parent(
     let api_key_row = adw::ActionRow::builder().title("API Key").build();
     let api_key_entry = PasswordEntry::builder()
         .valign(gtk::Align::Center)
-        .width_request(180)
+        .width_request(140)
+        .max_width_chars(16)
         .hexpand(true)
         .build();
     api_key_row.add_suffix(&api_key_entry);

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -306,8 +306,7 @@ pub fn build_settings_window_with_parent(
     conn_group.add(&save_btn);
 
     let settings_breakpoint = adw::Breakpoint::new(
-        adw::BreakpointCondition::parse("max-width: 500sp")
-            .expect("valid breakpoint condition"),
+        adw::BreakpointCondition::parse("max-width: 500sp").expect("valid breakpoint condition"),
     );
     settings_breakpoint.add_setter(&internal_row, "title", Some(&"LAN URL".to_value()));
     settings_breakpoint.add_setter(&external_row, "title", Some(&"WAN URL".to_value()));

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -98,7 +98,7 @@ pub fn build_settings_window_with_parent(
             .destroy_with_parent(true);
     }
     let window = window_builder.build();
-    window.set_size_request(360, 640);
+    window.set_size_request(360, 480);
 
     let view_stack = adw::ViewStack::builder()
         .vexpand(true)
@@ -252,12 +252,13 @@ pub fn build_settings_window_with_parent(
     // Internal URL
     let internal_row = adw::ActionRow::builder()
         .title("Internal URL (LAN)")
+        .title_lines(1)
         .build();
     let internal_switch = Switch::builder().valign(gtk::Align::Center).build();
     let internal_entry = Entry::builder()
         .placeholder_text("http://192.168.1.10:2283")
         .valign(gtk::Align::Center)
-        .width_request(0)
+        .width_request(180)
         .hexpand(true)
         .build();
     internal_row.add_prefix(&internal_switch);
@@ -267,12 +268,13 @@ pub fn build_settings_window_with_parent(
     // External URL
     let external_row = adw::ActionRow::builder()
         .title("External URL (WAN)")
+        .title_lines(1)
         .build();
     let external_switch = Switch::builder().valign(gtk::Align::Center).build();
     let external_entry = Entry::builder()
         .placeholder_text("https://immich.example.com")
         .valign(gtk::Align::Center)
-        .width_request(0)
+        .width_request(180)
         .hexpand(true)
         .build();
     external_row.add_prefix(&external_switch);
@@ -283,6 +285,7 @@ pub fn build_settings_window_with_parent(
     let api_key_row = adw::ActionRow::builder().title("API Key").build();
     let api_key_entry = PasswordEntry::builder()
         .valign(gtk::Align::Center)
+        .width_request(180)
         .hexpand(true)
         .build();
     api_key_row.add_suffix(&api_key_entry);
@@ -301,6 +304,17 @@ pub fn build_settings_window_with_parent(
         .margin_top(6)
         .build();
     conn_group.add(&save_btn);
+
+    let settings_breakpoint = adw::Breakpoint::new(
+        adw::BreakpointCondition::parse("max-width: 500sp")
+            .expect("valid breakpoint condition"),
+    );
+    settings_breakpoint.add_setter(&internal_row, "title", Some(&"LAN URL".to_value()));
+    settings_breakpoint.add_setter(&external_row, "title", Some(&"WAN URL".to_value()));
+    settings_breakpoint.add_setter(&internal_entry, "width-request", Some(&140i32.to_value()));
+    settings_breakpoint.add_setter(&external_entry, "width-request", Some(&140i32.to_value()));
+    settings_breakpoint.add_setter(&api_key_entry, "width-request", Some(&140i32.to_value()));
+    window.add_breakpoint(settings_breakpoint);
 
     // Clone before moving into test_btn closure so api_client is still available below
     let api_client_for_test = api_client.clone();

--- a/src/settings_window/queue_inspector.rs
+++ b/src/settings_window/queue_inspector.rs
@@ -22,6 +22,8 @@ pub fn show_queue_inspector(
         .title("Queue Inspector")
         .default_width(900)
         .default_height(680)
+        .width_request(360)
+        .height_request(480)
         .build();
     let content = Box::builder()
         .orientation(Orientation::Vertical)
@@ -68,6 +70,7 @@ pub fn show_queue_inspector(
                         .unwrap_or(task.path.as_str()),
                 )
                 .subtitle(&task.path)
+                .title_lines(1)
                 .subtitle_lines(3)
                 .build();
             let retry_btn = Button::builder().label("Retry").build();
@@ -120,12 +123,14 @@ pub fn show_queue_inspector(
                     .map(|detail| format!(" | {}", detail))
                     .unwrap_or_default()
             ))
+            .title_lines(1)
             .subtitle_lines(4)
             .build();
         row.add_prefix(
             &gtk::Label::builder()
                 .label(display_watch_path(&event.path))
-                .wrap(true)
+                .ellipsize(gtk::pango::EllipsizeMode::End)
+                .max_width_chars(20)
                 .halign(gtk::Align::Start)
                 .build(),
         );
@@ -155,6 +160,16 @@ pub fn show_queue_inspector(
         }
     ));
     content.append(&close_btn);
+
+    let bp = adw::Breakpoint::new(
+        adw::BreakpointCondition::parse("max-width: 500sp")
+            .expect("valid breakpoint condition"),
+    );
+    bp.add_setter(&retry_all_btn, "label", Some(&"Retry All".to_value()));
+    bp.add_setter(&clear_failed_btn, "label", Some(&"Clear".to_value()));
+    bp.add_setter(&events_scroll, "min-content-height", Some(&220i32.to_value()));
+    dialog.add_breakpoint(bp);
+
     dialog.present();
 }
 

--- a/src/settings_window/queue_inspector.rs
+++ b/src/settings_window/queue_inspector.rs
@@ -162,12 +162,15 @@ pub fn show_queue_inspector(
     content.append(&close_btn);
 
     let bp = adw::Breakpoint::new(
-        adw::BreakpointCondition::parse("max-width: 500sp")
-            .expect("valid breakpoint condition"),
+        adw::BreakpointCondition::parse("max-width: 500sp").expect("valid breakpoint condition"),
     );
     bp.add_setter(&retry_all_btn, "label", Some(&"Retry All".to_value()));
     bp.add_setter(&clear_failed_btn, "label", Some(&"Clear".to_value()));
-    bp.add_setter(&events_scroll, "min-content-height", Some(&220i32.to_value()));
+    bp.add_setter(
+        &events_scroll,
+        "min-content-height",
+        Some(&220i32.to_value()),
+    );
     dialog.add_breakpoint(bp);
 
     dialog.present();

--- a/src/settings_window/watch_folders.rs
+++ b/src/settings_window/watch_folders.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use adw::prelude::*;
 use glib::clone;
 use gtk::prelude::*;
-use gtk::{Box, Button, Entry, ListBox, Orientation};
+use gtk::{Box, Button, Entry, ListBox, Orientation, ScrolledWindow};
 use libadwaita as adw;
 
 use crate::config::{FolderRules, FolderSyncMethod, StartupCatchupMode};
@@ -198,7 +198,8 @@ fn show_folder_rules_dialog(
         .transient_for(parent)
         .modal(true)
         .title("Folder Rules")
-        .default_width(420)
+        .default_width(380)
+        .default_height(640)
         .width_request(360)
         .build();
     let content = Box::builder()
@@ -209,12 +210,19 @@ fn show_folder_rules_dialog(
         .margin_start(12)
         .margin_end(12)
         .build();
-    dialog.set_content(Some(&content));
+    let scroll = ScrolledWindow::builder()
+        .hscrollbar_policy(gtk::PolicyType::Never)
+        .vscrollbar_policy(gtk::PolicyType::Automatic)
+        .vexpand(true)
+        .child(&content)
+        .build();
+    dialog.set_content(Some(&scroll));
 
     let title = gtk::Label::builder()
         .label(format!("Rules for {}", display_watch_path(folder_path)))
         .halign(gtk::Align::Start)
-        .wrap(true)
+        .ellipsize(gtk::pango::EllipsizeMode::Middle)
+        .max_width_chars(28)
         .build();
     content.append(&title);
 
@@ -228,6 +236,8 @@ fn show_folder_rules_dialog(
     let ignore_hidden = adw::SwitchRow::builder()
         .title("Ignore Hidden Files / Folders")
         .subtitle("Skip paths that contain hidden components such as .cache or .thumbnails.")
+        .title_lines(1)
+        .subtitle_lines(3)
         .active(current.ignore_hidden)
         .build();
 
@@ -239,6 +249,8 @@ fn show_folder_rules_dialog(
     let sync_method = adw::ComboRow::builder()
         .title("Sync Method")
         .subtitle("Controls which direction this folder syncs.")
+        .title_lines(1)
+        .subtitle_lines(2)
         .model(&sync_model)
         .build();
     sync_method.set_selected(match current.sync_method {
@@ -251,6 +263,8 @@ fn show_folder_rules_dialog(
     let startup_scan = adw::ComboRow::builder()
         .title("Startup Scan")
         .subtitle("Controls how this folder is scanned when Mimick starts.")
+        .title_lines(1)
+        .subtitle_lines(2)
         .model(&startup_model)
         .build();
     startup_scan.set_selected(
@@ -268,11 +282,15 @@ fn show_folder_rules_dialog(
     let delete_folder_to_album = adw::SwitchRow::builder()
         .title("Mirror Folder Deletions to Album")
         .subtitle("When a synced folder file is gone, move the matching Immich asset to trash.")
+        .title_lines(2)
+        .subtitle_lines(3)
         .active(current.delete_folder_to_album)
         .build();
     let delete_album_to_folder = adw::SwitchRow::builder()
         .title("Mirror Album Deletions to Folder")
         .subtitle("Currently unavailable — waiting on an upstream Flatpak Trash portal fix. The setting stays off until then.")
+        .title_lines(2)
+        .subtitle_lines(4)
         .active(false)
         .sensitive(false)
         .build();
@@ -285,8 +303,9 @@ fn show_folder_rules_dialog(
     content.append(&list_box);
 
     let max_size_entry = Entry::builder()
-        .placeholder_text("Max file size in MB, leave blank for no limit")
+        .placeholder_text("Max size in MB (blank = no limit)")
         .width_request(0)
+        .max_width_chars(16)
         .text(
             current
                 .max_file_size_mb
@@ -297,8 +316,9 @@ fn show_folder_rules_dialog(
     content.append(&max_size_entry);
 
     let extensions_entry = Entry::builder()
-        .placeholder_text("Comma-separated extensions, e.g. jpg,png,mp4")
+        .placeholder_text("Extensions: jpg,png,mp4")
         .width_request(0)
+        .max_width_chars(16)
         .text(current.allowed_extensions.join(", "))
         .build();
     content.append(&extensions_entry);

--- a/src/settings_window/watch_folders.rs
+++ b/src/settings_window/watch_folders.rs
@@ -48,10 +48,14 @@ pub(super) fn add_folder_row(
     let rules = Rc::new(RefCell::new(entry.rules()));
 
     let picker_btn = Button::builder()
-        .label(format!("Album: {}", album_name.borrow()))
+        .label(album_name.borrow().clone())
         .valign(gtk::Align::Center)
         .tooltip_text("Select or create a target Immich album")
         .build();
+    if let Some(label) = picker_btn.child().and_downcast::<gtk::Label>() {
+        label.set_ellipsize(gtk::pango::EllipsizeMode::End);
+        label.set_max_width_chars(16);
+    }
 
     let picker_btn_clone = picker_btn.clone();
     let album_name_clone = album_name.clone();
@@ -85,7 +89,10 @@ pub(super) fn add_folder_row(
         }
     ));
 
-    let album_subrow = adw::ActionRow::builder().title("Target Album").build();
+    let album_subrow = adw::ActionRow::builder()
+        .title("Target Album")
+        .title_lines(1)
+        .build();
     album_subrow.add_suffix(&picker_btn);
     expander_row.add_row(&album_subrow);
 
@@ -156,11 +163,17 @@ pub(super) fn add_folder_row(
         }
     ));
 
-    let rules_subrow = adw::ActionRow::builder().title("Folder Rules").build();
+    let rules_subrow = adw::ActionRow::builder()
+        .title("Folder Rules")
+        .title_lines(1)
+        .build();
     rules_subrow.add_suffix(&rules_btn);
     expander_row.add_row(&rules_subrow);
 
-    let remove_subrow = adw::ActionRow::builder().title("Remove Folder").build();
+    let remove_subrow = adw::ActionRow::builder()
+        .title("Remove Folder")
+        .title_lines(1)
+        .build();
     remove_subrow.add_suffix(&remove_btn);
     expander_row.add_row(&remove_subrow);
 
@@ -186,6 +199,7 @@ fn show_folder_rules_dialog(
         .modal(true)
         .title("Folder Rules")
         .default_width(420)
+        .width_request(360)
         .build();
     let content = Box::builder()
         .orientation(Orientation::Vertical)
@@ -363,6 +377,7 @@ pub(super) fn show_album_picker_dialog(
         .title("Select Album")
         .default_width(400)
         .default_height(500)
+        .width_request(360)
         .build();
 
     let header_bar = adw::HeaderBar::new();
@@ -423,7 +438,7 @@ pub(super) fn show_album_picker_dialog(
                 let on_settings_changed_clone = on_settings_changed.clone();
                 default_row.connect_activated(move |_| {
                     *state_clone.borrow_mut() = DEFAULT_ALBUM_LABEL.to_string();
-                    btn_clone.set_label(&format!("Album: {}", DEFAULT_ALBUM_LABEL));
+                    btn_clone.set_label(DEFAULT_ALBUM_LABEL);
                     (on_settings_changed_clone)();
                     dialog_clone.close();
                 });
@@ -443,7 +458,7 @@ pub(super) fn show_album_picker_dialog(
                 let on_settings_changed_clone = on_settings_changed.clone();
                 create_row.connect_activated(move |_| {
                     *state_clone.borrow_mut() = typed_raw.clone();
-                    btn_clone.set_label(&format!("Album: {}", typed_raw));
+                    btn_clone.set_label(&typed_raw);
                     (on_settings_changed_clone)();
                     dialog_clone.close();
                 });
@@ -468,7 +483,7 @@ pub(super) fn show_album_picker_dialog(
                     let on_settings_changed_clone = on_settings_changed.clone();
                     row.connect_activated(move |_| {
                         *state_clone.borrow_mut() = album_name_clone.clone();
-                        btn_clone.set_label(&format!("Album: {}", album_name_clone));
+                        btn_clone.set_label(&album_name_clone);
                         (on_settings_changed_clone)();
                         dialog_clone.close();
                     });


### PR DESCRIPTION
## Summary

First pass at making the library window, settings, and dialogs scale to phone-class viewports (~360×720). More follow-ups expected on this branch.

## Changes

- **Library window**: `AdwBreakpoint` at `max-width: 600sp` collapses the `OverlaySplitView` sidebar into an overlay drawer, flips the controls box to vertical, and clamps `GridView` to 1–2 columns.
- **Controls reorganized** into three logical groups — `source_group` (source + Timeline), `search_group` (search-mode + entry + filters), `sort_group` — so the narrow stack is 3 grouped rows instead of 6 unrelated widgets.
- **Adaptive thumbnails**: grid cells and album/explore cards shrink from 356/300 px to ~160 px on narrow via a shared `Rc<Cell<bool>>` narrow flag plus a recursive widget walker keyed on css classes (`mimick-thumbnail-loading`, `mimick-explore-tile`, `mimick-details-pane`).
- **Lightbox details pane** shrinks from 320 to 260 on narrow; walker re-runs after `nav.push` so a lightbox opened narrow is sized correctly.
- **Per-dialog breakpoints** on filters dialog, watch_folders Folder Rules / Album Picker, and queue inspector (each with explicit `width_request(360)` floor so they can actually shrink).
- **ActionRow text** gets `title_lines(1)` / `subtitle_lines(N)` across sidebar, album link row, watch_folders rows, and queue inspector rows — kills the character-by-character title wrap on narrow.
- **Transfer bar**: `max_width_chars` 48 → 24, added `ellipsize=End`, hidden entirely on narrow via breakpoint setter.
- **Bulk + album link buttons** swap to shorter labels on narrow via breakpoint setters ("Delete" → "Del", "Link folder…" → "Link", etc.).
- **Settings window**: connectivity entries get `width_request(180)` floor; window-level breakpoint at `max-width: 500sp` shortens "Internal URL (LAN)" → "LAN URL", "External URL (WAN)" → "WAN URL", and trims entry minimums.
- **Watch folders picker button** no longer prefixes "Album: "; its child label is configured with `ellipsize=End` + `max_width_chars=16`.
