### PR TITLE
docs: revise API key permissions mapping to match exact Immich scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,12 @@ When generating the API key in Immich (Account Settings → API Keys), grant onl
 
 | Permission       | Why                                              |
 | ---------------- | ------------------------------------------------ |
+| `user.read`      | Establish current user session and identity      |
 | `asset.upload`   | Send media to the server                         |
 | `asset.update`   | Apply correct timezone metadata after upload     |
 | `album.read`     | Look up the target album for a watch folder      |
 | `album.create`   | Auto-create the target album if it doesn't exist |
-| `album.addAsset` | Link uploaded media to the target album          |
+| `albumAsset.create` | Link uploaded media to the target album          |
 
 **Optional — only required for the features you enable:**
 
@@ -178,7 +179,7 @@ When generating the API key in Immich (Account Settings → API Keys), grant onl
 | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Library / Explore view (browse photos inside Mimick)                | `asset.read`, `asset.view`, `asset.download`, `person.read`                                                                                                    |
 | **Sync Method** set to **Full** or **Download Only** (folder rules) | `asset.read`, `asset.download`                                                                                                                                 |
-| **Mirror Folder Deletions to Album** (folder rules toggle)          | `asset.delete` _and_ `album.removeAsset` (the latter is used when the same asset is referenced by another watch folder, so we just unlink instead of trashing) |
+| **Mirror Folder Deletions to Album** (folder rules toggle)          | `asset.delete` _and_ `albumAsset.delete` (the latter is used when the same asset is referenced by another watch folder, so we just unlink instead of trashing) |
 | **Mirror Album Deletions to Folder** (folder rules toggle)          | No additional remote permissions — the album listing is already covered by `album.read`, the trash happens locally                                             |
 
 If you grant `all`, every feature works without further configuration. The granular list above is for users who prefer least-privilege keys.

--- a/src/api_client/upload.rs
+++ b/src/api_client/upload.rs
@@ -219,7 +219,7 @@ impl ImmichApiClient {
                     401 | 403 => {
                         self.set_issue(ApiIssue {
                             summary: "Immich rejected the API key".to_string(),
-                            guidance: "Update the API key in Settings and ensure it has the Asset upload + update and Album read/create/addAsset permissions."
+                            guidance: "Update the API key in Settings and ensure it has the Asset upload + update and Album read/create/albumAsset.create permissions."
                                 .to_string(),
                         })
                         .await;

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -178,12 +178,12 @@ pub fn build_settings_window_with_parent(
     if is_unconfigured {
         let welcome_group = adw::PreferencesGroup::builder()
             .title("Welcome to Mimick!")
-            .description("Start by adding your API key, testing the connection, and choosing at least one folder. The key needs Asset (upload, update, read, download, delete) and Album (read, create, addAsset, removeAsset) permissions.")
+            .description("Start by adding your API key, testing the connection, and choosing at least one folder. The key needs Asset (read, view, upload, update, download, delete), Album (read, create, update), and albumAsset (create, delete) permissions.")
             .build();
 
         let help_row = adw::ActionRow::builder()
             .title("How to get an API Key")
-            .subtitle("Required permissions: Asset upload/update + Album read/create/addAsset. Add delete + download for full bidirectional sync.")
+            .subtitle("Base sync: user.read, asset.upload/update, album.read/create, albumAsset.create. See docs for Library/deletion scopes.")
             .activatable(true)
             .build();
 

--- a/wiki/Configuration-and-First-Run.md
+++ b/wiki/Configuration-and-First-Run.md
@@ -54,7 +54,7 @@ The window follows your desktop appearance preference, so it can render in eithe
     * Open your Immich Web Interface in a browser.
     * Go to **Account Settings** → **API Keys**.
     * Click **New API Key**, give it a name (like "Linux Desktop"), and click Create.
-    * Make sure the key includes **Asset Read/Create/Update/Download** and **Album Read/Create/Update** permissions.
+    * Make sure the key includes **Asset (Read, View, Download, Upload, Update, Delete)**, **Album (Read, Create, Update)**, **User (Read)**, and **Person (Read)** permissions.
     * Copy the key and paste it into the API Key field in Mimick.
     * *The key is stored securely using the `oo7` crate (encrypted portal file in Flatpak, or D-Bus Secret Service native).*
 
@@ -351,11 +351,12 @@ When generating an API Key in the Immich Web UI (Account Settings → API Keys),
 
 | Permission | Why |
 |---|---|
+| `user.read` | Establish current user session and identity |
 | `asset.upload` | Send media to the server |
 | `asset.update` | Apply correct timezone metadata after upload |
 | `album.read` | Look up the target album for a watch folder |
 | `album.create` | Auto-create the target album if it doesn't exist |
-| `album.addAsset` | Link uploaded media to the target album |
+| `albumAsset.create` | Link uploaded media to the target album |
 
 **Feature-specific — grant only if you use that feature:**
 
@@ -363,7 +364,7 @@ When generating an API Key in the Immich Web UI (Account Settings → API Keys),
 |---|---|
 | Library / Explore browsing inside Mimick | `asset.read`, `asset.view`, `asset.download`, `person.read` |
 | Sync Method set to **Full** or **Download Only** (folder rules) | `asset.read`, `asset.download` |
-| **Mirror Folder Deletions to Album** (folder rules toggle) | `asset.delete` and `album.removeAsset` (used when the same asset is referenced by another watch folder, so we unlink instead of trashing) |
+| **Mirror Folder Deletions to Album** (folder rules toggle) | `asset.delete` and `albumAsset.delete` (used when the same asset is referenced by another watch folder, so we unlink instead of trashing) |
 | **Mirror Album Deletions to Folder** (folder rules toggle) | No additional remote permissions — `album.read` already lists the album, and the local trash is purely client-side |
 
 If you grant `all`, every feature works without further configuration. The list above is for users who prefer scoped keys.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -36,9 +36,9 @@ Then re-enter and save your API key from the settings window.
 
 The key is valid but missing one or more permissions Mimick uses. Confirm in Immich (Account Settings → API Keys → edit) that the key has at least:
 
-- Base sync: `asset.upload`, `asset.update`, `album.read`, `album.create`, `album.addAsset`
-- Add `asset.read` + `asset.download` if you use Library view or Download Only / Full sync method
-- Add `asset.delete` + `album.removeAsset` if you enabled **Mirror Folder Deletions to Album** in any folder's rules
+- Base sync: `user.read`, `asset.upload`, `asset.update`, `album.read`, `album.create`, `albumAsset.create`
+- Add `asset.read`, `asset.view`, `asset.download`, and `person.read` if you use Library view or Download Only / Full sync method
+- Add `asset.delete` and `albumAsset.delete` if you enabled **Mirror Folder Deletions to Album** in any folder's rules
 
 See Configuration & First Run → "API Key Security & Required Permissions" for the full feature/permission mapping.
 
@@ -66,7 +66,7 @@ If a file seems to be ignored completely, check:
 1. the watch folder was selected through the app
 2. the file extension is supported (Only Immich-compatible image and video formats are recognized)
 3. the file finished writing to disk (temporary files are ignored)
-4. the API key and server URLs are valid, and the key has the required permissions (`asset.upload`, `asset.update`, `album.read`, `album.create`, `album.addAsset` — see Configuration & First Run for the full table)
+4. the API key and server URLs are valid, and the key has the required permissions (`user.read`, `asset.upload`, `asset.update`, `album.read`, `album.create`, `albumAsset.create` — see Configuration & First Run for the full table)
 5. folder rules are not excluding the file (hidden files, or max-size restrictions)
 
 > **Check the Queue Inspector**


### PR DESCRIPTION
- Clarifies mapping between app functionality and Immich API enum scopes
- Adds missing requirements: user.read, asset.view, person.read
- Corrects album asset management scopes to albumAsset.create and albumAsset.delete