### PR TITLE
docs: fix wiki screenshots and add rustdoc references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,8 @@ Open an Issue on GitHub. Include:
 4. If you add logic, add unit tests in the same file under `#[cfg(test)]`.
 5. Run tests: `cargo test`.
 6. Ensure no warnings: `cargo clippy`.
-7. Submit your PR.
+7. Review the [API docs](https://mimick.nicx.dev/docs/) if you need to understand module interfaces.
+8. Submit your PR.
 
 ### 4. Code Style
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ flatpak run dev.nicx.mimick
 [![Development](https://img.shields.io/badge/Development-Guide-B8860B?style=for-the-badge&labelColor=B8860B)](https://github.com/nicx17/mimick/wiki/Development)
 [![Testing](https://img.shields.io/badge/Testing-Guide-0E7490?style=for-the-badge&labelColor=0E7490)](https://github.com/nicx17/mimick/wiki/Testing)
 [![Troubleshooting](https://img.shields.io/badge/Troubleshooting-Guide-CB4B16?style=for-the-badge&labelColor=CB4B16)](https://github.com/nicx17/mimick/wiki/Troubleshooting)
+[![API Docs](https://img.shields.io/badge/API-Rustdoc-F74C00?style=for-the-badge&logo=rust&logoColor=white&labelColor=F74C00)](https://mimick.nicx.dev/docs/)
 [![Security](https://img.shields.io/badge/Security-Policy-5B8C5A?style=for-the-badge&labelColor=5B8C5A)](SECURITY.md)
 
 </div>

--- a/wiki/Development.md
+++ b/wiki/Development.md
@@ -40,6 +40,14 @@ cargo run
 cargo run -- --settings
 ```
 
+## API Documentation (Rustdoc)
+
+Rustdoc is generated and deployed to [mimick.nicx.dev/docs](https://mimick.nicx.dev/docs/) on each release. To generate the docs locally:
+
+```bash
+cargo doc --no-deps --open
+```
+
 ## Profile Switcher
 
 Mimick supports isolated runtime profiles via the `MIMICK_PROFILE` environment

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -37,6 +37,7 @@ Mimick is a Linux background app that watches selected folders and syncs photos 
 [![Testing](https://img.shields.io/badge/Testing-Guide-444444?style=for-the-badge&labelColor=444444)](Testing)
 [![Release Ops](https://img.shields.io/badge/Release-Operations-444444?style=for-the-badge&labelColor=444444)](Release-Operations)
 [![Repo Automation](https://img.shields.io/badge/Repository-Automation-444444?style=for-the-badge&labelColor=444444)](Repository-Automation)
+[![API Docs](https://img.shields.io/badge/API-Rustdoc-F74C00?style=for-the-badge&logo=rust&logoColor=white&labelColor=F74C00)](https://mimick.nicx.dev/docs/)
 
 </div>
 

--- a/wiki/Screenshots.md
+++ b/wiki/Screenshots.md
@@ -5,89 +5,89 @@ This gallery showcases the various views, settings, and desktop integration feat
 ## Library View
 
 ### Photos (Light)
-![Photos page light](../docs/screenshots/photos_page_view_sidebar_on.png)
+![Photos page light](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/photos_page_view_sidebar_on.png)
 
 ### Photos (Dark)
-![Photos page dark](../docs/screenshots/photos_page_view_dark_sidebar_on.png)
+![Photos page dark](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/photos_page_view_dark_sidebar_on.png)
 
 ### Explore Page
-![Explore page](../docs/screenshots/explore_page_view_showing_people_places_sidebar_on.png)
+![Explore page](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/explore_page_view_showing_people_places_sidebar_on.png)
 
 ### Album Page
-![Album page](../docs/screenshots/album_page_view_showing_albums_recent_youralbums.png)
+![Album page](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/album_page_view_showing_albums_recent_youralbums.png)
 
 ### Selected Album (Dark)
-![Selected album dark](../docs/screenshots/selected_album_view_dark.png)
+![Selected album dark](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/selected_album_view_dark.png)
 
 ### Album View (Dark, Sidebar Off)
-![Album sidebar off](../docs/screenshots/name_dark_album_selected_view_sidebar_off.png)
+![Album sidebar off](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/name_dark_album_selected_view_sidebar_off.png)
 
 ### Lightbox (Details On)
-![Lightbox details on](../docs/screenshots/lightbox_view_details_pane_on.png)
+![Lightbox details on](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/lightbox_view_details_pane_on.png)
 
 ### Lightbox (Details Off)
-![Lightbox details off](../docs/screenshots/lightbox_view_details_pane_off.png)
+![Lightbox details off](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/lightbox_view_details_pane_off.png)
 
 ### Multi-Select with Checkboxes
-![Multi-select](../docs/screenshots/library_view_photos_page_showing_selected_assets_with_checkboxes.png)
+![Multi-select](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/library_view_photos_page_showing_selected_assets_with_checkboxes.png)
 
 ### OCR Search
-![OCR search](../docs/screenshots/search_view_with_thequickbrownfox_searched_ocr_mode.png)
+![OCR search](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/search_view_with_thequickbrownfox_searched_ocr_mode.png)
 
 ### Search Options
-![Search options](../docs/screenshots/search_options_menu_library_view.png)
+![Search options](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/search_options_menu_library_view.png)
 
 ### View Options (Remote / Local / Unified)
-![View options](../docs/screenshots/library_view_showing_view_options_for_albums_remote_local_unified.png)
+![View options](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/library_view_showing_view_options_for_albums_remote_local_unified.png)
 
 ### Advanced Filters
-![Advanced filters](../docs/screenshots/advanced_filters_menu_library_view.png)
+![Advanced filters](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/advanced_filters_menu_library_view.png)
 
 ### Advanced Filters (More Options)
-![Advanced filters more](../docs/screenshots/advanced_filters_menu_library_view_more_options.png)
+![Advanced filters more](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/advanced_filters_menu_library_view_more_options.png)
 
 ### Sync Album Dialog
-![Sync album](../docs/screenshots/library_view_showing_sync_album_dialog_upload_download_apply_cancel.png)
+![Sync album](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/library_view_showing_sync_album_dialog_upload_download_apply_cancel.png)
 
 ### Queue Inspector
-![Queue inspector](../docs/screenshots/queue_inspector_dialog.png)
+![Queue inspector](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/queue_inspector_dialog.png)
 
 ## Settings
 
 ### Connectivity
-![Connectivity](../docs/screenshots/settings_pane_showing_connnectivity_config_details.png)
+![Connectivity](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/settings_pane_showing_connnectivity_config_details.png)
 
 ### Connection Successful
-![Connection test](../docs/screenshots/settings_pane_connection_successful_dialog.png)
+![Connection test](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/settings_pane_connection_successful_dialog.png)
 
 ### Behaviour Settings
-![Behaviour](../docs/screenshots/settings_pane_showing_behaviour_settings.png)
+![Behaviour](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/settings_pane_showing_behaviour_settings.png)
 
 ### Library and Watch Folders
-![Library settings](../docs/screenshots/settings_pane_showing_library_settings_and_watch_folders.png)
+![Library settings](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/settings_pane_showing_library_settings_and_watch_folders.png)
 
 ### Watch Folder Details
-![Watch folders](../docs/screenshots/watching_folders_list_in_settings_showing_folder_details.png)
+![Watch folders](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/watching_folders_list_in_settings_showing_folder_details.png)
 
 ### Album Selection for Watch Folder
-![Album selection](../docs/screenshots/album_selection_menu_for_watching_folder.png)
+![Album selection](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/album_selection_menu_for_watching_folder.png)
 
 ### Album Selection with Search
-![Album search](../docs/screenshots/watching_folder_album_selection_menu_with_search_feat.png)
+![Album search](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/watching_folder_album_selection_menu_with_search_feat.png)
 
 ### Folder Rules Dialog
-![Folder rules](../docs/screenshots/album_specific_rule_dialog.png)
+![Folder rules](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/album_specific_rule_dialog.png)
 
 ### Status and Health Dashboard
-![Status dashboard](../docs/screenshots/status_pane_sync_status_health_dashboard_actions.png)
+![Status dashboard](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/status_pane_sync_status_health_dashboard_actions.png)
 
 ### About Mimick
-![About dialog](../docs/screenshots/about_mimick_dialog.png)
+![About dialog](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/about_mimick_dialog.png)
 
 ## Desktop Integration
 
 ### Tray Icon Menu
-![Tray icon](../docs/screenshots/tray_icon_menu.png)
+![Tray icon](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/tray_icon_menu.png)
 
 ### Desktop Notification
-![Notification](../docs/screenshots/mimick_notification_popup_on_desktop.png)
+![Notification](https://raw.githubusercontent.com/nicx17/mimick/main/docs/screenshots/mimick_notification_popup_on_desktop.png)


### PR DESCRIPTION
- Fix wiki screenshot gallery showing no images (relative paths replaced with absolute `raw.githubusercontent.com` URLs)
- Add rustdoc API reference links to README, wiki Home, Development guide, and CONTRIBUTING