### PR TITLE
feat: XMP sidecar upload support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Embedded JPEG preview extraction from RAW files via `libraw_unpack_thumb` + `libraw_dcraw_make_mem_thumb`. Supported across all major RAW formats (CR2, CR3, NEF, ARW, DNG, ORF, RW2, PEF, FFF, RAF, SR2, MRW, etc.) with automatic fallback to full demosaic when no embedded preview exists.
 - Toggleable RAW decode cache setting in Settings > Library. Stores demosaiced textures as PNGs on disk to skip re-processing on re-opens. Defaults to off to conserve storage.
 - Lightbox swipe gesture navigation: swipe left for next asset, swipe right for previous. Works with both touch and trackpad input. Automatically disabled when zoomed in to avoid conflicting with pan gestures. Essential on mobile viewports (360px) where the prev/next header buttons are hidden.
+- XMP sidecar upload support: companion `.xmp` files alongside media are automatically detected and attached via the Immich `sidecarData` multipart field during upload. Searches `photo.ext.xmp` (preferred) then `photo.xmp` (fallback), case-insensitive. Global toggle in Settings > Behavior with per-folder override in Folder Rules.
 
 ### Changed
 

--- a/src/api_client/upload.rs
+++ b/src/api_client/upload.rs
@@ -18,10 +18,14 @@ use super::{ApiIssue, ImmichApiClient, TransferProgressCallback};
 
 impl ImmichApiClient {
     /// Upload a single local asset to the Immich server with progressive status tracking.
+    ///
+    /// When `sidecar_path` points to an existing XMP file it is attached as the
+    /// `sidecarData` multipart field so Immich ingests it alongside the asset.
     pub async fn upload_asset(
         &self,
         file_path: &str,
         checksum: &str,
+        sidecar_path: Option<&str>,
         progress: Option<TransferProgressCallback>,
     ) -> Option<String> {
         let base_url = match self.get_active_url().await {
@@ -115,13 +119,38 @@ impl ImmichApiClient {
             .mime_str(mime)
             .ok()?;
 
-        let form = reqwest::multipart::Form::new()
+        let mut form = reqwest::multipart::Form::new()
             .part("assetData", file_part)
             .text("deviceAssetId", device_asset_id)
             .text("deviceId", device_id)
             .text("fileCreatedAt", created_at)
             .text("fileModifiedAt", modified_at)
             .text("isFavorite", "false");
+
+        // Attach XMP sidecar when present.
+        if let Some(sidecar) = sidecar_path {
+            let sidecar_p = Path::new(sidecar);
+            if sidecar_p.exists() {
+                match tokio::fs::read(sidecar_p).await {
+                    Ok(sidecar_bytes) => {
+                        let sidecar_filename = sidecar_p
+                            .file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_else(|| "sidecar.xmp".to_string());
+                        if let Ok(sidecar_part) = reqwest::multipart::Part::bytes(sidecar_bytes)
+                            .file_name(sidecar_filename.clone())
+                            .mime_str("application/xml")
+                        {
+                            form = form.part("sidecarData", sidecar_part);
+                            log::info!("Attaching sidecar: {}", sidecar_filename);
+                        }
+                    }
+                    Err(err) => {
+                        log::warn!("Could not read sidecar '{}': {}", sidecar, err);
+                    }
+                }
+            }
+        }
 
         let url = format!("{}/api/assets", base_url);
         let api_key = self.settings.read().api_key.clone();

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,6 +87,14 @@ impl FolderRules {
 
         true
     }
+
+    /// Resolve whether XMP sidecar upload is enabled for this folder.
+    ///
+    /// Returns the per-folder override when set, otherwise falls back to the
+    /// caller-supplied global default.
+    pub fn xmp_sidecar_enabled(&self, global_default: bool) -> bool {
+        self.include_xmp_sidecar.unwrap_or(global_default)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,10 @@ pub struct FolderRules {
     /// Delete remote asset when its corresponding local file is removed.
     #[serde(default)]
     pub delete_album_to_folder: bool,
+    /// Per-folder override for XMP sidecar upload. `None` inherits the global
+    /// `upload_xmp_sidecars` setting; `Some(true/false)` overrides it.
+    #[serde(default)]
+    pub include_xmp_sidecar: Option<bool>,
 }
 
 impl FolderRules {
@@ -271,6 +275,10 @@ pub struct ConfigData {
     /// Include hidden people in the Explore view.
     #[serde(default)]
     pub show_hidden_faces: bool,
+    /// Attach XMP sidecar files alongside media during upload. Per-folder
+    /// rules can override this global default.
+    #[serde(default = "default_true")]
+    pub upload_xmp_sidecars: bool,
 }
 
 impl Default for ConfigData {
@@ -299,6 +307,7 @@ impl Default for ConfigData {
             raw_full_decode: false,
             show_unnamed_faces: true,
             show_hidden_faces: false,
+            upload_xmp_sidecars: true,
         }
     }
 }

--- a/src/library/album_sync.rs
+++ b/src/library/album_sync.rs
@@ -326,6 +326,8 @@ pub async fn execute_uploads(
 ) -> usize {
     let mut queued = 0;
     for entry in entries {
+        let sidecar_path = crate::sidecar::find_sidecar(&entry.local.path)
+            .map(|p| p.to_string_lossy().into_owned());
         let task = FileTask {
             path: entry.local.path.to_string_lossy().to_string(),
             watch_path: watch_path.to_string_lossy().to_string(),
@@ -334,6 +336,7 @@ pub async fn execute_uploads(
             album_name: Some(album_name.clone()),
             reassociate_only: false,
             skip_album: false,
+            sidecar_path,
         };
         if ctx.queue_manager.add_to_queue(task).await {
             queued += 1;

--- a/src/library/album_sync.rs
+++ b/src/library/album_sync.rs
@@ -324,10 +324,25 @@ pub async fn execute_uploads(
     watch_path: PathBuf,
     entries: Vec<LocalEntry>,
 ) -> usize {
+    let folder_xmp = {
+        let cfg = ctx.config.read();
+        let global_xmp = cfg.data.upload_xmp_sidecars;
+        cfg.data
+            .watch_paths
+            .iter()
+            .find(|e| e.path() == watch_path.to_string_lossy())
+            .map(|e| e.rules().xmp_sidecar_enabled(global_xmp))
+            .unwrap_or(global_xmp)
+    };
+
     let mut queued = 0;
     for entry in entries {
-        let sidecar_path = crate::sidecar::find_sidecar(&entry.local.path)
-            .map(|p| p.to_string_lossy().into_owned());
+        let sidecar_path = if folder_xmp {
+            crate::sidecar::find_sidecar(&entry.local.path)
+                .map(|p| p.to_string_lossy().into_owned())
+        } else {
+            None
+        };
         let task = FileTask {
             path: entry.local.path.to_string_lossy().to_string(),
             watch_path: watch_path.to_string_lossy().to_string(),

--- a/src/library/upload_picker.rs
+++ b/src/library/upload_picker.rs
@@ -83,8 +83,11 @@ fn spawn_enqueue(ctx: Arc<AppContext>, album: Option<(String, String)>, paths: V
                         continue;
                     }
                 };
-            let sidecar_path =
-                crate::sidecar::find_sidecar(&path).map(|p| p.to_string_lossy().into_owned());
+            let sidecar_path = if ctx.config.read().data.upload_xmp_sidecars {
+                crate::sidecar::find_sidecar(&path).map(|p| p.to_string_lossy().into_owned())
+            } else {
+                None
+            };
             let task = FileTask {
                 path: path_str,
                 watch_path,

--- a/src/library/upload_picker.rs
+++ b/src/library/upload_picker.rs
@@ -83,6 +83,8 @@ fn spawn_enqueue(ctx: Arc<AppContext>, album: Option<(String, String)>, paths: V
                         continue;
                     }
                 };
+            let sidecar_path =
+                crate::sidecar::find_sidecar(&path).map(|p| p.to_string_lossy().into_owned());
             let task = FileTask {
                 path: path_str,
                 watch_path,
@@ -95,6 +97,7 @@ fn spawn_enqueue(ctx: Arc<AppContext>, album: Option<(String, String)>, paths: V
                 // queue's parent-dir-as-album fallback would otherwise create
                 // a junk album named after the user's file system layout.
                 skip_album: album.is_none(),
+                sidecar_path,
             };
             if ctx.queue_manager.add_to_queue(task).await {
                 queued += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod remote_sync;
 mod runtime_env;
 mod sanitize;
 mod settings_window;
+mod sidecar;
 mod startup_scan;
 mod state_manager;
 mod sync_index;
@@ -510,7 +511,7 @@ async fn main() {
         tokio::spawn(async move {
             while let Some(event) = rx.recv().await {
                 match event {
-                    MonitorEvent::Ready { path, checksum } => {
+                    MonitorEvent::Ready { path, checksum, sidecar_path } => {
                         if deletion_ctx.expected_self_downloads.consume(&path) {
                             continue;
                         }
@@ -576,6 +577,7 @@ async fn main() {
                                 album_name,
                                 reassociate_only,
                                 skip_album: false,
+                                sidecar_path,
                             })
                             .await;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -516,24 +516,34 @@ async fn main() {
                             continue;
                         }
 
-                        let (album_id, album_name, watch_path) = {
+                        let (album_id, album_name, watch_path, folder_rules) = {
                             let path_configs = live_watch_paths_for_queue.lock();
                             best_matching_watch_entry(std::path::Path::new(&path), &path_configs)
                                 .map(|entry| match entry {
                                     config::WatchPathEntry::WithConfig {
                                         album_id,
                                         album_name,
+                                        rules,
                                         ..
                                     } => (
                                         album_id.clone(),
                                         album_name.clone(),
                                         entry.path().to_string(),
+                                        rules.clone(),
                                     ),
                                     config::WatchPathEntry::Simple(_) => {
-                                        (None, None, entry.path().to_string())
+                                        (None, None, entry.path().to_string(), Default::default())
                                     }
                                 })
-                                .unwrap_or((None, None, String::new()))
+                                .unwrap_or((None, None, String::new(), Default::default()))
+                        };
+
+                        // Resolve XMP: per-folder override -> global default.
+                        let global_xmp = deletion_ctx.config.read().data.upload_xmp_sidecars;
+                        let sidecar_path = if folder_rules.xmp_sidecar_enabled(global_xmp) {
+                            sidecar_path
+                        } else {
+                            None
                         };
 
                         let target = SyncTarget {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -39,6 +39,8 @@ pub enum MonitorEvent {
         path: String,
         /// File SHA-1 checksum.
         checksum: String,
+        /// Companion XMP sidecar path, if one was found on disk.
+        sidecar_path: Option<String>,
     },
     /// Emitted when a watched file is deleted.
     Deleted {
@@ -115,11 +117,15 @@ impl Monitor {
                             .await
                         {
                             Ok(Ok(checksum)) => {
+                                let sidecar_path =
+                                    crate::sidecar::find_sidecar(std::path::Path::new(&path_str))
+                                        .map(|p| p.to_string_lossy().into_owned());
                                 log::info!("File ready: {} (sha1={})", path_str, checksum);
                                 let _ = tx_out
                                     .send(MonitorEvent::Ready {
                                         path: path_str.clone(),
                                         checksum,
+                                        sidecar_path,
                                     })
                                     .await;
                             }

--- a/src/queue_manager.rs
+++ b/src/queue_manager.rs
@@ -70,6 +70,10 @@ pub struct FileTask {
     /// existing parent-dir-as-album fallback still applies.
     #[serde(default)]
     pub skip_album: bool,
+    /// Absolute path to an XMP sidecar file to attach during upload.
+    /// `None` when no companion sidecar exists or sidecar upload is disabled.
+    #[serde(default)]
+    pub sidecar_path: Option<String>,
 }
 
 pub struct QueueManager {
@@ -892,8 +896,13 @@ async fn handle_upload(
             Some(existing)
         }
         None => {
-            api.upload_asset(&task.path, &task.checksum, Some(progress.clone()))
-                .await
+            api.upload_asset(
+                &task.path,
+                &task.checksum,
+                task.sidecar_path.as_deref(),
+                Some(progress.clone()),
+            )
+            .await
         }
     };
 
@@ -1124,6 +1133,7 @@ mod tests {
             album_name: Some("Album".to_string()),
             reassociate_only: false,
             skip_album: false,
+            sidecar_path: None,
         };
         let js = serde_json::to_string(&task).unwrap();
         assert!(js.contains("sha123"));
@@ -1150,6 +1160,10 @@ mod tests {
             !task.skip_album,
             "legacy entries inherit album-creation behaviour"
         );
+        assert!(
+            task.sidecar_path.is_none(),
+            "legacy entries default to no sidecar"
+        );
     }
 
     #[test]
@@ -1162,6 +1176,7 @@ mod tests {
             album_name: None,
             reassociate_only: false,
             skip_album: true,
+            sidecar_path: None,
         };
         let js = serde_json::to_string(&task).unwrap();
         let restored: FileTask = serde_json::from_str(&js).unwrap();
@@ -1181,6 +1196,7 @@ mod tests {
             album_name: None,
             reassociate_only: false,
             skip_album: false,
+            sidecar_path: None,
         };
 
         let tasks = vec![task];
@@ -1201,6 +1217,7 @@ mod tests {
             album_name: Some("Album".into()),
             reassociate_only: false,
             skip_album: false,
+            sidecar_path: None,
         };
 
         assert!(qm.add_to_queue(task.clone()).await);
@@ -1223,6 +1240,7 @@ mod tests {
             album_name: None,
             reassociate_only: false,
             skip_album: false,
+            sidecar_path: None,
         };
 
         retry_list.lock().push(task.clone());
@@ -1258,6 +1276,7 @@ mod tests {
             album_name: None,
             reassociate_only: false,
             skip_album: false,
+            sidecar_path: None,
         };
 
         retry_list.lock().push(task.clone());

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -515,6 +515,12 @@ pub fn build_settings_window_with_parent(
         .build();
     behavior_group.add(&concurrency_row);
 
+    let xmp_sidecar_row = adw::SwitchRow::builder()
+        .title("Upload XMP Sidecars")
+        .subtitle("Attach companion .xmp sidecar files alongside media during upload.")
+        .build();
+    behavior_group.add(&xmp_sidecar_row);
+
     // Quiet hours — enable switch + two hour spinners
     let quiet_hours_row = adw::SwitchRow::builder()
         .title("Quiet Hours")
@@ -749,6 +755,8 @@ pub fn build_settings_window_with_parent(
         catchup_row,
         #[weak]
         background_sync_row,
+        #[weak]
+        xmp_sidecar_row,
         #[strong]
         tracked_rows,
         #[strong]
@@ -835,6 +843,7 @@ pub fn build_settings_window_with_parent(
             let quiet_hours_start = quiet_hours_enabled.then(|| quiet_start_row.value() as u8);
             let quiet_hours_end = quiet_hours_enabled.then(|| quiet_end_row.value() as u8);
             let background_sync_enabled = background_sync_row.is_active();
+            let upload_xmp_sidecars = xmp_sidecar_row.is_active();
             let catchup_mode = match catchup_row.selected() {
                 1 => StartupCatchupMode::RecentOnly,
                 2 => StartupCatchupMode::NewFilesOnly,
@@ -965,6 +974,7 @@ pub fn build_settings_window_with_parent(
                         new_config.data.upload_concurrency = upload_concurrency;
                         new_config.data.quiet_hours_start = quiet_hours_start;
                         new_config.data.quiet_hours_end = quiet_hours_end;
+                        new_config.data.upload_xmp_sidecars = upload_xmp_sidecars;
 
                         if include_connectivity
                             && !api_key.is_empty()
@@ -1413,6 +1423,7 @@ pub fn build_settings_window_with_parent(
         disk_cache_row.set_value(config.data.cache_disk_cap_mb as f64);
     }
     concurrency_row.set_value(config.data.upload_concurrency as f64);
+    xmp_sidecar_row.set_active(config.data.upload_xmp_sidecars);
     let qh_enabled = config.data.quiet_hours_start.is_some();
     quiet_hours_row.set_active(qh_enabled);
     quiet_start_row.set_value(config.data.quiet_hours_start.unwrap_or(22) as f64);

--- a/src/settings_window/watch_folders.rs
+++ b/src/settings_window/watch_folders.rs
@@ -301,11 +301,20 @@ fn show_folder_rules_dialog(
         .sensitive(false)
         .build();
 
+    let include_xmp = adw::SwitchRow::builder()
+        .title("Include XMP Sidecars")
+        .subtitle("Attach companion .xmp files alongside media during upload.")
+        .title_lines(1)
+        .subtitle_lines(2)
+        .active(current.include_xmp_sidecar.unwrap_or(true))
+        .build();
+
     list_box.append(&sync_method);
     list_box.append(&startup_scan);
     list_box.append(&delete_folder_to_album);
     list_box.append(&delete_album_to_folder);
     list_box.append(&ignore_hidden);
+    list_box.append(&include_xmp);
     content.append(&list_box);
 
     let max_size_entry = Entry::builder()
@@ -382,6 +391,7 @@ fn show_folder_rules_dialog(
                 }),
                 delete_folder_to_album: delete_folder_to_album.is_active(),
                 delete_album_to_folder: stored_delete_album_to_folder,
+                include_xmp_sidecar: Some(include_xmp.is_active()),
             };
             (on_settings_changed)();
             dialog.close();

--- a/src/sidecar.rs
+++ b/src/sidecar.rs
@@ -1,0 +1,130 @@
+//! XMP sidecar file discovery.
+//!
+//! Locates `.xmp` companion files alongside media assets using the same
+//! naming conventions that Immich recognises:
+//!   1. `photo.jpg.xmp`  (preferred -- includes the media extension)
+//!   2. `photo.xmp`      (fallback  -- stem only)
+//!
+//! Both patterns are probed case-insensitively so `photo.CR2.XMP` is found.
+
+use std::path::{Path, PathBuf};
+
+/// Find the XMP sidecar companion for a media file, if one exists on disk.
+///
+/// Returns the preferred `<name>.<ext>.xmp` path when present, otherwise
+/// falls back to `<stem>.xmp`. Returns `None` when neither exists.
+pub fn find_sidecar(media_path: &Path) -> Option<PathBuf> {
+    let parent = media_path.parent()?;
+    let filename = media_path.file_name()?.to_str()?;
+
+    // Preferred: photo.jpg.xmp
+    let preferred = parent.join(format!("{}.xmp", filename));
+    if case_insensitive_exists(&preferred) {
+        return Some(resolve_case_insensitive(&preferred).unwrap_or(preferred));
+    }
+
+    // Fallback: photo.xmp
+    let stem = media_path.file_stem()?.to_str()?;
+    let fallback = parent.join(format!("{}.xmp", stem));
+    if case_insensitive_exists(&fallback) {
+        return Some(resolve_case_insensitive(&fallback).unwrap_or(fallback));
+    }
+
+    None
+}
+/// Check whether a file exists using case-insensitive extension matching.
+///
+/// Tries the exact path first (fast), then scans the parent directory for
+/// a case-variant match (e.g. `.XMP` vs `.xmp`).
+fn case_insensitive_exists(path: &Path) -> bool {
+    if path.exists() {
+        return true;
+    }
+    resolve_case_insensitive(path).is_some()
+}
+
+/// Scan the parent directory for a file whose name matches case-insensitively.
+fn resolve_case_insensitive(path: &Path) -> Option<PathBuf> {
+    let parent = path.parent()?;
+    let target = path.file_name()?.to_str()?.to_ascii_lowercase();
+    let entries = std::fs::read_dir(parent).ok()?;
+    for entry in entries.flatten() {
+        if let Some(name) = entry.file_name().to_str()
+            && name.to_ascii_lowercase() == target
+        {
+            return Some(entry.path());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn setup() -> TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn preferred_pattern_found() {
+        let dir = setup();
+        let media = dir.path().join("photo.jpg");
+        let sidecar = dir.path().join("photo.jpg.xmp");
+        fs::write(&media, b"img").unwrap();
+        fs::write(&sidecar, b"<xmp/>").unwrap();
+
+        assert_eq!(find_sidecar(&media), Some(sidecar));
+    }
+
+    #[test]
+    fn fallback_pattern_found() {
+        let dir = setup();
+        let media = dir.path().join("photo.cr2");
+        let sidecar = dir.path().join("photo.xmp");
+        fs::write(&media, b"raw").unwrap();
+        fs::write(&sidecar, b"<xmp/>").unwrap();
+
+        assert_eq!(find_sidecar(&media), Some(sidecar));
+    }
+
+    #[test]
+    fn preferred_takes_priority_over_fallback() {
+        let dir = setup();
+        let media = dir.path().join("photo.dng");
+        let preferred = dir.path().join("photo.dng.xmp");
+        let _fallback = dir.path().join("photo.xmp");
+        fs::write(&media, b"raw").unwrap();
+        fs::write(&preferred, b"<preferred/>").unwrap();
+        fs::write(&_fallback, b"<fallback/>").unwrap();
+
+        assert_eq!(find_sidecar(&media), Some(preferred));
+    }
+
+    #[test]
+    fn no_sidecar_returns_none() {
+        let dir = setup();
+        let media = dir.path().join("photo.jpg");
+        fs::write(&media, b"img").unwrap();
+
+        assert_eq!(find_sidecar(&media), None);
+    }
+
+    #[test]
+    fn case_insensitive_extension() {
+        let dir = setup();
+        let media = dir.path().join("photo.nef");
+        let sidecar = dir.path().join("photo.nef.XMP");
+        fs::write(&media, b"raw").unwrap();
+        fs::write(&sidecar, b"<xmp/>").unwrap();
+
+        let result = find_sidecar(&media);
+        assert!(result.is_some(), "should find .XMP variant");
+        assert_eq!(
+            result.unwrap().file_name().unwrap().to_str().unwrap(),
+            "photo.nef.XMP"
+        );
+    }
+}

--- a/src/startup_scan.rs
+++ b/src/startup_scan.rs
@@ -721,6 +721,9 @@ async fn hash_to_task(
         }
     };
 
+    let sidecar_path = crate::sidecar::find_sidecar(std::path::Path::new(&path))
+        .map(|p| p.to_string_lossy().into_owned());
+
     Ok(FileTask {
         path,
         watch_path,
@@ -729,6 +732,7 @@ async fn hash_to_task(
         album_name,
         reassociate_only,
         skip_album: false,
+        sidecar_path,
     })
 }
 

--- a/src/startup_scan.rs
+++ b/src/startup_scan.rs
@@ -32,6 +32,8 @@ struct ScanCandidate {
     watch_path: String,
     /// Inferred or configured album name.
     album_name: String,
+    /// Whether XMP sidecar attachment is enabled for this candidate.
+    sidecar_enabled: bool,
 }
 
 /// Scans watch folders at startup and queues new, changed, or retargeted files for upload.
@@ -60,8 +62,15 @@ pub async fn queue_unsynced_files(
         .last_successful_sync_at
         .unwrap_or_default();
 
-    let (candidates, mut seen_paths, skipped_enum, enum_errors) =
-        enumerate_candidates(&watch_paths, catchup_mode, last_sync, &shared_state);
+    let global_xmp_enabled = app_ctx.config.read().data.upload_xmp_sidecars;
+
+    let (candidates, mut seen_paths, skipped_enum, enum_errors) = enumerate_candidates(
+        &watch_paths,
+        catchup_mode,
+        last_sync,
+        &shared_state,
+        global_xmp_enabled,
+    );
 
     // ── Stage 2: Async decide + queue ────────────────────────────────────
 
@@ -171,6 +180,7 @@ pub async fn queue_unsynced_files(
                     Some(album_name),
                     reassociate_only,
                     cached_checksum,
+                    candidate.sidecar_enabled,
                 )
                 .await
                 {
@@ -586,6 +596,7 @@ fn enumerate_candidates(
     fallback_catchup_mode: StartupCatchupMode,
     last_sync: f64,
     shared_state: &Arc<Mutex<AppState>>,
+    global_xmp_enabled: bool,
 ) -> (Vec<ScanCandidate>, HashSet<String>, usize, usize) {
     let skipped = AtomicUsize::new(0);
     let errors = AtomicUsize::new(0);
@@ -670,10 +681,13 @@ fn enumerate_candidates(
 
                             seen_paths.lock().insert(path_str.clone());
                             let album_name = effective_album_name(entry, &path);
+                            let sidecar_enabled =
+                                entry.rules().xmp_sidecar_enabled(global_xmp_enabled);
                             results.push(ScanCandidate {
                                 path: path_str,
                                 watch_path: watch_path_str.clone(),
                                 album_name,
+                                sidecar_enabled,
                             });
                         }
                         Err(err) => {
@@ -703,6 +717,7 @@ async fn hash_to_task(
     album_name: Option<String>,
     reassociate_only: bool,
     checksum: Option<String>,
+    sidecar_enabled: bool,
 ) -> Result<FileTask, ()> {
     let checksum = if let Some(checksum) = checksum {
         checksum
@@ -721,8 +736,12 @@ async fn hash_to_task(
         }
     };
 
-    let sidecar_path = crate::sidecar::find_sidecar(std::path::Path::new(&path))
-        .map(|p| p.to_string_lossy().into_owned());
+    let sidecar_path = if sidecar_enabled {
+        crate::sidecar::find_sidecar(std::path::Path::new(&path))
+            .map(|p| p.to_string_lossy().into_owned())
+    } else {
+        None
+    };
 
     Ok(FileTask {
         path,


### PR DESCRIPTION
Attach companion .xmp sidecar files during upload via Immich `sidecarData` multipart field.

- Probe `photo.ext.xmp` then `photo.xmp` (case-insensitive)
- Global toggle in Settings > Behavior (default on)
- Per-folder override in Folder Rules
- Wired through monitor, startup scan, album sync, and manual upload paths

Refs #137