### PR TITLE
feat(library): masonry photos grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,10 +59,11 @@ test_gobject.sh
 codebase_analysis.md
 test_about.py
 
-
+.flatpak-builder/
 # Added by cargo
 /target
-
+/build-dir
+flatpak-venv
 .codex
 /pv_docs
 workflow_audit.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New masonry layout for the Photos view in Library. Images now keep their natural aspect ratios and pack into justified rows instead of a fixed tile grid.
+- New `Library Thumbnail Quality` setting with `Auto`, `Thumbnail`, `Preview`, and `Full Size` options. `Auto` chooses a size based on the rendered cell size, and `Full Size` falls back automatically when the server does not provide that image size.
+
+### Changed
+
+- Library layout now uses image dimensions from Immich EXIF data earlier in the load path, so rows are sized more accurately from the first paint.
+- Thumbnail memory cache is now sized automatically from available system RAM, using up to 20% of memory with built-in minimum and maximum limits, so the manual memory-cache limit setting has been removed.
+- Thumbnail loading now uses separate concurrency limits for smaller thumbnails and larger preview/full-size requests to keep browsing responsive while larger images are still loading.
+- Library settings text was shortened and cleaned up to make common options easier to scan.
+
+### Fixed
+
+- Masonry grid scrolling and thumbnail loading are now more stable. Items close to the visible area load first, and the layout no longer shifts as much while images are coming in.
+- Large cells can now request higher-quality preview and full-size thumbnail buckets correctly, with automatic fallback when a higher bucket is unavailable on the server.
+
 ## [9.6.1] - 2026-05-31
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,15 +2135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libraw-rs"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ec60aab878560c299c6e70a0c6dc2278a2159ac6fe09650917266b8985387f"
-dependencies = [
- "libraw-rs-sys",
-]
-
-[[package]]
 name = "libraw-rs-sys"
 version = "0.0.4+libraw-0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,7 +2268,6 @@ dependencies = [
  "ksni",
  "libadwaita",
  "libheif-rs",
- "libraw-rs",
  "libraw-rs-sys",
  "log",
  "lru",
@@ -2288,7 +2278,6 @@ dependencies = [
  "parking_lot",
  "phf",
  "psd",
- "rawloader",
  "rayon",
  "reqwest",
  "resvg",
@@ -2296,7 +2285,6 @@ dependencies = [
  "serde_json",
  "sha1",
  "tempfile",
- "thumbhash",
  "tokio",
  "tokio-util",
  "turbojpeg",
@@ -3570,12 +3558,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "thumbhash"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7726e0245a7331bd0c9a1fb4fd99fd695bcd478ca569f0eda2ff2cb14e7a00"
 
 [[package]]
 name = "tiff"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1380,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1428,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1877,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-grid"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e0ef92d5d60e76bf41098e57e985f523185e08fad54268da448637feca6989"
+checksum = "01671307879a033bfa52e6e8784b941aca770b3f3a7d33830b455b6844f793fb"
 dependencies = [
  "tracing",
 ]
@@ -1916,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-modular"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da758b2f989aafd9eeb39489fe43d7be5a3a0d2ad61cf1bad705eb6990a6053c"
+checksum = "2a2f045b24c738dd91d482be385512b512721ae08a671bd4b27bf1c47f215235"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
@@ -1930,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-oxide"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8ecd2678ed70c1eda42b811ccb2e25ab836edeb18e7f1178c1f917ed36b772"
+checksum = "d36c662923f47586880211f3bc7c0d83fb3a9b410d278c7bde93450748abeef3"
 dependencies = [
  "brotli-decompressor",
  "jxl-bitstream",
@@ -1958,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-render"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa0c3100918bd3c41bb0f8ce1f4f1664e48f3032ff8eeab0d6a2cfc3276f462d"
+checksum = "d34386bfdb6a19b5a30cc9beb4d475d537422c31ae8c39bb69640fcce3fcaf19"
 dependencies = [
  "bytemuck",
  "jxl-bitstream",
@@ -2155,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
@@ -2226,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -2389,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "nom-exif"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c66d9825e7ca13aa8d4eea2ac1e0a4cc7365c8d0cf166d21b8a7368bfa9154"
+checksum = "0b1119c4c070d57fc82e59e06b8b995185f38b2afd56d437c88a04f1f233f390"
 dependencies = [
  "bytes",
  "chrono",
@@ -3028,9 +3028,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -3371,9 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3429,9 +3429,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3514,9 +3514,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -3750,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -3880,9 +3880,9 @@ dependencies = [
 
 [[package]]
 name = "turbojpeg-sys"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d87290369f91af10f425f9ec0b8ce775cf79ea189291faa974c0b4e02e1e2f"
+checksum = "49b5a974bc59382d35927e3a07eef2ba9a24fe7227cefe52ec44b508e1b90f86"
 dependencies = [
  "anyhow",
  "cmake",
@@ -3891,9 +3891,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -4014,9 +4014,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -4595,9 +4595,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
 dependencies = [
  "async-broadcast",
  "async-recursion",
@@ -4625,9 +4625,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4651,18 +4651,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4775,9 +4775,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
 dependencies = [
  "endi",
  "enumflags2",
@@ -4790,9 +4790,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4803,9 +4803,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ tokio = { version = "1.52.1", features = [
     "signal",
 ] }
 flexi_logger = "0.31.8"
-thumbhash = "0.1"
 base64 = "0.22"
 nom-exif = "3.4.2"
 image = { version = "0.25.10", default-features = false, features = [
@@ -65,9 +64,7 @@ libheif-rs = { version = "2.7.0", default-features = false, features = [
     "v1_20",
 ] }
 jxl-oxide = "0.12.5"
-rawloader = "0.37.1"
 imagepipe = "0.5.0"
-libraw-rs = "0.0.4"
 libraw-rs-sys = "0.0.4"
 resvg = { version = "0.47.0", default-features = false, features = [
     "text",

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -2693,19 +2693,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libraw-rs/libraw-rs-0.0.4.crate",
-        "sha256": "24ec60aab878560c299c6e70a0c6dc2278a2159ac6fe09650917266b8985387f",
-        "dest": "cargo/vendor/libraw-rs-0.0.4"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"24ec60aab878560c299c6e70a0c6dc2278a2159ac6fe09650917266b8985387f\", \"files\": {}}",
-        "dest": "cargo/vendor/libraw-rs-0.0.4",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/libraw-rs-sys/libraw-rs-sys-0.0.4+libraw-0.20.1.crate",
         "sha256": "ba094a3b8b04cc42fdeafaff06f81d3b13a7d01cc7a8eae55b943dae1b65c3cc",
         "dest": "cargo/vendor/libraw-rs-sys-0.0.4+libraw-0.20.1"
@@ -4495,19 +4482,6 @@
         "type": "inline",
         "contents": "{\"package\": \"ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5\", \"files\": {}}",
         "dest": "cargo/vendor/thiserror-impl-2.0.18",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thumbhash/thumbhash-0.1.0.crate",
-        "sha256": "8b7726e0245a7331bd0c9a1fb4fd99fd695bcd478ca569f0eda2ff2cb14e7a00",
-        "dest": "cargo/vendor/thumbhash-0.1.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"8b7726e0245a7331bd0c9a1fb4fd99fd695bcd478ca569f0eda2ff2cb14e7a00\", \"files\": {}}",
-        "dest": "cargo/vendor/thumbhash-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -340,14 +340,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/brotli-decompressor/brotli-decompressor-5.0.0.crate",
-        "sha256": "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03",
-        "dest": "cargo/vendor/brotli-decompressor-5.0.0"
+        "url": "https://static.crates.io/crates/brotli-decompressor/brotli-decompressor-5.0.1.crate",
+        "sha256": "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924",
+        "dest": "cargo/vendor/brotli-decompressor-5.0.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03\", \"files\": {}}",
-        "dest": "cargo/vendor/brotli-decompressor-5.0.0",
+        "contents": "{\"package\": \"5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924\", \"files\": {}}",
+        "dest": "cargo/vendor/brotli-decompressor-5.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -457,27 +457,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cc/cc-1.2.62.crate",
-        "sha256": "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98",
-        "dest": "cargo/vendor/cc-1.2.62"
+        "url": "https://static.crates.io/crates/cc/cc-1.2.63.crate",
+        "sha256": "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f",
+        "dest": "cargo/vendor/cc-1.2.63"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98\", \"files\": {}}",
-        "dest": "cargo/vendor/cc-1.2.62",
+        "contents": "{\"package\": \"556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.2.63",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.20.7.crate",
-        "sha256": "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368",
-        "dest": "cargo/vendor/cfg-expr-0.20.7"
+        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.20.8.crate",
+        "sha256": "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c",
+        "dest": "cargo/vendor/cfg-expr-0.20.8"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368\", \"files\": {}}",
-        "dest": "cargo/vendor/cfg-expr-0.20.7",
+        "contents": "{\"package\": \"fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-expr-0.20.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -808,14 +808,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/displaydoc/displaydoc-0.2.5.crate",
-        "sha256": "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0",
-        "dest": "cargo/vendor/displaydoc-0.2.5"
+        "url": "https://static.crates.io/crates/displaydoc/displaydoc-0.2.6.crate",
+        "sha256": "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f",
+        "dest": "cargo/vendor/displaydoc-0.2.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0\", \"files\": {}}",
-        "dest": "cargo/vendor/displaydoc-0.2.5",
+        "contents": "{\"package\": \"1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f\", \"files\": {}}",
+        "dest": "cargo/vendor/displaydoc-0.2.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1861,14 +1861,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/http/http-1.4.0.crate",
-        "sha256": "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a",
-        "dest": "cargo/vendor/http-1.4.0"
+        "url": "https://static.crates.io/crates/http/http-1.4.1.crate",
+        "sha256": "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0",
+        "dest": "cargo/vendor/http-1.4.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a\", \"files\": {}}",
-        "dest": "cargo/vendor/http-1.4.0",
+        "contents": "{\"package\": \"8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0\", \"files\": {}}",
+        "dest": "cargo/vendor/http-1.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1926,14 +1926,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/hyper/hyper-1.9.0.crate",
-        "sha256": "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca",
-        "dest": "cargo/vendor/hyper-1.9.0"
+        "url": "https://static.crates.io/crates/hyper/hyper-1.10.0.crate",
+        "sha256": "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc",
+        "dest": "cargo/vendor/hyper-1.10.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca\", \"files\": {}}",
-        "dest": "cargo/vendor/hyper-1.9.0",
+        "contents": "{\"package\": \"eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc\", \"files\": {}}",
+        "dest": "cargo/vendor/hyper-1.10.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2407,14 +2407,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/jxl-grid/jxl-grid-0.6.1.crate",
-        "sha256": "a0e0ef92d5d60e76bf41098e57e985f523185e08fad54268da448637feca6989",
-        "dest": "cargo/vendor/jxl-grid-0.6.1"
+        "url": "https://static.crates.io/crates/jxl-grid/jxl-grid-0.6.2.crate",
+        "sha256": "01671307879a033bfa52e6e8784b941aca770b3f3a7d33830b455b6844f793fb",
+        "dest": "cargo/vendor/jxl-grid-0.6.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a0e0ef92d5d60e76bf41098e57e985f523185e08fad54268da448637feca6989\", \"files\": {}}",
-        "dest": "cargo/vendor/jxl-grid-0.6.1",
+        "contents": "{\"package\": \"01671307879a033bfa52e6e8784b941aca770b3f3a7d33830b455b6844f793fb\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-grid-0.6.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2446,27 +2446,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/jxl-modular/jxl-modular-0.11.2.crate",
-        "sha256": "da758b2f989aafd9eeb39489fe43d7be5a3a0d2ad61cf1bad705eb6990a6053c",
-        "dest": "cargo/vendor/jxl-modular-0.11.2"
+        "url": "https://static.crates.io/crates/jxl-modular/jxl-modular-0.11.3.crate",
+        "sha256": "2a2f045b24c738dd91d482be385512b512721ae08a671bd4b27bf1c47f215235",
+        "dest": "cargo/vendor/jxl-modular-0.11.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"da758b2f989aafd9eeb39489fe43d7be5a3a0d2ad61cf1bad705eb6990a6053c\", \"files\": {}}",
-        "dest": "cargo/vendor/jxl-modular-0.11.2",
+        "contents": "{\"package\": \"2a2f045b24c738dd91d482be385512b512721ae08a671bd4b27bf1c47f215235\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-modular-0.11.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/jxl-oxide/jxl-oxide-0.12.5.crate",
-        "sha256": "ee8ecd2678ed70c1eda42b811ccb2e25ab836edeb18e7f1178c1f917ed36b772",
-        "dest": "cargo/vendor/jxl-oxide-0.12.5"
+        "url": "https://static.crates.io/crates/jxl-oxide/jxl-oxide-0.12.6.crate",
+        "sha256": "d36c662923f47586880211f3bc7c0d83fb3a9b410d278c7bde93450748abeef3",
+        "dest": "cargo/vendor/jxl-oxide-0.12.6"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ee8ecd2678ed70c1eda42b811ccb2e25ab836edeb18e7f1178c1f917ed36b772\", \"files\": {}}",
-        "dest": "cargo/vendor/jxl-oxide-0.12.5",
+        "contents": "{\"package\": \"d36c662923f47586880211f3bc7c0d83fb3a9b410d278c7bde93450748abeef3\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-oxide-0.12.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2485,14 +2485,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/jxl-render/jxl-render-0.12.3.crate",
-        "sha256": "aa0c3100918bd3c41bb0f8ce1f4f1664e48f3032ff8eeab0d6a2cfc3276f462d",
-        "dest": "cargo/vendor/jxl-render-0.12.3"
+        "url": "https://static.crates.io/crates/jxl-render/jxl-render-0.12.4.crate",
+        "sha256": "d34386bfdb6a19b5a30cc9beb4d475d537422c31ae8c39bb69640fcce3fcaf19",
+        "dest": "cargo/vendor/jxl-render-0.12.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"aa0c3100918bd3c41bb0f8ce1f4f1664e48f3032ff8eeab0d6a2cfc3276f462d\", \"files\": {}}",
-        "dest": "cargo/vendor/jxl-render-0.12.3",
+        "contents": "{\"package\": \"d34386bfdb6a19b5a30cc9beb4d475d537422c31ae8c39bb69640fcce3fcaf19\", \"files\": {}}",
+        "dest": "cargo/vendor/jxl-render-0.12.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2719,14 +2719,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libredox/libredox-0.1.16.crate",
-        "sha256": "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c",
-        "dest": "cargo/vendor/libredox-0.1.16"
+        "url": "https://static.crates.io/crates/libredox/libredox-0.1.17.crate",
+        "sha256": "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3",
+        "dest": "cargo/vendor/libredox-0.1.17"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c\", \"files\": {}}",
-        "dest": "cargo/vendor/libredox-0.1.16",
+        "contents": "{\"package\": \"f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3\", \"files\": {}}",
+        "dest": "cargo/vendor/libredox-0.1.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2797,14 +2797,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/log/log-0.4.29.crate",
-        "sha256": "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897",
-        "dest": "cargo/vendor/log-0.4.29"
+        "url": "https://static.crates.io/crates/log/log-0.4.30.crate",
+        "sha256": "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5",
+        "dest": "cargo/vendor/log-0.4.30"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897\", \"files\": {}}",
-        "dest": "cargo/vendor/log-0.4.29",
+        "contents": "{\"package\": \"616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5\", \"files\": {}}",
+        "dest": "cargo/vendor/log-0.4.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2836,14 +2836,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/memchr/memchr-2.8.0.crate",
-        "sha256": "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79",
-        "dest": "cargo/vendor/memchr-2.8.0"
+        "url": "https://static.crates.io/crates/memchr/memchr-2.8.1.crate",
+        "sha256": "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8",
+        "dest": "cargo/vendor/memchr-2.8.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79\", \"files\": {}}",
-        "dest": "cargo/vendor/memchr-2.8.0",
+        "contents": "{\"package\": \"6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8\", \"files\": {}}",
+        "dest": "cargo/vendor/memchr-2.8.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2914,14 +2914,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/mio/mio-1.2.0.crate",
-        "sha256": "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1",
-        "dest": "cargo/vendor/mio-1.2.0"
+        "url": "https://static.crates.io/crates/mio/mio-1.2.1.crate",
+        "sha256": "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda",
+        "dest": "cargo/vendor/mio-1.2.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1\", \"files\": {}}",
-        "dest": "cargo/vendor/mio-1.2.0",
+        "contents": "{\"package\": \"02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda\", \"files\": {}}",
+        "dest": "cargo/vendor/mio-1.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2992,14 +2992,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/nom-exif/nom-exif-3.5.0.crate",
-        "sha256": "67c66d9825e7ca13aa8d4eea2ac1e0a4cc7365c8d0cf166d21b8a7368bfa9154",
-        "dest": "cargo/vendor/nom-exif-3.5.0"
+        "url": "https://static.crates.io/crates/nom-exif/nom-exif-3.6.0.crate",
+        "sha256": "0b1119c4c070d57fc82e59e06b8b995185f38b2afd56d437c88a04f1f233f390",
+        "dest": "cargo/vendor/nom-exif-3.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"67c66d9825e7ca13aa8d4eea2ac1e0a4cc7365c8d0cf166d21b8a7368bfa9154\", \"files\": {}}",
-        "dest": "cargo/vendor/nom-exif-3.5.0",
+        "contents": "{\"package\": \"0b1119c4c070d57fc82e59e06b8b995185f38b2afd56d437c88a04f1f233f390\", \"files\": {}}",
+        "dest": "cargo/vendor/nom-exif-3.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3811,14 +3811,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/reqwest/reqwest-0.13.3.crate",
-        "sha256": "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0",
-        "dest": "cargo/vendor/reqwest-0.13.3"
+        "url": "https://static.crates.io/crates/reqwest/reqwest-0.13.4.crate",
+        "sha256": "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3",
+        "dest": "cargo/vendor/reqwest-0.13.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0\", \"files\": {}}",
-        "dest": "cargo/vendor/reqwest-0.13.3",
+        "contents": "{\"package\": \"219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3\", \"files\": {}}",
+        "dest": "cargo/vendor/reqwest-0.13.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4201,14 +4201,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/shlex/shlex-1.3.0.crate",
-        "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
-        "dest": "cargo/vendor/shlex-1.3.0"
+        "url": "https://static.crates.io/crates/shlex/shlex-2.0.1.crate",
+        "sha256": "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba",
+        "dest": "cargo/vendor/shlex-2.0.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64\", \"files\": {}}",
-        "dest": "cargo/vendor/shlex-1.3.0",
+        "contents": "{\"package\": \"f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba\", \"files\": {}}",
+        "dest": "cargo/vendor/shlex-2.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4305,14 +4305,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/socket2/socket2-0.6.3.crate",
-        "sha256": "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e",
-        "dest": "cargo/vendor/socket2-0.6.3"
+        "url": "https://static.crates.io/crates/socket2/socket2-0.6.4.crate",
+        "sha256": "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51",
+        "dest": "cargo/vendor/socket2-0.6.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e\", \"files\": {}}",
-        "dest": "cargo/vendor/socket2-0.6.3",
+        "contents": "{\"package\": \"52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51\", \"files\": {}}",
+        "dest": "cargo/vendor/socket2-0.6.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4422,14 +4422,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.13.3.crate",
-        "sha256": "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c",
-        "dest": "cargo/vendor/target-lexicon-0.13.3"
+        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.13.5.crate",
+        "sha256": "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca",
+        "dest": "cargo/vendor/target-lexicon-0.13.5"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c\", \"files\": {}}",
-        "dest": "cargo/vendor/target-lexicon-0.13.3",
+        "contents": "{\"package\": \"adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca\", \"files\": {}}",
+        "dest": "cargo/vendor/target-lexicon-0.13.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4708,14 +4708,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.25.11+spec-1.1.0.crate",
-        "sha256": "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b",
-        "dest": "cargo/vendor/toml_edit-0.25.11+spec-1.1.0"
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.25.12+spec-1.1.0.crate",
+        "sha256": "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7",
+        "dest": "cargo/vendor/toml_edit-0.25.12+spec-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_edit-0.25.11+spec-1.1.0",
+        "contents": "{\"package\": \"d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.25.12+spec-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4877,27 +4877,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/turbojpeg-sys/turbojpeg-sys-1.1.1.crate",
-        "sha256": "d2d87290369f91af10f425f9ec0b8ce775cf79ea189291faa974c0b4e02e1e2f",
-        "dest": "cargo/vendor/turbojpeg-sys-1.1.1"
+        "url": "https://static.crates.io/crates/turbojpeg-sys/turbojpeg-sys-1.2.0.crate",
+        "sha256": "49b5a974bc59382d35927e3a07eef2ba9a24fe7227cefe52ec44b508e1b90f86",
+        "dest": "cargo/vendor/turbojpeg-sys-1.2.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"d2d87290369f91af10f425f9ec0b8ce775cf79ea189291faa974c0b4e02e1e2f\", \"files\": {}}",
-        "dest": "cargo/vendor/turbojpeg-sys-1.1.1",
+        "contents": "{\"package\": \"49b5a974bc59382d35927e3a07eef2ba9a24fe7227cefe52ec44b508e1b90f86\", \"files\": {}}",
+        "dest": "cargo/vendor/turbojpeg-sys-1.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/typenum/typenum-1.20.0.crate",
-        "sha256": "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de",
-        "dest": "cargo/vendor/typenum-1.20.0"
+        "url": "https://static.crates.io/crates/typenum/typenum-1.20.1.crate",
+        "sha256": "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20",
+        "dest": "cargo/vendor/typenum-1.20.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de\", \"files\": {}}",
-        "dest": "cargo/vendor/typenum-1.20.0",
+        "contents": "{\"package\": \"b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20\", \"files\": {}}",
+        "dest": "cargo/vendor/typenum-1.20.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5085,14 +5085,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/uuid/uuid-1.23.1.crate",
-        "sha256": "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76",
-        "dest": "cargo/vendor/uuid-1.23.1"
+        "url": "https://static.crates.io/crates/uuid/uuid-1.23.2.crate",
+        "sha256": "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7",
+        "dest": "cargo/vendor/uuid-1.23.2"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76\", \"files\": {}}",
-        "dest": "cargo/vendor/uuid-1.23.1",
+        "contents": "{\"package\": \"d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7\", \"files\": {}}",
+        "dest": "cargo/vendor/uuid-1.23.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5904,27 +5904,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zbus/zbus-5.15.0.crate",
-        "sha256": "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1",
-        "dest": "cargo/vendor/zbus-5.15.0"
+        "url": "https://static.crates.io/crates/zbus/zbus-5.16.0.crate",
+        "sha256": "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285",
+        "dest": "cargo/vendor/zbus-5.16.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1\", \"files\": {}}",
-        "dest": "cargo/vendor/zbus-5.15.0",
+        "contents": "{\"package\": \"eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus-5.16.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zbus_macros/zbus_macros-5.15.0.crate",
-        "sha256": "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff",
-        "dest": "cargo/vendor/zbus_macros-5.15.0"
+        "url": "https://static.crates.io/crates/zbus_macros/zbus_macros-5.16.0.crate",
+        "sha256": "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6",
+        "dest": "cargo/vendor/zbus_macros-5.16.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff\", \"files\": {}}",
-        "dest": "cargo/vendor/zbus_macros-5.15.0",
+        "contents": "{\"package\": \"adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus_macros-5.16.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5943,27 +5943,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zerocopy/zerocopy-0.8.48.crate",
-        "sha256": "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9",
-        "dest": "cargo/vendor/zerocopy-0.8.48"
+        "url": "https://static.crates.io/crates/zerocopy/zerocopy-0.8.49.crate",
+        "sha256": "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b",
+        "dest": "cargo/vendor/zerocopy-0.8.49"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9\", \"files\": {}}",
-        "dest": "cargo/vendor/zerocopy-0.8.48",
+        "contents": "{\"package\": \"bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-0.8.49",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.8.48.crate",
-        "sha256": "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4",
-        "dest": "cargo/vendor/zerocopy-derive-0.8.48"
+        "url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.8.49.crate",
+        "sha256": "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e",
+        "dest": "cargo/vendor/zerocopy-derive-0.8.49"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4\", \"files\": {}}",
-        "dest": "cargo/vendor/zerocopy-derive-0.8.48",
+        "contents": "{\"package\": \"8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-derive-0.8.49",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -6112,40 +6112,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zvariant/zvariant-5.11.0.crate",
-        "sha256": "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee",
-        "dest": "cargo/vendor/zvariant-5.11.0"
+        "url": "https://static.crates.io/crates/zvariant/zvariant-5.12.0.crate",
+        "sha256": "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0",
+        "dest": "cargo/vendor/zvariant-5.12.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee\", \"files\": {}}",
-        "dest": "cargo/vendor/zvariant-5.11.0",
+        "contents": "{\"package\": \"a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant-5.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zvariant_derive/zvariant_derive-5.11.0.crate",
-        "sha256": "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda",
-        "dest": "cargo/vendor/zvariant_derive-5.11.0"
+        "url": "https://static.crates.io/crates/zvariant_derive/zvariant_derive-5.12.0.crate",
+        "sha256": "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737",
+        "dest": "cargo/vendor/zvariant_derive-5.12.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda\", \"files\": {}}",
-        "dest": "cargo/vendor/zvariant_derive-5.11.0",
+        "contents": "{\"package\": \"90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant_derive-5.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zvariant_utils/zvariant_utils-3.3.1.crate",
-        "sha256": "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691",
-        "dest": "cargo/vendor/zvariant_utils-3.3.1"
+        "url": "https://static.crates.io/crates/zvariant_utils/zvariant_utils-3.4.0.crate",
+        "sha256": "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6",
+        "dest": "cargo/vendor/zvariant_utils-3.4.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691\", \"files\": {}}",
-        "dest": "cargo/vendor/zvariant_utils-3.3.1",
+        "contents": "{\"package\": \"1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant_utils-3.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/api_client/mod.rs
+++ b/src/api_client/mod.rs
@@ -424,12 +424,13 @@ pub struct AssetDetails {
 }
 
 /// Type of asset thumbnails requested.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ThumbnailSize {
-    /// Mapped standard thumbnail preview.
     Thumbnail,
-    /// High-resolution large image preview.
     Preview,
+    /// Server-generated full-resolution copy; only present when the server
+    /// has the "save full-size image" job enabled. 404s otherwise.
+    Fullsize,
 }
 
 impl ThumbnailSize {
@@ -437,6 +438,7 @@ impl ThumbnailSize {
         match self {
             ThumbnailSize::Thumbnail => "thumbnail",
             ThumbnailSize::Preview => "preview",
+            ThumbnailSize::Fullsize => "fullsize",
         }
     }
 }

--- a/src/api_client/mod.rs
+++ b/src/api_client/mod.rs
@@ -115,6 +115,9 @@ pub struct LibraryAsset {
     /// Canonical lowercase SHA-1 checksum.
     #[serde(default, deserialize_with = "deserialize_checksum_to_hex")]
     pub checksum: Option<String>,
+    /// EXIF block; Immich keeps pixel dimensions here, not at the top level.
+    #[serde(rename = "exifInfo", default)]
+    pub exif_info: Option<ExifInfo>,
 }
 
 /// Immich returns asset checksums as base64-encoded SHA1, while Mimick computes
@@ -355,7 +358,7 @@ pub struct PlaceItem {
 }
 
 /// Full EXIF metadata schema properties returned by Immich.
-#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExifInfo {
     /// Camera manufacturer name.

--- a/src/api_client/search.rs
+++ b/src/api_client/search.rs
@@ -383,10 +383,14 @@ impl ImmichApiClient {
     pub(super) async fn fetch_search_assets(
         &self,
         endpoint: &str,
-        body: serde_json::Value,
+        mut body: serde_json::Value,
         context: RequestContext,
         subject: Option<&str>,
     ) -> Result<(Vec<LibraryAsset>, bool), String> {
+        if let Some(obj) = body.as_object_mut() {
+            obj.entry("withExif")
+                .or_insert(serde_json::Value::Bool(true));
+        }
         let base_url = self
             .get_active_url()
             .await

--- a/src/config.rs
+++ b/src/config.rs
@@ -263,9 +263,6 @@ pub struct ConfigData {
     /// Grid thumbnail quality: "auto", "thumbnail", "preview". Defaults to auto.
     #[serde(default = "default_grid_quality")]
     pub library_grid_quality: String,
-    /// In-memory thumbnail cache cap in megabytes (0 = use built-in default of 80MB).
-    #[serde(default)]
-    pub library_thumbnail_cache_mb: u32,
     /// Total on-disk cache cap in megabytes across all subcaches
     /// (thumbnails, raw_decode, exif, video, preview, open-in).
     /// Pruning runs once at startup. Defaults to 2000 MB.
@@ -313,7 +310,6 @@ impl Default for ConfigData {
             download_target_path: None,
             library_preview_full_resolution: false,
             library_grid_quality: default_grid_quality(),
-            library_thumbnail_cache_mb: 0,
             cache_disk_cap_mb: default_cache_disk_cap_mb(),
             raw_decode_cache_enabled: false,
             raw_full_decode: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -260,6 +260,9 @@ pub struct ConfigData {
     /// When true, lightbox loads original full-resolution image instead of preview.
     #[serde(default)]
     pub library_preview_full_resolution: bool,
+    /// Grid thumbnail quality: "auto", "thumbnail", "preview". Defaults to auto.
+    #[serde(default = "default_grid_quality")]
+    pub library_grid_quality: String,
     /// In-memory thumbnail cache cap in megabytes (0 = use built-in default of 80MB).
     #[serde(default)]
     pub library_thumbnail_cache_mb: u32,
@@ -309,6 +312,7 @@ impl Default for ConfigData {
             library_view_enabled: false,
             download_target_path: None,
             library_preview_full_resolution: false,
+            library_grid_quality: default_grid_quality(),
             library_thumbnail_cache_mb: 0,
             cache_disk_cap_mb: default_cache_disk_cap_mb(),
             raw_decode_cache_enabled: false,
@@ -323,6 +327,10 @@ impl Default for ConfigData {
 /// Helper to default boolean fields to true during serialization.
 fn default_true() -> bool {
     true
+}
+
+fn default_grid_quality() -> String {
+    "auto".to_string()
 }
 
 /// Helper to default parallel upload worker threads to 3.

--- a/src/library/asset_model.rs
+++ b/src/library/asset_model.rs
@@ -136,26 +136,6 @@ fn build_asset_objects(assets: &[LibraryAsset], ctx: &AppContext) -> Vec<AssetOb
     use super::{LOCAL_ID_PREFIX, immich_checksum_to_hex};
     use crate::library::local_source::local_sync_state;
 
-    let total = assets.len();
-    let with_exif = assets.iter().filter(|a| a.exif_info.is_some()).count();
-    let with_dims = assets
-        .iter()
-        .filter(|a| {
-            a.width.unwrap_or(0.0) > 0.0
-                || a.exif_info
-                    .as_ref()
-                    .and_then(|e| e.exif_image_width)
-                    .unwrap_or(0)
-                    > 0
-        })
-        .count();
-    log::debug!(
-        "build_asset_objects total={} with_exif={} with_dims={}",
-        total,
-        with_exif,
-        with_dims,
-    );
-
     assets
         .iter()
         .map(|asset| {

--- a/src/library/asset_model.rs
+++ b/src/library/asset_model.rs
@@ -136,6 +136,26 @@ fn build_asset_objects(assets: &[LibraryAsset], ctx: &AppContext) -> Vec<AssetOb
     use super::{LOCAL_ID_PREFIX, immich_checksum_to_hex};
     use crate::library::local_source::local_sync_state;
 
+    let total = assets.len();
+    let with_exif = assets.iter().filter(|a| a.exif_info.is_some()).count();
+    let with_dims = assets
+        .iter()
+        .filter(|a| {
+            a.width.unwrap_or(0.0) > 0.0
+                || a.exif_info
+                    .as_ref()
+                    .and_then(|e| e.exif_image_width)
+                    .unwrap_or(0)
+                    > 0
+        })
+        .count();
+    log::debug!(
+        "build_asset_objects total={} with_exif={} with_dims={}",
+        total,
+        with_exif,
+        with_dims,
+    );
+
     assets
         .iter()
         .map(|asset| {
@@ -162,8 +182,23 @@ fn build_asset_objects(assets: &[LibraryAsset], ctx: &AppContext) -> Vec<AssetOb
                 .as_deref()
                 .and_then(|hex| ctx.sync_index.local_path_for_checksum(hex));
             let sync_state = if local_match.is_some() { 2 } else { 0 };
-            let width = asset.width.unwrap_or(0.0).max(0.0) as u32;
-            let height = asset.height.unwrap_or(0.0).max(0.0) as u32;
+            let (exif_w, exif_h) = asset
+                .exif_info
+                .as_ref()
+                .map(|e| (e.exif_image_width, e.exif_image_height))
+                .unwrap_or((None, None));
+            let width = asset
+                .width
+                .map(|v| v.max(0.0) as u32)
+                .filter(|v| *v > 0)
+                .or(exif_w)
+                .unwrap_or(0);
+            let height = asset
+                .height
+                .map(|v| v.max(0.0) as u32)
+                .filter(|v| *v > 0)
+                .or(exif_h)
+                .unwrap_or(0);
             let object = AssetObject::new(
                 &asset.id,
                 &asset.filename,

--- a/src/library/asset_model.rs
+++ b/src/library/asset_model.rs
@@ -15,7 +15,7 @@ use gtk::subclass::prelude::*;
 
 use crate::api_client::LibraryAsset;
 use crate::app_context::AppContext;
-use crate::library::asset_object::AssetObject;
+use crate::library::asset_object::{AssetInit, AssetObject};
 use crate::library::state::LibrarySortMode;
 
 mod imp {
@@ -199,17 +199,17 @@ fn build_asset_objects(assets: &[LibraryAsset], ctx: &AppContext) -> Vec<AssetOb
                 .filter(|v| *v > 0)
                 .or(exif_h)
                 .unwrap_or(0);
-            let object = AssetObject::new(
-                &asset.id,
-                &asset.filename,
-                &asset.mime_type,
-                &asset.created_at,
-                &asset.asset_type,
+            let object = AssetObject::new(AssetInit {
+                id: &asset.id,
+                filename: &asset.filename,
+                mime_type: &asset.mime_type,
+                created_at: &asset.created_at,
+                asset_type: &asset.asset_type,
                 sync_state,
-                asset.thumbhash.as_deref(),
+                thumbhash: asset.thumbhash.as_deref(),
                 width,
                 height,
-            );
+            });
             if let Some(path) = local_match {
                 object.set_property("local-path", path);
             }

--- a/src/library/asset_model.rs
+++ b/src/library/asset_model.rs
@@ -162,6 +162,8 @@ fn build_asset_objects(assets: &[LibraryAsset], ctx: &AppContext) -> Vec<AssetOb
                 .as_deref()
                 .and_then(|hex| ctx.sync_index.local_path_for_checksum(hex));
             let sync_state = if local_match.is_some() { 2 } else { 0 };
+            let width = asset.width.unwrap_or(0.0).max(0.0) as u32;
+            let height = asset.height.unwrap_or(0.0).max(0.0) as u32;
             let object = AssetObject::new(
                 &asset.id,
                 &asset.filename,
@@ -170,6 +172,8 @@ fn build_asset_objects(assets: &[LibraryAsset], ctx: &AppContext) -> Vec<AssetOb
                 &asset.asset_type,
                 sync_state,
                 asset.thumbhash.as_deref(),
+                width,
+                height,
             );
             if let Some(path) = local_match {
                 object.set_property("local-path", path);

--- a/src/library/asset_object.rs
+++ b/src/library/asset_object.rs
@@ -52,6 +52,15 @@ mod imp {
         /// has been matched to one via checksum); empty string otherwise.
         #[property(get, set)]
         remote_id: RefCell<String>,
+
+        /// Native pixel width of the asset; 0 = unknown (settled later from
+        /// thumbnail decode for sources without EXIF metadata).
+        #[property(get, set)]
+        width: Cell<u32>,
+
+        /// Native pixel height of the asset; 0 = unknown.
+        #[property(get, set)]
+        height: Cell<u32>,
     }
 
     #[glib::object_subclass]
@@ -71,6 +80,8 @@ glib::wrapper! {
 
 impl AssetObject {
     /// Create a new `AssetObject` with all fields populated.
+    /// Pass `width` / `height` as 0 when unknown.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: &str,
         filename: &str,
@@ -79,6 +90,8 @@ impl AssetObject {
         asset_type: &str,
         sync_state: u32,
         thumbhash: Option<&str>,
+        width: u32,
+        height: u32,
     ) -> Self {
         glib::Object::builder()
             .property("id", id)
@@ -90,6 +103,8 @@ impl AssetObject {
             .property("thumbhash", thumbhash)
             .property("local-path", "")
             .property("remote-id", id)
+            .property("width", width)
+            .property("height", height)
             .build()
     }
 
@@ -114,6 +129,8 @@ impl AssetObject {
             .property("thumbhash", None::<String>)
             .property("local-path", local_path)
             .property("remote-id", "")
+            .property("width", 0u32)
+            .property("height", 0u32)
             .build()
     }
 }

--- a/src/library/asset_object.rs
+++ b/src/library/asset_object.rs
@@ -78,33 +78,34 @@ glib::wrapper! {
     pub struct AssetObject(ObjectSubclass<imp::AssetObject>);
 }
 
+/// Constructor parameters for a remote `AssetObject`.
+/// Pass `width` / `height` as 0 when unknown.
+pub struct AssetInit<'a> {
+    pub id: &'a str,
+    pub filename: &'a str,
+    pub mime_type: &'a str,
+    pub created_at: &'a str,
+    pub asset_type: &'a str,
+    pub sync_state: u32,
+    pub thumbhash: Option<&'a str>,
+    pub width: u32,
+    pub height: u32,
+}
+
 impl AssetObject {
-    /// Create a new `AssetObject` with all fields populated.
-    /// Pass `width` / `height` as 0 when unknown.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        id: &str,
-        filename: &str,
-        mime_type: &str,
-        created_at: &str,
-        asset_type: &str,
-        sync_state: u32,
-        thumbhash: Option<&str>,
-        width: u32,
-        height: u32,
-    ) -> Self {
+    pub fn new(init: AssetInit<'_>) -> Self {
         glib::Object::builder()
-            .property("id", id)
-            .property("filename", filename)
-            .property("mime-type", mime_type)
-            .property("created-at", created_at)
-            .property("asset-type", asset_type)
-            .property("sync-state", sync_state)
-            .property("thumbhash", thumbhash)
+            .property("id", init.id)
+            .property("filename", init.filename)
+            .property("mime-type", init.mime_type)
+            .property("created-at", init.created_at)
+            .property("asset-type", init.asset_type)
+            .property("sync-state", init.sync_state)
+            .property("thumbhash", init.thumbhash)
             .property("local-path", "")
-            .property("remote-id", id)
-            .property("width", width)
-            .property("height", height)
+            .property("remote-id", init.id)
+            .property("width", init.width)
+            .property("height", init.height)
             .build()
     }
 

--- a/src/library/controls.rs
+++ b/src/library/controls.rs
@@ -481,32 +481,33 @@ pub(super) fn sidebar_dispatch(ui: Rc<LibraryWindowUi>, source: LibrarySource) {
 }
 
 pub(super) fn connect_grid_handlers(ui: Rc<LibraryWindowUi>) {
-    ui.grid.view.connect_activate(clone!(
-        #[strong]
-        ui,
-        move |_, position| {
-            let Some(item) = ui.grid.model.item(position).and_downcast::<AssetObject>() else {
-                return;
-            };
-            let asset_id = item.property::<String>("id");
-            let filename = item.property::<String>("filename");
-            let local_path = item.property::<String>("local-path");
-            let asset_type = item.property::<String>("asset-type");
+    let ui_for_activate = ui.clone();
+    ui.grid.canvas.set_activate_handler(move |position| {
+        let Some(item) = ui_for_activate
+            .grid
+            .model
+            .item(position)
+            .and_downcast::<AssetObject>()
+        else {
+            return;
+        };
+        let asset_id = item.property::<String>("id");
+        let filename = item.property::<String>("filename");
+        let local_path = item.property::<String>("local-path");
+        let asset_type = item.property::<String>("asset-type");
 
-            // Videos open in the system default player per spec -- no in-app
-            // playback for v1.
-            if asset_type.eq_ignore_ascii_case("VIDEO") {
-                if !local_path.is_empty() {
-                    open_local_with_default_app(&local_path);
-                } else {
-                    spawn_video_handoff(ui.clone(), asset_id, filename);
-                }
-                return;
+        // Videos open in the system default player.
+        if asset_type.eq_ignore_ascii_case("VIDEO") {
+            if !local_path.is_empty() {
+                open_local_with_default_app(&local_path);
+            } else {
+                spawn_video_handoff(ui_for_activate.clone(), asset_id, filename);
             }
-
-            open_lightbox(ui.clone(), position);
+            return;
         }
-    ));
+
+        open_lightbox(ui_for_activate.clone(), position);
+    });
 
     let scroll_pending = Rc::new(std::cell::Cell::new(false));
     ui.grid.scrolled.vadjustment().connect_value_changed(clone!(

--- a/src/library/grid_view.rs
+++ b/src/library/grid_view.rs
@@ -1,345 +1,62 @@
-//! Grid view construction, thumbnail binding, and infinite-scroll pagination.
-//!
-//! Sets up a `gtk::GridView` backed by a `gio::ListStore` of `AssetObject`
-//! items. Thumbnails are loaded asynchronously via the thumbnail cache and
-//! bound to picture widgets through a factory. Scroll-to-bottom triggers
-//! automatic next-page fetches.
+//! Photos grid construction. Builds a `MasonryCanvas` inside a
+//! `ScrolledWindow`, returns it alongside the shared model + selection.
 
-use std::cell::Cell;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use gdk4::Texture;
 use gtk::prelude::*;
 
 use crate::app_context::AppContext;
 use crate::library::asset_model::LibraryAssetModel;
-use crate::library::asset_object::AssetObject;
+use crate::library::masonry_canvas::MasonryCanvas;
 
-const POS_DATA_KEY: &str = "mimick-cell-pos";
 pub type AssetContextMenuHandler = Rc<RefCell<Option<Box<dyn Fn(u32, f64, f64)>>>>;
 
-/// Contains references to the model, selection, and scrolled container of the GridView browser.
 pub struct GridViewParts {
     pub model: LibraryAssetModel,
     pub scrolled: gtk::ScrolledWindow,
-    pub view: gtk::GridView,
+    pub canvas: MasonryCanvas,
     pub selection: gtk::MultiSelection,
     pub context_menu_handler: AssetContextMenuHandler,
 }
 
-/// Build and assemble the main GridView interface for library asset browsing.
 pub fn build_grid_view(
     ctx: Arc<AppContext>,
     select_toggle: gtk::ToggleButton,
-    _narrow: Rc<Cell<bool>>,
+    narrow: Rc<Cell<bool>>,
 ) -> GridViewParts {
     let model = LibraryAssetModel::new();
     let selection = gtk::MultiSelection::new(Some(model.clone()));
-    let factory = gtk::SignalListItemFactory::new();
     let context_menu_handler: AssetContextMenuHandler = Rc::new(RefCell::new(None));
 
-    let select_toggle_for_setup = select_toggle.clone();
-    let selection_for_setup = selection.clone();
-    factory.connect_setup(move |_, list_item| {
-        let Some(list_item) = list_item.downcast_ref::<gtk::ListItem>() else {
-            return;
-        };
-        let container = gtk::Overlay::builder()
-            .css_classes(vec!["mimick-cell".to_string()])
-            .build();
+    let canvas = MasonryCanvas::new(
+        ctx.thumbnail_cache.clone(),
+        model.clone(),
+        selection.clone(),
+    );
+    canvas.set_narrow(narrow.get());
+    canvas.set_select_mode(select_toggle.is_active());
+    canvas.set_context_menu_handler(context_menu_handler.clone());
 
-        let picture = gtk::Picture::builder()
-            .width_request(114)
-            .height_request(85)
-            .can_shrink(true)
-            .content_fit(gtk::ContentFit::Cover)
-            .css_classes(vec![
-                "mimick-grid-thumb".to_string(),
-                "mimick-thumbnail-loading".to_string(),
-            ])
-            .build();
-
-        let checkbox = gtk::CheckButton::builder()
-            .halign(gtk::Align::Start)
-            .valign(gtk::Align::Start)
-            .margin_top(6)
-            .margin_start(6)
-            .can_focus(false)
-            .css_classes(vec!["mimick-select-checkbox".to_string()])
-            .build();
-        select_toggle_for_setup
-            .bind_property("active", &checkbox, "visible")
-            .sync_create()
-            .build();
-
-        let pos_cell = Rc::new(Cell::new(u32::MAX));
-        let suppress = Rc::new(Cell::new(false));
-        let pos_for_toggle = pos_cell.clone();
-        let suppress_for_toggle = suppress.clone();
-        let selection_for_toggle = selection_for_setup.clone();
-        checkbox.connect_toggled(move |cb| {
-            if suppress_for_toggle.get() {
-                return;
-            }
-            let pos = pos_for_toggle.get();
-            if pos == u32::MAX {
-                return;
-            }
-            if cb.is_active() {
-                selection_for_toggle.select_item(pos, false);
-            } else {
-                selection_for_toggle.unselect_item(pos);
+    {
+        let canvas = canvas.clone();
+        select_toggle.connect_toggled(move |toggle| {
+            canvas.set_select_mode(toggle.is_active());
+        });
+    }
+    {
+        let canvas = canvas.clone();
+        let toggle = select_toggle.clone();
+        canvas.set_select_mode_changer(move |on| {
+            if toggle.is_active() != on {
+                toggle.set_active(on);
             }
         });
-        // SAFETY: glib::ObjectExt::set_data is unsafe because GLib's data store is type-erased.
-        // We guarantee safety by strictly pairing POS_DATA_KEY with the `(Rc<Cell<u32>>, Rc<Cell<bool>>)` type
-        // on both storage and retrieval.
-        unsafe {
-            checkbox.set_data::<(Rc<Cell<u32>>, Rc<Cell<bool>>)>(
-                POS_DATA_KEY,
-                (pos_cell.clone(), suppress.clone()),
-            );
-        }
-
-        let cb_for_selection = checkbox.clone();
-        let pos_for_selection = pos_cell.clone();
-        let suppress_for_selection = suppress.clone();
-        selection_for_setup.connect_selection_changed(move |sel, start, n_items| {
-            let pos = pos_for_selection.get();
-            if pos == u32::MAX || pos < start || pos >= start + n_items {
-                return;
-            }
-            let selected = sel.is_selected(pos);
-            if cb_for_selection.is_active() == selected {
-                return;
-            }
-            suppress_for_selection.set(true);
-            cb_for_selection.set_active(selected);
-            suppress_for_selection.set(false);
-        });
-
-        let status = gtk::Image::builder()
-            .icon_name("checkbox-symbolic")
-            .halign(gtk::Align::End)
-            .valign(gtk::Align::Start)
-            .margin_top(6)
-            .margin_end(6)
-            .pixel_size(14)
-            .css_classes(vec!["mimick-status-badge".to_string()])
-            .build();
-        let video_badge = gtk::Image::builder()
-            .icon_name("mimick-video-symbolic")
-            .halign(gtk::Align::Center)
-            .valign(gtk::Align::Center)
-            .pixel_size(32)
-            .visible(false)
-            .css_classes(vec!["mimick-video-badge".to_string()])
-            .build();
-
-        container.set_child(Some(&picture));
-        container.add_overlay(&checkbox);
-        container.add_overlay(&status);
-        container.add_overlay(&video_badge);
-        // SAFETY: glib::ObjectExt::set_data is unsafe because GLib's data store is type-erased.
-        // We guarantee safety by strictly pairing POS_DATA_KEY with the `Rc<Cell<u32>>` type
-        // on both storage and retrieval for the overlay container.
-        unsafe {
-            container.set_data::<Rc<Cell<u32>>>(POS_DATA_KEY, pos_cell);
-        }
-        list_item.set_child(Some(&container));
-    });
-
-    let selection_for_bind = selection.clone();
-    factory.connect_bind(move |_, list_item| {
-        let Some(list_item) = list_item.downcast_ref::<gtk::ListItem>() else {
-            return;
-        };
-        let item = match list_item.item().and_downcast::<AssetObject>() {
-            Some(item) => item,
-            None => return,
-        };
-        let Some(container) = list_item.child().and_downcast::<gtk::Overlay>() else {
-            return;
-        };
-        let Some(picture) = container.child().and_downcast::<gtk::Picture>() else {
-            return;
-        };
-        let Some(status) = find_overlay_image(&container, "mimick-status-badge") else {
-            return;
-        };
-        let Some(video_badge) = find_overlay_image(&container, "mimick-video-badge") else {
-            return;
-        };
-        let checkbox = find_select_checkbox(&container);
-
-        let position = list_item.position();
-        if let Some(cb) = checkbox.as_ref() {
-            sync_checkbox_state(cb, position, selection_for_bind.is_selected(position));
-        }
-
-        let asset_id = item.property::<String>("id");
-        let local_path = item.property::<String>("local-path");
-        let sync_state = item.property::<u32>("sync-state");
-        let thumbhash = item.property::<Option<String>>("thumbhash");
-        let asset_type = item.property::<String>("asset-type");
-        picture.set_tooltip_text(Some(&asset_id));
-        status.set_icon_name(Some(sync_icon_name(sync_state)));
-        status.set_tooltip_text(Some(sync_state_label(sync_state)));
-
-        let in_timeline = ctx
-            .library_timeline_active
-            .load(std::sync::atomic::Ordering::Relaxed);
-        status.set_visible(true);
-        video_badge.set_visible(asset_type.eq_ignore_ascii_case("VIDEO"));
-        set_square_class(&picture, in_timeline);
-
-        let generation = bump_generation(&picture);
-
-        let cache = ctx.thumbnail_cache.clone();
-        if let Some(texture) =
-            cache.get_cached(&asset_id, crate::api_client::ThumbnailSize::Thumbnail)
-        {
-            picture.set_paintable(Some(&texture));
-            set_thumb_state(&picture, ThumbState::Loaded);
-            return;
-        }
-
-        match thumbhash.as_deref().and_then(decode_thumbhash_texture) {
-            Some(placeholder) => {
-                picture.set_paintable(Some(&placeholder));
-                set_thumb_state(&picture, ThumbState::Loaded);
-            }
-            None => {
-                picture.set_paintable(Option::<&Texture>::None);
-                set_thumb_state(&picture, ThumbState::Loading);
-            }
-        }
-
-        schedule_thumbnail_load(
-            ctx.clone(),
-            picture.clone(),
-            asset_id,
-            local_path,
-            generation,
-        );
-
-        prefetch_thumbnails_around(ctx.clone(), &selection_for_bind, position);
-    });
-
-    factory.connect_unbind(|_, list_item| {
-        let Some(list_item) = list_item.downcast_ref::<gtk::ListItem>() else {
-            return;
-        };
-        if let Some(container) = list_item.child().and_downcast::<gtk::Overlay>()
-            && let Some(picture) = container.child().and_downcast::<gtk::Picture>()
-        {
-            bump_generation(&picture);
-            picture.set_tooltip_text(None);
-            picture.set_paintable(Option::<&Texture>::None);
-            set_thumb_state(&picture, ThumbState::Loading);
-        }
-    });
-
-    let view = gtk::GridView::builder()
-        .model(&selection)
-        .factory(&factory)
-        .single_click_activate(!select_toggle.is_active())
-        .enable_rubberband(false)
-        .max_columns(8)
-        .min_columns(2)
-        .build();
-    select_toggle.connect_toggled(clone_view_for_toggle(&view));
-
-    let ctrl_gesture = gtk::GestureClick::builder()
-        .button(gtk::gdk::BUTTON_PRIMARY)
-        .propagation_phase(gtk::PropagationPhase::Capture)
-        .build();
-    let selection_for_gesture = selection.clone();
-    let select_toggle_for_gesture = select_toggle.clone();
-    ctrl_gesture.connect_pressed(move |gesture, _n_press, x, y| {
-        let state = gesture.current_event_state();
-        if !state.contains(gtk::gdk::ModifierType::CONTROL_MASK) {
-            return;
-        }
-        let Some(view) = gesture.widget().and_downcast::<gtk::GridView>() else {
-            return;
-        };
-        let Some(picked) = view.pick(x, y, gtk::PickFlags::DEFAULT) else {
-            return;
-        };
-        let mut node = Some(picked);
-        while let Some(widget) = node {
-            if widget.has_css_class("mimick-cell") {
-                // SAFETY: glib::ObjectExt::data is unsafe because GLib's data store is type-erased.
-                // We guarantee safety because `widget` represents the overlay container ("mimick-cell"),
-                // which is strictly paired with the `Rc<Cell<u32>>` type under POS_DATA_KEY.
-                let pos = unsafe {
-                    widget
-                        .data::<Rc<Cell<u32>>>(POS_DATA_KEY)
-                        .map(|p| p.as_ref().get())
-                };
-                if let Some(pos) = pos
-                    && pos != u32::MAX
-                {
-                    if selection_for_gesture.is_selected(pos) {
-                        selection_for_gesture.unselect_item(pos);
-                    } else {
-                        selection_for_gesture.select_item(pos, false);
-                    }
-                    select_toggle_for_gesture.set_active(true);
-                    gesture.set_state(gtk::EventSequenceState::Claimed);
-                }
-                return;
-            }
-            node = widget.parent();
-        }
-    });
-    view.add_controller(ctrl_gesture);
-    let secondary = gtk::GestureClick::builder()
-        .button(gtk::gdk::BUTTON_SECONDARY)
-        .propagation_phase(gtk::PropagationPhase::Capture)
-        .build();
-    let context_handler = context_menu_handler.clone();
-    secondary.connect_pressed(move |gesture, _, x, y| {
-        let Some(view) = gesture.widget().and_downcast::<gtk::GridView>() else {
-            return;
-        };
-        let Some(picked) = view.pick(x, y, gtk::PickFlags::DEFAULT) else {
-            return;
-        };
-        let mut node = Some(picked);
-        while let Some(widget) = node {
-            if widget.has_css_class("mimick-cell") {
-                // SAFETY: glib::ObjectExt::data is unsafe because GLib's data store is type-erased.
-                // We guarantee safety because `widget` represents the overlay container ("mimick-cell"),
-                // which is strictly paired with the `Rc<Cell<u32>>` type under POS_DATA_KEY.
-                let pos = unsafe {
-                    widget
-                        .data::<Rc<Cell<u32>>>(POS_DATA_KEY)
-                        .map(|p| p.as_ref().get())
-                };
-                if let Some(pos) = pos
-                    && pos != u32::MAX
-                    && let Some(handler) = context_handler.borrow().as_ref()
-                {
-                    handler(pos, x, y);
-                    gesture.set_state(gtk::EventSequenceState::Claimed);
-                }
-                return;
-            }
-            node = widget.parent();
-        }
-    });
-    view.add_controller(secondary);
-    if let Some(layout) = view.layout_manager().and_downcast::<gtk::GridLayout>() {
-        layout.set_column_spacing(0);
-        layout.set_row_spacing(0);
     }
 
     let scrolled = gtk::ScrolledWindow::builder()
-        .child(&view)
+        .child(&canvas)
         .hscrollbar_policy(gtk::PolicyType::Never)
         .vexpand(true)
         .hexpand(true)
@@ -348,273 +65,8 @@ pub fn build_grid_view(
     GridViewParts {
         model,
         scrolled,
-        view,
+        canvas,
         selection,
         context_menu_handler,
     }
-}
-
-/// Construct a click activation toggle closure for the GridView.
-fn clone_view_for_toggle(view: &gtk::GridView) -> impl Fn(&gtk::ToggleButton) + 'static {
-    let view = view.clone();
-    move |toggle| {
-        view.set_single_click_activate(!toggle.is_active());
-    }
-}
-
-/// Locate the checkbox child widget inside an overlay container.
-fn find_select_checkbox(container: &gtk::Overlay) -> Option<gtk::CheckButton> {
-    let mut child = container.first_child();
-    while let Some(c) = child {
-        let next = c.next_sibling();
-        if c.has_css_class("mimick-select-checkbox")
-            && let Ok(cb) = c.downcast::<gtk::CheckButton>()
-        {
-            return Some(cb);
-        }
-        child = next;
-    }
-    None
-}
-
-/// Synchronize the checkbutton state with list selection without triggering loops.
-fn sync_checkbox_state(checkbox: &gtk::CheckButton, position: u32, selected: bool) {
-    // SAFETY: glib::ObjectExt::data is unsafe because GLib's data store is type-erased.
-    // We guarantee safety because `checkbox` is strictly paired with the `(Rc<Cell<u32>>, Rc<Cell<bool>>)`
-    // type under POS_DATA_KEY.
-    let data = unsafe {
-        checkbox
-            .data::<(Rc<Cell<u32>>, Rc<Cell<bool>>)>(POS_DATA_KEY)
-            .map(|p| p.as_ref().clone())
-    };
-    let Some((pos_cell, suppress)) = data else {
-        return;
-    };
-    pos_cell.set(position);
-    suppress.set(true);
-    checkbox.set_active(selected);
-    suppress.set(false);
-}
-
-/// Retrieve a descriptive text label for the specified sync state code.
-fn sync_state_label(sync_state: u32) -> &'static str {
-    match sync_state {
-        2 => "On Immich and locally",
-        1 => "Local only",
-        _ => "On Immich only",
-    }
-}
-
-/// Retrieve an icon name corresponding to the specified sync state code.
-fn sync_icon_name(sync_state: u32) -> &'static str {
-    match sync_state {
-        2 => "mimick-check-circle-symbolic",
-        1 => "mimick-computer-symbolic",
-        _ => "mimick-cloud-symbolic",
-    }
-}
-
-/// Locate a child image matching a specific CSS class inside the overlay container.
-fn find_overlay_image(container: &gtk::Overlay, class_name: &str) -> Option<gtk::Image> {
-    let mut child = container.first_child();
-    while let Some(c) = child {
-        let next = c.next_sibling();
-        if c.has_css_class(class_name)
-            && let Ok(image) = c.downcast::<gtk::Image>()
-        {
-            return Some(image);
-        }
-        child = next;
-    }
-    None
-}
-
-/// Represents the current loading phase status of a thumbnail image.
-#[derive(Clone, Copy)]
-enum ThumbState {
-    Loading,
-    Loaded,
-    Error,
-}
-
-/// Set the appropriate thumbnail state CSS classes on a picture widget.
-fn set_thumb_state(picture: &gtk::Picture, state: ThumbState) {
-    let want = match state {
-        ThumbState::Loading => "mimick-thumbnail-loading",
-        ThumbState::Loaded => "mimick-thumbnail-loaded",
-        ThumbState::Error => "mimick-thumbnail-error",
-    };
-    for cls in [
-        "mimick-thumbnail-loading",
-        "mimick-thumbnail-loaded",
-        "mimick-thumbnail-error",
-    ] {
-        if cls == want {
-            if !picture.has_css_class(cls) {
-                picture.add_css_class(cls);
-            }
-        } else if picture.has_css_class(cls) {
-            picture.remove_css_class(cls);
-        }
-    }
-    if matches!(state, ThumbState::Error) {
-        picture.set_tooltip_text(Some("Thumbnail unavailable"));
-    }
-}
-
-/// Toggle the timeline square shape styling class on a picture widget.
-fn set_square_class(picture: &gtk::Picture, on: bool) {
-    let has = picture.has_css_class("mimick-thumbnail-square");
-    if on && !has {
-        picture.add_css_class("mimick-thumbnail-square");
-    } else if !on && has {
-        picture.remove_css_class("mimick-thumbnail-square");
-    }
-}
-
-/// Asynchronously load and apply a local or remote thumbnail to a picture widget.
-fn schedule_thumbnail_load(
-    ctx: Arc<AppContext>,
-    picture: gtk::Picture,
-    asset_id: String,
-    local_path: String,
-    generation: u64,
-) {
-    let local_path = (!local_path.is_empty()).then(|| std::path::PathBuf::from(local_path));
-    let gen_cell = generation_cell(&picture);
-
-    glib::MainContext::default().spawn_local(async move {
-        if gen_cell.get() != generation {
-            return;
-        }
-        let cancel_cell = gen_cell.clone();
-        let is_cancelled = move || cancel_cell.get() != generation;
-        let cache = ctx.thumbnail_cache.clone();
-        let result = match local_path {
-            Some(path) => {
-                let local_res = cache
-                    .load_local_thumbnail_cancellable(&asset_id, &path, is_cancelled.clone())
-                    .await;
-                if local_res.is_err() && !asset_id.starts_with(crate::library::LOCAL_ID_PREFIX) {
-                    cache
-                        .load_thumbnail_cancellable(
-                            &asset_id,
-                            crate::api_client::ThumbnailSize::Thumbnail,
-                            is_cancelled.clone(),
-                        )
-                        .await
-                } else {
-                    local_res
-                }
-            }
-            None => {
-                cache
-                    .load_thumbnail_cancellable(
-                        &asset_id,
-                        crate::api_client::ThumbnailSize::Thumbnail,
-                        is_cancelled.clone(),
-                    )
-                    .await
-            }
-        };
-        if gen_cell.get() != generation {
-            return;
-        }
-        match result {
-            Ok(texture) => {
-                picture.set_paintable(Some(&texture));
-                set_thumb_state(&picture, ThumbState::Loaded);
-            }
-            Err(_) => set_thumb_state(&picture, ThumbState::Error),
-        }
-    });
-}
-
-const GEN_DATA_KEY: &str = "mimick-cell-gen";
-
-/// Retrieve or initialize the cell generation cell tracking counter.
-fn generation_cell(picture: &gtk::Picture) -> Rc<Cell<u64>> {
-    // SAFETY: glib::ObjectExt::data is unsafe because GLib's data store is type-erased.
-    // We guarantee safety by strictly pairing GEN_DATA_KEY with the `Rc<Cell<u64>>` type on `picture`.
-    let existing = unsafe {
-        picture
-            .data::<Rc<Cell<u64>>>(GEN_DATA_KEY)
-            .map(|p| p.as_ref().clone())
-    };
-    if let Some(cell) = existing {
-        return cell;
-    }
-    let cell = Rc::new(Cell::new(0u64));
-    // SAFETY: glib::ObjectExt::set_data is unsafe because GLib's data store is type-erased.
-    // We guarantee safety by strictly pairing GEN_DATA_KEY with the `Rc<Cell<u64>>` type on `picture`.
-    unsafe {
-        picture.set_data::<Rc<Cell<u64>>>(GEN_DATA_KEY, cell.clone());
-    }
-    cell
-}
-
-/// Increment and retrieve the cell's task generation tracker.
-fn bump_generation(picture: &gtk::Picture) -> u64 {
-    let cell = generation_cell(picture);
-    let next = cell.get().wrapping_add(1);
-    cell.set(next);
-    next
-}
-
-/// Prefetch neighboring thumbnails around the active scrolling viewport index.
-fn prefetch_thumbnails_around(
-    ctx: Arc<AppContext>,
-    model: &impl IsA<gtk::gio::ListModel>,
-    position: u32,
-) {
-    let total = model.n_items();
-    let start = position.saturating_add(5);
-    let end = position.saturating_add(15).min(total);
-    for pos in start..end {
-        let Some(item) = model.item(pos).and_downcast::<AssetObject>() else {
-            continue;
-        };
-        let local_path = item.property::<String>("local-path");
-        if !local_path.is_empty() {
-            continue;
-        }
-        let asset_id = item.property::<String>("id");
-        if asset_id.is_empty() || asset_id.starts_with(super::LOCAL_ID_PREFIX) {
-            continue;
-        }
-        if ctx
-            .thumbnail_cache
-            .get_cached(&asset_id, crate::api_client::ThumbnailSize::Thumbnail)
-            .is_some()
-        {
-            continue;
-        }
-        let cache = ctx.thumbnail_cache.clone();
-        glib::MainContext::default().spawn_local(async move {
-            let _ = cache
-                .load_thumbnail(&asset_id, crate::api_client::ThumbnailSize::Thumbnail)
-                .await;
-        });
-    }
-}
-
-/// Decode a ThumbHash Base64 string and compile it to a standard GDK texture.
-fn decode_thumbhash_texture(thumbhash_b64: &str) -> Option<Texture> {
-    use base64::Engine;
-    let bytes = base64::engine::general_purpose::STANDARD
-        .decode(thumbhash_b64)
-        .ok()?;
-    let (w, h, rgba) = thumbhash::thumb_hash_to_rgba(&bytes).ok()?;
-    let stride = w * 4;
-    let pixel_bytes = glib::Bytes::from_owned(rgba);
-    Some(
-        gdk4::MemoryTexture::new(
-            w as i32,
-            h as i32,
-            gdk4::MemoryFormat::R8g8b8a8,
-            &pixel_bytes,
-            stride,
-        )
-        .upcast(),
-    )
 }

--- a/src/library/grid_view.rs
+++ b/src/library/grid_view.rs
@@ -9,7 +9,7 @@ use gtk::prelude::*;
 
 use crate::app_context::AppContext;
 use crate::library::asset_model::LibraryAssetModel;
-use crate::library::masonry_canvas::MasonryCanvas;
+use crate::library::masonry_canvas::{GridQuality, MasonryCanvas};
 
 pub type AssetContextMenuHandler = Rc<RefCell<Option<Box<dyn Fn(u32, f64, f64)>>>>;
 
@@ -38,6 +38,8 @@ pub fn build_grid_view(
     canvas.set_narrow(narrow.get());
     canvas.set_select_mode(select_toggle.is_active());
     canvas.set_context_menu_handler(context_menu_handler.clone());
+    let initial_quality = GridQuality::parse(&ctx.config.read().data.library_grid_quality);
+    canvas.set_quality(initial_quality);
 
     {
         let canvas = canvas.clone();

--- a/src/library/masonry/canvas.rs
+++ b/src/library/masonry/canvas.rs
@@ -11,10 +11,10 @@ use gtk::gsk::RoundedRect;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 
+use super::grid_view::AssetContextMenuHandler;
 use crate::api_client::ThumbnailSize;
 use crate::library::asset_model::LibraryAssetModel;
 use crate::library::asset_object::AssetObject;
-use crate::library::grid_view::AssetContextMenuHandler;
 use crate::library::thumbnail_cache::ThumbnailCache;
 
 type ActivateHandler = Rc<dyn Fn(u32)>;
@@ -25,11 +25,9 @@ pub(super) const CORNER_RADIUS: f32 = 0.0;
 const VIEWPORTS_BEHIND: f32 = 2.0;
 const VIEWPORTS_AHEAD: f32 = 4.0;
 
-use crate::library::masonry::layout::{
-    LaidRow, LayoutConfig, first_row_at_or_after, item_at_x, pack_rows, row_at_y,
-};
-pub use crate::library::masonry::quality::GridQuality;
-use crate::library::masonry::quality::{bucket_for_row_height, fallback_bucket};
+use super::layout::{LaidRow, LayoutConfig, first_row_at_or_after, item_at_x, pack_rows, row_at_y};
+pub use super::quality::GridQuality;
+use super::quality::{bucket_for_row_height, fallback_bucket};
 
 mod imp {
     use super::*;
@@ -359,7 +357,7 @@ mod imp {
     }
 }
 
-use crate::library::masonry::load::{collect_dims, load_with_fallback, propagate_dimensions};
+use super::load::{collect_dims, load_with_fallback, propagate_dimensions};
 
 glib::wrapper! {
     pub struct MasonryCanvas(ObjectSubclass<imp::MasonryCanvas>)

--- a/src/library/masonry/grid_view.rs
+++ b/src/library/masonry/grid_view.rs
@@ -7,9 +7,9 @@ use std::sync::Arc;
 
 use gtk::prelude::*;
 
+use super::canvas::{GridQuality, MasonryCanvas};
 use crate::app_context::AppContext;
 use crate::library::asset_model::LibraryAssetModel;
-use crate::library::masonry_canvas::{GridQuality, MasonryCanvas};
 
 pub type AssetContextMenuHandler = Rc<RefCell<Option<Box<dyn Fn(u32, f64, f64)>>>>;
 

--- a/src/library/masonry/layout.rs
+++ b/src/library/masonry/layout.rs
@@ -1,0 +1,334 @@
+//! Pure layout math for the justified-row masonry grid.
+//!
+//! `pack_rows` greedily fills rows up to `canvas_w` then scales each row to
+//! fit. Includes `O(log n)` row lookup helpers used by the snapshot + hit-test
+//! paths.
+
+const FALLBACK_W: f32 = 4.0;
+const FALLBACK_H: f32 = 3.0;
+
+pub(crate) const MIN_ROW_HEIGHT_NARROW: f32 = 120.0;
+pub(crate) const MAX_ROW_HEIGHT_NARROW: f32 = 240.0;
+pub(crate) const MIN_ROW_HEIGHT_WIDE: f32 = 180.0;
+pub(crate) const MAX_ROW_HEIGHT_WIDE: f32 = 360.0;
+
+pub(crate) const GAP: f32 = 0.0;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LaidItem {
+    pub asset_index: u32,
+    pub x: f32,
+    pub w: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LaidRow {
+    pub y: f32,
+    pub h: f32,
+    pub items: Vec<LaidItem>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LayoutConfig {
+    pub min_row_height: f32,
+    pub max_row_height: f32,
+    pub gap: f32,
+}
+
+impl LayoutConfig {
+    pub(crate) fn narrow() -> Self {
+        Self {
+            min_row_height: MIN_ROW_HEIGHT_NARROW,
+            max_row_height: MAX_ROW_HEIGHT_NARROW,
+            gap: GAP,
+        }
+    }
+
+    pub(crate) fn wide() -> Self {
+        Self {
+            min_row_height: MIN_ROW_HEIGHT_WIDE,
+            max_row_height: MAX_ROW_HEIGHT_WIDE,
+            gap: GAP,
+        }
+    }
+}
+
+fn aspect(width: u32, height: u32) -> f32 {
+    if width == 0 || height == 0 {
+        FALLBACK_W / FALLBACK_H
+    } else {
+        (width as f32) / (height as f32)
+    }
+}
+
+/// Greedy justified-row pack. `dims[i] = (w, h)` for asset i.
+pub(crate) fn pack_rows(
+    dims: &[(u32, u32)],
+    canvas_w: f32,
+    cfg: LayoutConfig,
+) -> (Vec<LaidRow>, f32) {
+    if dims.is_empty() || canvas_w <= 0.0 {
+        return (Vec::new(), 0.0);
+    }
+
+    let mut rows: Vec<LaidRow> = Vec::new();
+    let mut y_cursor = 0.0_f32;
+    let mut i = 0_usize;
+
+    while i < dims.len() {
+        let mut indices: Vec<usize> = Vec::new();
+        let mut summed_w = 0.0_f32;
+        while i < dims.len() {
+            let w_at_max = aspect(dims[i].0, dims[i].1) * cfg.max_row_height;
+            let gap_before = if indices.is_empty() { 0.0 } else { cfg.gap };
+            if !indices.is_empty() && summed_w + gap_before + w_at_max > canvas_w {
+                break;
+            }
+            indices.push(i);
+            summed_w += w_at_max + gap_before;
+            i += 1;
+        }
+        let last_row = i >= dims.len() && summed_w + cfg.gap < canvas_w;
+
+        let mut row_h = scale_to_fit(&indices, dims, canvas_w, cfg);
+
+        // Pop the trailing item if the row is too short — it spills to the next row.
+        if indices.len() > 1 && row_h < cfg.min_row_height {
+            let popped = indices.pop().unwrap();
+            i = popped;
+            row_h = scale_to_fit(&indices, dims, canvas_w, cfg);
+        }
+
+        // Filled rows keep their computed height so the row reaches canvas_w.
+        // Only the underfilled trailing row is clamped.
+        if last_row {
+            row_h = row_h.clamp(cfg.min_row_height, cfg.max_row_height);
+        }
+
+        let mut placed = Vec::with_capacity(indices.len());
+        let mut x_cursor = 0.0_f32;
+        for &idx in &indices {
+            let w = aspect(dims[idx].0, dims[idx].1) * row_h;
+            placed.push(LaidItem {
+                asset_index: idx as u32,
+                x: x_cursor,
+                w,
+            });
+            x_cursor += w + cfg.gap;
+        }
+
+        rows.push(LaidRow {
+            y: y_cursor,
+            h: row_h,
+            items: placed,
+        });
+        y_cursor += row_h + cfg.gap;
+    }
+
+    let total_height = (y_cursor - cfg.gap).max(0.0);
+    (rows, total_height)
+}
+
+fn scale_to_fit(indices: &[usize], dims: &[(u32, u32)], canvas_w: f32, cfg: LayoutConfig) -> f32 {
+    let total_gap = if indices.len() > 1 {
+        cfg.gap * (indices.len() as f32 - 1.0)
+    } else {
+        0.0
+    };
+    let sum: f32 = indices
+        .iter()
+        .map(|&idx| aspect(dims[idx].0, dims[idx].1) * cfg.max_row_height)
+        .sum();
+    if sum <= 0.0 {
+        return cfg.max_row_height;
+    }
+    let scale = ((canvas_w - total_gap) / sum).max(0.0);
+    cfg.max_row_height * scale
+}
+
+pub(crate) fn first_row_at_or_after(rows: &[LaidRow], y: f32) -> usize {
+    let mut lo = 0;
+    let mut hi = rows.len();
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if rows[mid].y + rows[mid].h < y {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    lo
+}
+
+pub(crate) fn row_at_y(rows: &[LaidRow], y: f32) -> Option<usize> {
+    if rows.is_empty() {
+        return None;
+    }
+    let mut lo = 0;
+    let mut hi = rows.len();
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        let r = &rows[mid];
+        if y < r.y {
+            hi = mid;
+        } else if y >= r.y + r.h {
+            lo = mid + 1;
+        } else {
+            return Some(mid);
+        }
+    }
+    None
+}
+
+pub(crate) fn item_at_x(row: &LaidRow, x: f32) -> Option<&LaidItem> {
+    row.items.iter().find(|it| x >= it.x && x < it.x + it.w)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> LayoutConfig {
+        LayoutConfig {
+            min_row_height: 100.0,
+            max_row_height: 200.0,
+            gap: 0.0,
+        }
+    }
+
+    #[test]
+    fn empty_input_yields_empty_layout() {
+        let (rows, h) = pack_rows(&[], 1000.0, cfg());
+        assert!(rows.is_empty());
+        assert_eq!(h, 0.0);
+    }
+
+    #[test]
+    fn zero_canvas_width_yields_empty() {
+        let (rows, h) = pack_rows(&[(100, 100)], 0.0, cfg());
+        assert!(rows.is_empty());
+        assert_eq!(h, 0.0);
+    }
+
+    #[test]
+    fn fallback_aspect_when_dimensions_zero() {
+        let (rows, _) = pack_rows(&[(0, 0), (0, 0), (0, 0)], 1200.0, cfg());
+        assert_eq!(rows.len(), 1);
+        assert!((rows[0].h - 200.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn full_row_fills_canvas_width_within_a_pixel() {
+        let dims = &[(1600, 900), (1600, 900), (1600, 900), (1600, 900)];
+        let (rows, _) = pack_rows(dims, 1200.0, cfg());
+        let r1 = &rows[0];
+        let last = r1.items.last().unwrap();
+        let fill = last.x + last.w;
+        assert!((fill - 1200.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn all_items_placed_across_rows() {
+        let dims: Vec<(u32, u32)> = (0..8).map(|_| (3000, 1000)).collect();
+        let (rows, _) = pack_rows(&dims, 1200.0, cfg());
+        let total: usize = rows.iter().map(|r| r.items.len()).sum();
+        assert_eq!(total, 8);
+    }
+
+    #[test]
+    fn last_row_clamped_to_max_height() {
+        let mut dims: Vec<(u32, u32)> = (0..6).map(|_| (4000, 3000)).collect();
+        dims.push((1000, 1500));
+        let (rows, _) = pack_rows(&dims, 1200.0, cfg());
+        let last = rows.last().unwrap();
+        assert!(last.h <= 200.0 + 0.01);
+    }
+
+    #[test]
+    fn binary_search_finds_correct_row() {
+        let rows = vec![
+            LaidRow {
+                y: 0.0,
+                h: 100.0,
+                items: vec![],
+            },
+            LaidRow {
+                y: 100.0,
+                h: 150.0,
+                items: vec![],
+            },
+            LaidRow {
+                y: 250.0,
+                h: 80.0,
+                items: vec![],
+            },
+        ];
+        assert_eq!(row_at_y(&rows, 0.0), Some(0));
+        assert_eq!(row_at_y(&rows, 100.0), Some(1));
+        assert_eq!(row_at_y(&rows, 329.9), Some(2));
+        assert_eq!(row_at_y(&rows, 330.0), None);
+    }
+
+    #[test]
+    fn item_hit_test_within_row() {
+        let row = LaidRow {
+            y: 0.0,
+            h: 100.0,
+            items: vec![
+                LaidItem {
+                    asset_index: 5,
+                    x: 0.0,
+                    w: 50.0,
+                },
+                LaidItem {
+                    asset_index: 6,
+                    x: 50.0,
+                    w: 80.0,
+                },
+                LaidItem {
+                    asset_index: 7,
+                    x: 130.0,
+                    w: 40.0,
+                },
+            ],
+        };
+        assert_eq!(item_at_x(&row, 0.0).map(|i| i.asset_index), Some(5));
+        assert_eq!(item_at_x(&row, 50.0).map(|i| i.asset_index), Some(6));
+        assert_eq!(item_at_x(&row, 130.0).map(|i| i.asset_index), Some(7));
+        assert!(item_at_x(&row, 200.0).is_none());
+    }
+
+    #[test]
+    fn gap_increases_total_layout_height() {
+        let dims = &[(100, 100), (100, 100), (100, 100), (100, 100)];
+        let (_, h0) = pack_rows(dims, 200.0, LayoutConfig { gap: 0.0, ..cfg() });
+        let (_, h1) = pack_rows(dims, 200.0, LayoutConfig { gap: 10.0, ..cfg() });
+        assert!(h1 > h0);
+    }
+
+    #[test]
+    fn first_row_skip_lands_on_intersecting_row() {
+        let rows = vec![
+            LaidRow {
+                y: 0.0,
+                h: 100.0,
+                items: vec![],
+            },
+            LaidRow {
+                y: 100.0,
+                h: 100.0,
+                items: vec![],
+            },
+            LaidRow {
+                y: 200.0,
+                h: 100.0,
+                items: vec![],
+            },
+        ];
+        assert_eq!(first_row_at_or_after(&rows, -50.0), 0);
+        assert_eq!(first_row_at_or_after(&rows, 0.0), 0);
+        assert_eq!(first_row_at_or_after(&rows, 150.0), 1);
+        assert_eq!(first_row_at_or_after(&rows, 250.0), 2);
+        assert_eq!(first_row_at_or_after(&rows, 500.0), 3);
+    }
+}

--- a/src/library/masonry/load.rs
+++ b/src/library/masonry/load.rs
@@ -1,0 +1,86 @@
+//! Async load plumbing for the masonry grid.
+//!
+//! `load_with_fallback` consults the shared `ThumbnailCache`, walking the
+//! `quality::fallback_bucket` chain on 404 so opt-in server features (e.g.
+//! fullsize generation) degrade gracefully to whatever the server has.
+//! `collect_dims` / `propagate_dimensions` keep the layout's `(w, h)` view
+//! of each asset in sync with what eventually decodes.
+
+use gdk4::Texture;
+use gtk::prelude::*;
+
+use crate::api_client::ThumbnailSize;
+use crate::library::asset_model::LibraryAssetModel;
+use crate::library::asset_object::AssetObject;
+use crate::library::masonry::quality::fallback_bucket;
+use crate::library::thumbnail_cache::ThumbnailCache;
+
+pub(crate) fn collect_dims(model: &LibraryAssetModel) -> Vec<(u32, u32)> {
+    let n = model.n_items();
+    let mut out = Vec::with_capacity(n as usize);
+    for i in 0..n {
+        if let Some(obj) = model.item(i).and_downcast::<AssetObject>() {
+            out.push((obj.property::<u32>("width"), obj.property::<u32>("height")));
+        } else {
+            out.push((0, 0));
+        }
+    }
+    out
+}
+
+/// Try requested bucket, then walk `fallback_bucket` chain on 404. Only the
+/// 404 path is retried — auth, network, etc. surface unchanged.
+pub(crate) async fn load_with_fallback<F: Fn() -> bool>(
+    cache: &ThumbnailCache,
+    asset_id: &str,
+    requested: ThumbnailSize,
+    is_cancelled: &F,
+) -> Result<Texture, String> {
+    let mut current = requested;
+    loop {
+        match cache
+            .load_thumbnail_cancellable(asset_id, current, is_cancelled)
+            .await
+        {
+            Ok(tex) => return Ok(tex),
+            Err(e) if e.contains("404") => match fallback_bucket(current) {
+                Some(next) => {
+                    log::debug!(
+                        "masonry fallback id={} {:?} -> {:?} ({})",
+                        asset_id,
+                        current,
+                        next,
+                        e
+                    );
+                    current = next;
+                }
+                None => return Err(e),
+            },
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// Returns true if the AssetObject dimensions were filled in (relayout needed).
+pub(crate) fn propagate_dimensions(
+    model: &LibraryAssetModel,
+    asset_id: &str,
+    tex: &Texture,
+) -> bool {
+    let n = model.n_items();
+    for i in 0..n {
+        if let Some(obj) = model.item(i).and_downcast::<AssetObject>()
+            && obj.property::<String>("id") == asset_id
+        {
+            let w = obj.property::<u32>("width");
+            let h = obj.property::<u32>("height");
+            if w == 0 || h == 0 {
+                obj.set_property("width", tex.width() as u32);
+                obj.set_property("height", tex.height() as u32);
+                return true;
+            }
+            return false;
+        }
+    }
+    false
+}

--- a/src/library/masonry/mod.rs
+++ b/src/library/masonry/mod.rs
@@ -1,0 +1,5 @@
+//! Justified-row masonry layout pieces for the photos grid.
+
+pub mod layout;
+pub mod load;
+pub mod quality;

--- a/src/library/masonry/mod.rs
+++ b/src/library/masonry/mod.rs
@@ -1,5 +1,9 @@
 //! Justified-row masonry layout pieces for the photos grid.
 
+pub mod canvas;
+pub mod grid_view;
 pub mod layout;
 pub mod load;
 pub mod quality;
+
+pub use grid_view::{GridViewParts, build_grid_view};

--- a/src/library/masonry/quality.rs
+++ b/src/library/masonry/quality.rs
@@ -1,0 +1,95 @@
+//! Bucket selection policy for the masonry grid.
+//!
+//! Maps a `GridQuality` choice (auto / explicit) and a row's rendered height
+//! to a concrete `ThumbnailSize`. `fallback_bucket` defines the degradation
+//! chain used when a server lacks higher buckets (e.g. no fullsize).
+
+use crate::api_client::ThumbnailSize;
+
+pub(crate) const PREVIEW_BUCKET_THRESHOLD: f32 = 600.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GridQuality {
+    #[default]
+    Auto,
+    Thumbnail,
+    Preview,
+    Fullsize,
+}
+
+impl GridQuality {
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "thumbnail" => Self::Thumbnail,
+            "preview" => Self::Preview,
+            "fullsize" => Self::Fullsize,
+            _ => Self::Auto,
+        }
+    }
+}
+
+pub(crate) fn bucket_for_row_height(h: f32, quality: GridQuality) -> ThumbnailSize {
+    match quality {
+        GridQuality::Thumbnail => ThumbnailSize::Thumbnail,
+        GridQuality::Preview => ThumbnailSize::Preview,
+        GridQuality::Fullsize => ThumbnailSize::Fullsize,
+        GridQuality::Auto => {
+            if h <= PREVIEW_BUCKET_THRESHOLD {
+                ThumbnailSize::Thumbnail
+            } else {
+                ThumbnailSize::Preview
+            }
+        }
+    }
+}
+
+/// Smaller size to try when a requested bucket isn't available on the server.
+pub(crate) fn fallback_bucket(size: ThumbnailSize) -> Option<ThumbnailSize> {
+    match size {
+        ThumbnailSize::Fullsize => Some(ThumbnailSize::Preview),
+        ThumbnailSize::Preview | ThumbnailSize::Thumbnail => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bucket_thumbnail_under_threshold() {
+        assert!(matches!(
+            bucket_for_row_height(200.0, GridQuality::Auto),
+            ThumbnailSize::Thumbnail
+        ));
+        assert!(matches!(
+            bucket_for_row_height(PREVIEW_BUCKET_THRESHOLD, GridQuality::Auto),
+            ThumbnailSize::Thumbnail
+        ));
+        assert!(matches!(
+            bucket_for_row_height(PREVIEW_BUCKET_THRESHOLD + 1.0, GridQuality::Auto),
+            ThumbnailSize::Preview
+        ));
+    }
+
+    #[test]
+    fn explicit_quality_overrides_row_height() {
+        assert!(matches!(
+            bucket_for_row_height(2000.0, GridQuality::Thumbnail),
+            ThumbnailSize::Thumbnail
+        ));
+        assert!(matches!(
+            bucket_for_row_height(50.0, GridQuality::Fullsize),
+            ThumbnailSize::Fullsize
+        ));
+    }
+
+    #[test]
+    fn fallback_chain_degrades_fullsize_to_preview() {
+        assert_eq!(
+            fallback_bucket(ThumbnailSize::Fullsize),
+            Some(ThumbnailSize::Preview)
+        );
+        assert_eq!(fallback_bucket(ThumbnailSize::Preview), None);
+        assert_eq!(fallback_bucket(ThumbnailSize::Thumbnail), None);
+    }
+}

--- a/src/library/masonry_canvas.rs
+++ b/src/library/masonry_canvas.rs
@@ -33,7 +33,7 @@ pub(super) const GAP: f32 = 0.0;
 pub(super) const CORNER_RADIUS: f32 = 0.0;
 
 /// Row height above which we request the larger Preview thumbnail.
-const PREVIEW_BUCKET_THRESHOLD: f32 = 280.0;
+const PREVIEW_BUCKET_THRESHOLD: f32 = 600.0;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LaidItem {
@@ -213,8 +213,9 @@ mod imp {
         pub cached_width: Cell<f32>,
         pub layout_h: Cell<f32>,
         pub pending: RefCell<HashSet<String>>,
-        /// Textures retained per asset so re-painting after scroll never has
-        /// to re-fetch when the shared ThumbnailCache LRU evicts.
+        /// Permanently failed ids; skipped to avoid re-queueing every frame.
+        pub failed: RefCell<HashSet<String>>,
+        /// Per-canvas texture retain to survive shared cache eviction.
         pub textures: RefCell<HashMap<String, Texture>>,
         pub vadjustment: RefCell<Option<gtk::Adjustment>>,
         pub activate_handler: RefCell<Option<ActivateHandler>>,
@@ -244,9 +245,13 @@ mod imp {
 
         fn measure(&self, orientation: gtk::Orientation, for_size: i32) -> (i32, i32, i32, i32) {
             match orientation {
-                gtk::Orientation::Horizontal => (0, 0, -1, -1),
+                gtk::Orientation::Horizontal => (200, 200, -1, -1),
                 _ => {
-                    let width = for_size.max(0) as f32;
+                    let width = if for_size > 0 {
+                        for_size as f32
+                    } else {
+                        self.cached_width.get().max(200.0)
+                    };
                     let h = self.layout_for_width(width);
                     let h_i = h.ceil() as i32;
                     (h_i, h_i, -1, -1)
@@ -255,20 +260,24 @@ mod imp {
         }
 
         fn size_allocate(&self, width: i32, _height: i32, _baseline: i32) {
-            let _ = self.layout_for_width(width.max(0) as f32);
+            let w = width.max(0) as f32;
+            if (w - self.cached_width.get()).abs() > 0.5 {
+                self.cached_width.set(-1.0);
+            }
+            let _ = self.layout_for_width(w);
         }
 
         fn snapshot(&self, snapshot: &gtk::Snapshot) {
             let widget = self.obj();
             let canvas_w = widget.width() as f32;
+            let canvas_h = widget.height() as f32;
             if canvas_w <= 0.0 {
                 return;
             }
             let _ = self.layout_for_width(canvas_w);
 
             let (scroll_y, viewport_h) = self.viewport();
-            let visible_top = scroll_y;
-            let visible_bottom = scroll_y + viewport_h;
+            let viewport_center = scroll_y + viewport_h * 0.5;
 
             let rows = self.rows.borrow();
             let Some(model) = self.model.get() else {
@@ -278,20 +287,18 @@ mod imp {
                 return;
             };
 
-            let placeholder = gdk4::RGBA::new(0.18, 0.18, 0.18, 1.0);
+            let placeholder = gdk4::RGBA::new(0.24, 0.22, 0.30, 1.0);
             let select_tint = gdk4::RGBA::new(0.30, 0.55, 0.95, 0.35);
             let selection = self.selection.get();
-            let mut needs_load: Vec<(String, ThumbnailSize, String, bool)> = Vec::new();
+            let mut to_load: Vec<(f32, String, ThumbnailSize, String, bool)> = Vec::new();
+            let mut hits = 0usize;
+            let mut misses = 0usize;
+            let mut painted = 0usize;
+            let row_count = rows.len();
+            let last_row_bottom = rows.last().map(|r| r.y + r.h).unwrap_or(0.0);
 
             for row in rows.iter() {
-                if row.y + row.h < visible_top {
-                    continue;
-                }
-                if row.y > visible_bottom {
-                    break;
-                }
                 for it in &row.items {
-                    let rect = Rect::new(it.x, row.y, it.w, row.h);
                     let bucket = bucket_for_row_height(row.h);
                     let Some(asset) = model.item(it.asset_index).and_downcast::<AssetObject>()
                     else {
@@ -309,21 +316,20 @@ mod imp {
                             cache.get_cached(&asset_id, bucket)
                         }
                     });
+
+                    let rect = Rect::new(it.x, row.y, it.w, row.h);
                     let clipped = CORNER_RADIUS > 0.0;
                     if clipped {
                         let corner = Size::new(CORNER_RADIUS, CORNER_RADIUS);
                         let rounded = RoundedRect::new(rect, corner, corner, corner, corner);
                         snapshot.push_rounded_clip(&rounded);
                     }
-                    if let Some(tex) = cached {
-                        snapshot.append_texture(&tex, &rect);
+                    if let Some(tex) = cached.as_ref() {
+                        snapshot.append_texture(tex, &rect);
+                        hits += 1;
                     } else {
                         snapshot.append_color(&placeholder, &rect);
-                        let mut pending = self.pending.borrow_mut();
-                        if !pending.contains(&asset_id) {
-                            pending.insert(asset_id.clone());
-                            needs_load.push((asset_id, bucket, local_path, is_local_only));
-                        }
+                        misses += 1;
                     }
                     let selected = selection
                         .map(|s| s.is_selected(it.asset_index))
@@ -334,11 +340,39 @@ mod imp {
                     if clipped {
                         snapshot.pop();
                     }
+                    painted += 1;
+
+                    if cached.is_none() && !self.failed.borrow().contains(&asset_id) {
+                        let mut pending = self.pending.borrow_mut();
+                        if !pending.contains(&asset_id) {
+                            pending.insert(asset_id.clone());
+                            let cell_center = row.y + row.h * 0.5;
+                            let priority = (cell_center - viewport_center).abs();
+                            to_load.push((priority, asset_id, bucket, local_path, is_local_only));
+                        }
+                    }
                 }
             }
             drop(rows);
+            to_load.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
 
-            for (asset_id, bucket, local_path, is_local) in needs_load {
+            log::debug!(
+                "masonry snapshot canvas=({:.0}x{:.0}) scroll_y={:.0} viewport_h={:.0} rows={} layout_h={:.0} painted={} hits={} misses={} pending={} textures={} queued={}",
+                canvas_w,
+                canvas_h,
+                scroll_y,
+                viewport_h,
+                row_count,
+                last_row_bottom,
+                painted,
+                hits,
+                misses,
+                self.pending.borrow().len(),
+                self.textures.borrow().len(),
+                to_load.len(),
+            );
+
+            for (_, asset_id, bucket, local_path, is_local) in to_load {
                 self.spawn_load(asset_id, bucket, local_path, is_local);
             }
         }
@@ -420,17 +454,13 @@ mod imp {
             };
             let widget = self.obj().clone();
             let id_for_remove = asset_id.clone();
-            // Off-screen loads cancel by reading the live pending set: each
-            // snapshot drops ids that are no longer visible, so backlogged
-            // loads can release their semaphore permit.
-            let cancel_widget = widget.downgrade();
-            let cancel_id = asset_id.clone();
-            let is_cancelled = move || {
-                let Some(w) = cancel_widget.upgrade() else {
-                    return true;
-                };
-                !w.imp().pending.borrow().contains(&cancel_id)
-            };
+            let is_cancelled = || false;
+            log::debug!(
+                "masonry spawn_load id={} bucket={:?} local={}",
+                asset_id,
+                bucket,
+                is_local
+            );
             glib::MainContext::default().spawn_local(async move {
                 let result = if is_local {
                     let path = std::path::PathBuf::from(&local_path);
@@ -444,9 +474,26 @@ mod imp {
                 };
                 let imp = widget.imp();
                 let mut dims_changed = false;
-                if let Ok(tex) = result {
-                    dims_changed = propagate_dimensions(&model, &asset_id, &tex);
-                    imp.textures.borrow_mut().insert(asset_id.clone(), tex);
+                match &result {
+                    Ok(tex) => {
+                        dims_changed = propagate_dimensions(&model, &asset_id, tex);
+                        imp.textures
+                            .borrow_mut()
+                            .insert(asset_id.clone(), tex.clone());
+                        log::debug!(
+                            "masonry load OK id={} dims=({}x{}) tex_total={}",
+                            asset_id,
+                            tex.width(),
+                            tex.height(),
+                            imp.textures.borrow().len()
+                        );
+                    }
+                    Err(e) => {
+                        if e != "cancelled" {
+                            imp.failed.borrow_mut().insert(asset_id.clone());
+                        }
+                        log::debug!("masonry load ERR id={} err={}", asset_id, e);
+                    }
                 }
                 imp.pending.borrow_mut().remove(&id_for_remove);
                 if dims_changed {
@@ -516,11 +563,8 @@ impl MasonryCanvas {
         let _ = imp.selection.set(selection.clone());
 
         let weak = canvas.downgrade();
-        model.connect_items_changed(move |model, _, _, _| {
+        model.connect_items_changed(move |model, position, removed, added| {
             if let Some(canvas) = weak.upgrade() {
-                // Drop only textures whose asset_id is no longer in the model.
-                // Avoids wiping retained textures on append-pagination that
-                // emits a full-range items_changed (client-sorted modes).
                 let imp = canvas.imp();
                 let n = model.n_items();
                 let mut current_ids: HashSet<String> = HashSet::with_capacity(n as usize);
@@ -529,9 +573,23 @@ impl MasonryCanvas {
                         current_ids.insert(obj.property::<String>("id"));
                     }
                 }
+                let tex_before = imp.textures.borrow().len();
                 imp.textures
                     .borrow_mut()
                     .retain(|id, _| current_ids.contains(id));
+                imp.failed
+                    .borrow_mut()
+                    .retain(|id| current_ids.contains(id));
+                let tex_after = imp.textures.borrow().len();
+                log::debug!(
+                    "masonry items_changed pos={} removed={} added={} model_n={} textures {} -> {}",
+                    position,
+                    removed,
+                    added,
+                    n,
+                    tex_before,
+                    tex_after,
+                );
                 imp.invalidate_layout();
                 canvas.queue_draw();
             }
@@ -777,11 +835,11 @@ mod tests {
             ThumbnailSize::Thumbnail
         ));
         assert!(matches!(
-            bucket_for_row_height(280.0),
+            bucket_for_row_height(PREVIEW_BUCKET_THRESHOLD),
             ThumbnailSize::Thumbnail
         ));
         assert!(matches!(
-            bucket_for_row_height(281.0),
+            bucket_for_row_height(PREVIEW_BUCKET_THRESHOLD + 1.0),
             ThumbnailSize::Preview
         ));
     }

--- a/src/library/masonry_canvas.rs
+++ b/src/library/masonry_canvas.rs
@@ -5,7 +5,6 @@ use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use gdk4::Texture;
 use gtk::glib;
 use gtk::graphene::{Rect, Size};
 use gtk::gsk::RoundedRect;
@@ -21,233 +20,16 @@ use crate::library::thumbnail_cache::ThumbnailCache;
 type ActivateHandler = Rc<dyn Fn(u32)>;
 type SelectModeChanger = Rc<dyn Fn(bool)>;
 
-const FALLBACK_W: f32 = 4.0;
-const FALLBACK_H: f32 = 3.0;
-
-pub(super) const MIN_ROW_HEIGHT_NARROW: f32 = 120.0;
-pub(super) const MAX_ROW_HEIGHT_NARROW: f32 = 240.0;
-pub(super) const MIN_ROW_HEIGHT_WIDE: f32 = 180.0;
-pub(super) const MAX_ROW_HEIGHT_WIDE: f32 = 360.0;
-
-pub(super) const GAP: f32 = 0.0;
 pub(super) const CORNER_RADIUS: f32 = 0.0;
 
-const PREVIEW_BUCKET_THRESHOLD: f32 = 600.0;
 const VIEWPORTS_BEHIND: f32 = 2.0;
 const VIEWPORTS_AHEAD: f32 = 4.0;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct LaidItem {
-    pub asset_index: u32,
-    pub x: f32,
-    pub w: f32,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct LaidRow {
-    pub y: f32,
-    pub h: f32,
-    pub items: Vec<LaidItem>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct LayoutConfig {
-    pub min_row_height: f32,
-    pub max_row_height: f32,
-    pub gap: f32,
-}
-
-impl LayoutConfig {
-    pub(super) fn narrow() -> Self {
-        Self {
-            min_row_height: MIN_ROW_HEIGHT_NARROW,
-            max_row_height: MAX_ROW_HEIGHT_NARROW,
-            gap: GAP,
-        }
-    }
-
-    pub(super) fn wide() -> Self {
-        Self {
-            min_row_height: MIN_ROW_HEIGHT_WIDE,
-            max_row_height: MAX_ROW_HEIGHT_WIDE,
-            gap: GAP,
-        }
-    }
-}
-
-fn aspect(width: u32, height: u32) -> f32 {
-    if width == 0 || height == 0 {
-        FALLBACK_W / FALLBACK_H
-    } else {
-        (width as f32) / (height as f32)
-    }
-}
-
-/// Greedy justified-row pack. `dims[i] = (w, h)` for asset i.
-pub(super) fn pack_rows(
-    dims: &[(u32, u32)],
-    canvas_w: f32,
-    cfg: LayoutConfig,
-) -> (Vec<LaidRow>, f32) {
-    if dims.is_empty() || canvas_w <= 0.0 {
-        return (Vec::new(), 0.0);
-    }
-
-    let mut rows: Vec<LaidRow> = Vec::new();
-    let mut y_cursor = 0.0_f32;
-    let mut i = 0_usize;
-
-    while i < dims.len() {
-        let mut indices: Vec<usize> = Vec::new();
-        let mut summed_w = 0.0_f32;
-        while i < dims.len() {
-            let w_at_max = aspect(dims[i].0, dims[i].1) * cfg.max_row_height;
-            let gap_before = if indices.is_empty() { 0.0 } else { cfg.gap };
-            if !indices.is_empty() && summed_w + gap_before + w_at_max > canvas_w {
-                break;
-            }
-            indices.push(i);
-            summed_w += w_at_max + gap_before;
-            i += 1;
-        }
-        let last_row = i >= dims.len() && summed_w + cfg.gap < canvas_w;
-
-        let mut row_h = scale_to_fit(&indices, dims, canvas_w, cfg);
-
-        // Pop the trailing item if the row is too short — it spills to the next row.
-        if indices.len() > 1 && row_h < cfg.min_row_height {
-            let popped = indices.pop().unwrap();
-            i = popped;
-            row_h = scale_to_fit(&indices, dims, canvas_w, cfg);
-        }
-
-        // Filled rows keep their computed height so the row reaches canvas_w.
-        // Only the underfilled trailing row is clamped.
-        if last_row {
-            row_h = row_h.clamp(cfg.min_row_height, cfg.max_row_height);
-        }
-
-        let mut placed = Vec::with_capacity(indices.len());
-        let mut x_cursor = 0.0_f32;
-        for &idx in &indices {
-            let w = aspect(dims[idx].0, dims[idx].1) * row_h;
-            placed.push(LaidItem {
-                asset_index: idx as u32,
-                x: x_cursor,
-                w,
-            });
-            x_cursor += w + cfg.gap;
-        }
-
-        rows.push(LaidRow {
-            y: y_cursor,
-            h: row_h,
-            items: placed,
-        });
-        y_cursor += row_h + cfg.gap;
-    }
-
-    let total_height = (y_cursor - cfg.gap).max(0.0);
-    (rows, total_height)
-}
-
-fn scale_to_fit(indices: &[usize], dims: &[(u32, u32)], canvas_w: f32, cfg: LayoutConfig) -> f32 {
-    let total_gap = if indices.len() > 1 {
-        cfg.gap * (indices.len() as f32 - 1.0)
-    } else {
-        0.0
-    };
-    let sum: f32 = indices
-        .iter()
-        .map(|&idx| aspect(dims[idx].0, dims[idx].1) * cfg.max_row_height)
-        .sum();
-    if sum <= 0.0 {
-        return cfg.max_row_height;
-    }
-    let scale = ((canvas_w - total_gap) / sum).max(0.0);
-    cfg.max_row_height * scale
-}
-
-fn first_row_at_or_after(rows: &[LaidRow], y: f32) -> usize {
-    let mut lo = 0;
-    let mut hi = rows.len();
-    while lo < hi {
-        let mid = lo + (hi - lo) / 2;
-        if rows[mid].y + rows[mid].h < y {
-            lo = mid + 1;
-        } else {
-            hi = mid;
-        }
-    }
-    lo
-}
-
-pub(super) fn row_at_y(rows: &[LaidRow], y: f32) -> Option<usize> {
-    if rows.is_empty() {
-        return None;
-    }
-    let mut lo = 0;
-    let mut hi = rows.len();
-    while lo < hi {
-        let mid = lo + (hi - lo) / 2;
-        let r = &rows[mid];
-        if y < r.y {
-            hi = mid;
-        } else if y >= r.y + r.h {
-            lo = mid + 1;
-        } else {
-            return Some(mid);
-        }
-    }
-    None
-}
-
-pub(super) fn item_at_x(row: &LaidRow, x: f32) -> Option<&LaidItem> {
-    row.items.iter().find(|it| x >= it.x && x < it.x + it.w)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum GridQuality {
-    #[default]
-    Auto,
-    Thumbnail,
-    Preview,
-    Fullsize,
-}
-
-impl GridQuality {
-    pub fn parse(s: &str) -> Self {
-        match s {
-            "thumbnail" => Self::Thumbnail,
-            "preview" => Self::Preview,
-            "fullsize" => Self::Fullsize,
-            _ => Self::Auto,
-        }
-    }
-}
-
-fn bucket_for_row_height(h: f32, quality: GridQuality) -> ThumbnailSize {
-    match quality {
-        GridQuality::Thumbnail => ThumbnailSize::Thumbnail,
-        GridQuality::Preview => ThumbnailSize::Preview,
-        GridQuality::Fullsize => ThumbnailSize::Fullsize,
-        GridQuality::Auto => {
-            if h <= PREVIEW_BUCKET_THRESHOLD {
-                ThumbnailSize::Thumbnail
-            } else {
-                ThumbnailSize::Preview
-            }
-        }
-    }
-}
-
-/// Smaller size to try when a requested bucket isn't available on the server.
-fn fallback_bucket(size: ThumbnailSize) -> Option<ThumbnailSize> {
-    match size {
-        ThumbnailSize::Fullsize => Some(ThumbnailSize::Preview),
-        ThumbnailSize::Preview | ThumbnailSize::Thumbnail => None,
-    }
-}
+use crate::library::masonry::layout::{
+    LaidRow, LayoutConfig, first_row_at_or_after, item_at_x, pack_rows, row_at_y,
+};
+pub use crate::library::masonry::quality::GridQuality;
+use crate::library::masonry::quality::{bucket_for_row_height, fallback_bucket};
 
 mod imp {
     use super::*;
@@ -319,7 +101,6 @@ mod imp {
         fn snapshot(&self, snapshot: &gtk::Snapshot) {
             let widget = self.obj();
             let canvas_w = widget.width() as f32;
-            let canvas_h = widget.height() as f32;
             if canvas_w <= 0.0 {
                 return;
             }
@@ -340,30 +121,24 @@ mod imp {
                 return;
             };
 
-            let placeholder = gdk4::RGBA::new(1.0, 0.0, 1.0, 1.0);
+            let placeholder = if libadwaita::StyleManager::default().is_dark() {
+                gdk4::RGBA::new(0.20, 0.20, 0.22, 1.0)
+            } else {
+                gdk4::RGBA::new(0.90, 0.90, 0.92, 1.0)
+            };
             let select_tint = gdk4::RGBA::new(0.30, 0.55, 0.95, 0.35);
             let selection = self.selection.get();
             let mut to_load: Vec<(f32, String, ThumbnailSize, String, bool)> = Vec::new();
             let mut hits = 0usize;
             let mut misses = 0usize;
             let mut painted = 0usize;
-            let row_count = rows.len();
-            let last_row_bottom = rows.last().map(|r| r.y + r.h).unwrap_or(0.0);
             let start_idx = first_row_at_or_after(&rows, band_top);
-            let mut first_painted_y = f32::NAN;
-            let mut last_painted_y = f32::NAN;
-            let mut rows_iterated = 0usize;
 
             for row in rows[start_idx..].iter() {
                 if row.y > band_bottom {
                     break;
                 }
                 let row_in_viewport = row.y + row.h > viewport_top && row.y < viewport_bottom;
-                rows_iterated += 1;
-                if first_painted_y.is_nan() {
-                    first_painted_y = row.y;
-                }
-                last_painted_y = row.y + row.h;
                 for it in &row.items {
                     let bucket = bucket_for_row_height(row.h, self.quality.get());
                     let asset = model.item(it.asset_index).and_downcast::<AssetObject>();
@@ -436,34 +211,10 @@ mod imp {
             drop(rows);
             to_load.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
 
-            let adj_info = self
-                .vadjustment
-                .borrow()
-                .as_ref()
-                .map(|a| {
-                    format!(
-                        "adj.value={:.0} adj.upper={:.0} adj.page={:.0}",
-                        a.value(),
-                        a.upper(),
-                        a.page_size()
-                    )
-                })
-                .unwrap_or_else(|| "adj=none".to_string());
             let (cache_n, cache_bytes, cache_max, cache_evicts) = cache.cache_stats();
             log::debug!(
-                "masonry snapshot canvas=({:.0}x{:.0}) scroll_y={:.0} viewport_h={:.0} band=[{:.0},{:.0}] rows={} start_idx={} iterated={} painted_y=[{:.0},{:.0}] layout_h={:.0} painted={} hits={} misses={} pending={} queued={} cache_n={} cache_mb={}/{} evicts={} {}",
-                canvas_w,
-                canvas_h,
+                "masonry snapshot y={:.0} painted={} hits={} misses={} pending={} queued={} cache={}/{}/{}MB evicts={}",
                 scroll_y,
-                viewport_h,
-                band_top,
-                band_bottom,
-                row_count,
-                start_idx,
-                rows_iterated,
-                first_painted_y,
-                last_painted_y,
-                last_row_bottom,
                 painted,
                 hits,
                 misses,
@@ -473,7 +224,6 @@ mod imp {
                 cache_bytes / (1024 * 1024),
                 cache_max / (1024 * 1024),
                 cache_evicts,
-                adj_info,
             );
 
             for (_, asset_id, bucket, local_path, is_local) in to_load {
@@ -536,13 +286,7 @@ mod imp {
                 if let Some(sw) = w.downcast_ref::<gtk::ScrolledWindow>() {
                     let adj = sw.vadjustment();
                     let weak = self.obj().downgrade();
-                    adj.connect_value_changed(move |a| {
-                        log::trace!(
-                            "masonry vadjustment value_changed value={:.0} upper={:.0} page={:.0}",
-                            a.value(),
-                            a.upper(),
-                            a.page_size()
-                        );
+                    adj.connect_value_changed(move |_| {
                         if let Some(canvas) = weak.upgrade() {
                             canvas.queue_draw();
                         }
@@ -571,7 +315,7 @@ mod imp {
             let widget = self.obj().clone();
             let id_for_remove = asset_id.clone();
             let is_cancelled = || false;
-            log::debug!(
+            log::trace!(
                 "masonry spawn_load id={} bucket={:?} local={}",
                 asset_id,
                 bucket,
@@ -591,7 +335,7 @@ mod imp {
                 match &result {
                     Ok(tex) => {
                         dims_changed = propagate_dimensions(&model, &asset_id, tex);
-                        log::debug!(
+                        log::trace!(
                             "masonry load OK id={} dims=({}x{})",
                             asset_id,
                             tex.width(),
@@ -602,7 +346,7 @@ mod imp {
                         if e != "cancelled" {
                             imp.failed.borrow_mut().insert(asset_id.clone());
                         }
-                        log::debug!("masonry load ERR id={} err={}", asset_id, e);
+                        log::warn!("masonry load ERR id={} err={}", asset_id, e);
                     }
                 }
                 imp.pending.borrow_mut().remove(&id_for_remove);
@@ -615,71 +359,7 @@ mod imp {
     }
 }
 
-fn collect_dims(model: &LibraryAssetModel) -> Vec<(u32, u32)> {
-    let n = model.n_items();
-    let mut out = Vec::with_capacity(n as usize);
-    for i in 0..n {
-        if let Some(obj) = model.item(i).and_downcast::<AssetObject>() {
-            out.push((obj.property::<u32>("width"), obj.property::<u32>("height")));
-        } else {
-            out.push((0, 0));
-        }
-    }
-    out
-}
-
-/// Try requested bucket, then walk `fallback_bucket` chain on 404. Only the
-/// 404 path is retried — auth, network, etc. surface unchanged.
-async fn load_with_fallback<F: Fn() -> bool>(
-    cache: &ThumbnailCache,
-    asset_id: &str,
-    requested: ThumbnailSize,
-    is_cancelled: &F,
-) -> Result<Texture, String> {
-    let mut current = requested;
-    loop {
-        match cache
-            .load_thumbnail_cancellable(asset_id, current, is_cancelled)
-            .await
-        {
-            Ok(tex) => return Ok(tex),
-            Err(e) if e.contains("404") => match fallback_bucket(current) {
-                Some(next) => {
-                    log::debug!(
-                        "masonry fallback id={} {:?} -> {:?} ({})",
-                        asset_id,
-                        current,
-                        next,
-                        e
-                    );
-                    current = next;
-                }
-                None => return Err(e),
-            },
-            Err(e) => return Err(e),
-        }
-    }
-}
-
-/// Returns true if the AssetObject dimensions were filled in (relayout needed).
-fn propagate_dimensions(model: &LibraryAssetModel, asset_id: &str, tex: &Texture) -> bool {
-    let n = model.n_items();
-    for i in 0..n {
-        if let Some(obj) = model.item(i).and_downcast::<AssetObject>()
-            && obj.property::<String>("id") == asset_id
-        {
-            let w = obj.property::<u32>("width");
-            let h = obj.property::<u32>("height");
-            if w == 0 || h == 0 {
-                obj.set_property("width", tex.width() as u32);
-                obj.set_property("height", tex.height() as u32);
-                return true;
-            }
-            return false;
-        }
-    }
-    false
-}
+use crate::library::masonry::load::{collect_dims, load_with_fallback, propagate_dimensions};
 
 glib::wrapper! {
     pub struct MasonryCanvas(ObjectSubclass<imp::MasonryCanvas>)
@@ -849,192 +529,5 @@ impl MasonryCanvas {
             }
         });
         self.add_controller(secondary);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn cfg() -> LayoutConfig {
-        LayoutConfig {
-            min_row_height: 100.0,
-            max_row_height: 200.0,
-            gap: 0.0,
-        }
-    }
-
-    #[test]
-    fn empty_input_yields_empty_layout() {
-        let (rows, h) = pack_rows(&[], 1000.0, cfg());
-        assert!(rows.is_empty());
-        assert_eq!(h, 0.0);
-    }
-
-    #[test]
-    fn zero_canvas_width_yields_empty() {
-        let (rows, h) = pack_rows(&[(100, 100)], 0.0, cfg());
-        assert!(rows.is_empty());
-        assert_eq!(h, 0.0);
-    }
-
-    #[test]
-    fn fallback_aspect_when_dimensions_zero() {
-        let (rows, _) = pack_rows(&[(0, 0), (0, 0), (0, 0)], 1200.0, cfg());
-        assert_eq!(rows.len(), 1);
-        assert!((rows[0].h - 200.0).abs() < 0.01);
-    }
-
-    #[test]
-    fn full_row_fills_canvas_width_within_a_pixel() {
-        let dims = &[(1600, 900), (1600, 900), (1600, 900), (1600, 900)];
-        let (rows, _) = pack_rows(dims, 1200.0, cfg());
-        let r1 = &rows[0];
-        let last = r1.items.last().unwrap();
-        let fill = last.x + last.w;
-        assert!((fill - 1200.0).abs() < 1.0);
-    }
-
-    #[test]
-    fn all_items_placed_across_rows() {
-        let dims: Vec<(u32, u32)> = (0..8).map(|_| (3000, 1000)).collect();
-        let (rows, _) = pack_rows(&dims, 1200.0, cfg());
-        let total: usize = rows.iter().map(|r| r.items.len()).sum();
-        assert_eq!(total, 8);
-    }
-
-    #[test]
-    fn last_row_clamped_to_max_height() {
-        let mut dims: Vec<(u32, u32)> = (0..6).map(|_| (4000, 3000)).collect();
-        dims.push((1000, 1500));
-        let (rows, _) = pack_rows(&dims, 1200.0, cfg());
-        let last = rows.last().unwrap();
-        assert!(last.h <= 200.0 + 0.01);
-    }
-
-    #[test]
-    fn binary_search_finds_correct_row() {
-        let rows = vec![
-            LaidRow {
-                y: 0.0,
-                h: 100.0,
-                items: vec![],
-            },
-            LaidRow {
-                y: 100.0,
-                h: 150.0,
-                items: vec![],
-            },
-            LaidRow {
-                y: 250.0,
-                h: 80.0,
-                items: vec![],
-            },
-        ];
-        assert_eq!(row_at_y(&rows, 0.0), Some(0));
-        assert_eq!(row_at_y(&rows, 100.0), Some(1));
-        assert_eq!(row_at_y(&rows, 329.9), Some(2));
-        assert_eq!(row_at_y(&rows, 330.0), None);
-    }
-
-    #[test]
-    fn item_hit_test_within_row() {
-        let row = LaidRow {
-            y: 0.0,
-            h: 100.0,
-            items: vec![
-                LaidItem {
-                    asset_index: 5,
-                    x: 0.0,
-                    w: 50.0,
-                },
-                LaidItem {
-                    asset_index: 6,
-                    x: 50.0,
-                    w: 80.0,
-                },
-                LaidItem {
-                    asset_index: 7,
-                    x: 130.0,
-                    w: 40.0,
-                },
-            ],
-        };
-        assert_eq!(item_at_x(&row, 0.0).map(|i| i.asset_index), Some(5));
-        assert_eq!(item_at_x(&row, 50.0).map(|i| i.asset_index), Some(6));
-        assert_eq!(item_at_x(&row, 130.0).map(|i| i.asset_index), Some(7));
-        assert!(item_at_x(&row, 200.0).is_none());
-    }
-
-    #[test]
-    fn gap_increases_total_layout_height() {
-        let dims = &[(100, 100), (100, 100), (100, 100), (100, 100)];
-        let (_, h0) = pack_rows(dims, 200.0, LayoutConfig { gap: 0.0, ..cfg() });
-        let (_, h1) = pack_rows(dims, 200.0, LayoutConfig { gap: 10.0, ..cfg() });
-        assert!(h1 > h0);
-    }
-
-    #[test]
-    fn bucket_thumbnail_under_threshold() {
-        assert!(matches!(
-            bucket_for_row_height(200.0, GridQuality::Auto),
-            ThumbnailSize::Thumbnail
-        ));
-        assert!(matches!(
-            bucket_for_row_height(PREVIEW_BUCKET_THRESHOLD, GridQuality::Auto),
-            ThumbnailSize::Thumbnail
-        ));
-        assert!(matches!(
-            bucket_for_row_height(PREVIEW_BUCKET_THRESHOLD + 1.0, GridQuality::Auto),
-            ThumbnailSize::Preview
-        ));
-    }
-
-    #[test]
-    fn explicit_quality_overrides_row_height() {
-        assert!(matches!(
-            bucket_for_row_height(2000.0, GridQuality::Thumbnail),
-            ThumbnailSize::Thumbnail
-        ));
-        assert!(matches!(
-            bucket_for_row_height(50.0, GridQuality::Fullsize),
-            ThumbnailSize::Fullsize
-        ));
-    }
-
-    #[test]
-    fn first_row_skip_lands_on_intersecting_row() {
-        let rows = vec![
-            LaidRow {
-                y: 0.0,
-                h: 100.0,
-                items: vec![],
-            },
-            LaidRow {
-                y: 100.0,
-                h: 100.0,
-                items: vec![],
-            },
-            LaidRow {
-                y: 200.0,
-                h: 100.0,
-                items: vec![],
-            },
-        ];
-        assert_eq!(first_row_at_or_after(&rows, -50.0), 0);
-        assert_eq!(first_row_at_or_after(&rows, 0.0), 0);
-        assert_eq!(first_row_at_or_after(&rows, 150.0), 1);
-        assert_eq!(first_row_at_or_after(&rows, 250.0), 2);
-        assert_eq!(first_row_at_or_after(&rows, 500.0), 3);
-    }
-
-    #[test]
-    fn fallback_chain_degrades_fullsize_to_preview() {
-        assert_eq!(
-            fallback_bucket(ThumbnailSize::Fullsize),
-            Some(ThumbnailSize::Preview)
-        );
-        assert_eq!(fallback_bucket(ThumbnailSize::Preview), None);
-        assert_eq!(fallback_bucket(ThumbnailSize::Thumbnail), None);
     }
 }

--- a/src/library/masonry_canvas.rs
+++ b/src/library/masonry_canvas.rs
@@ -1,0 +1,788 @@
+//! Justified-row masonry layout for the photos grid.
+
+use std::cell::{Cell, OnceCell, RefCell};
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
+use std::sync::Arc;
+
+use gdk4::Texture;
+use gtk::glib;
+use gtk::graphene::{Rect, Size};
+use gtk::gsk::RoundedRect;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+
+use crate::api_client::ThumbnailSize;
+use crate::library::asset_model::LibraryAssetModel;
+use crate::library::asset_object::AssetObject;
+use crate::library::grid_view::AssetContextMenuHandler;
+use crate::library::thumbnail_cache::ThumbnailCache;
+
+type ActivateHandler = Rc<dyn Fn(u32)>;
+type SelectModeChanger = Rc<dyn Fn(bool)>;
+
+const FALLBACK_W: f32 = 4.0;
+const FALLBACK_H: f32 = 3.0;
+
+pub(super) const MIN_ROW_HEIGHT_NARROW: f32 = 120.0;
+pub(super) const MAX_ROW_HEIGHT_NARROW: f32 = 240.0;
+pub(super) const MIN_ROW_HEIGHT_WIDE: f32 = 180.0;
+pub(super) const MAX_ROW_HEIGHT_WIDE: f32 = 360.0;
+
+pub(super) const GAP: f32 = 0.0;
+pub(super) const CORNER_RADIUS: f32 = 0.0;
+
+/// Row height above which we request the larger Preview thumbnail.
+const PREVIEW_BUCKET_THRESHOLD: f32 = 280.0;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LaidItem {
+    pub asset_index: u32,
+    pub x: f32,
+    pub w: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LaidRow {
+    pub y: f32,
+    pub h: f32,
+    pub items: Vec<LaidItem>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LayoutConfig {
+    pub min_row_height: f32,
+    pub max_row_height: f32,
+    pub gap: f32,
+}
+
+impl LayoutConfig {
+    pub(super) fn narrow() -> Self {
+        Self {
+            min_row_height: MIN_ROW_HEIGHT_NARROW,
+            max_row_height: MAX_ROW_HEIGHT_NARROW,
+            gap: GAP,
+        }
+    }
+
+    pub(super) fn wide() -> Self {
+        Self {
+            min_row_height: MIN_ROW_HEIGHT_WIDE,
+            max_row_height: MAX_ROW_HEIGHT_WIDE,
+            gap: GAP,
+        }
+    }
+}
+
+fn aspect(width: u32, height: u32) -> f32 {
+    if width == 0 || height == 0 {
+        FALLBACK_W / FALLBACK_H
+    } else {
+        (width as f32) / (height as f32)
+    }
+}
+
+/// Greedy justified-row pack. `dims[i] = (w, h)` for asset i.
+pub(super) fn pack_rows(
+    dims: &[(u32, u32)],
+    canvas_w: f32,
+    cfg: LayoutConfig,
+) -> (Vec<LaidRow>, f32) {
+    if dims.is_empty() || canvas_w <= 0.0 {
+        return (Vec::new(), 0.0);
+    }
+
+    let mut rows: Vec<LaidRow> = Vec::new();
+    let mut y_cursor = 0.0_f32;
+    let mut i = 0_usize;
+
+    while i < dims.len() {
+        let mut indices: Vec<usize> = Vec::new();
+        let mut summed_w = 0.0_f32;
+        while i < dims.len() {
+            let w_at_max = aspect(dims[i].0, dims[i].1) * cfg.max_row_height;
+            let gap_before = if indices.is_empty() { 0.0 } else { cfg.gap };
+            if !indices.is_empty() && summed_w + gap_before + w_at_max > canvas_w {
+                break;
+            }
+            indices.push(i);
+            summed_w += w_at_max + gap_before;
+            i += 1;
+        }
+        let last_row = i >= dims.len() && summed_w + cfg.gap < canvas_w;
+
+        let mut row_h = scale_to_fit(&indices, dims, canvas_w, cfg);
+
+        // Pop the trailing item if the row is too short — it spills to the next row.
+        if indices.len() > 1 && row_h < cfg.min_row_height {
+            let popped = indices.pop().unwrap();
+            i = popped;
+            row_h = scale_to_fit(&indices, dims, canvas_w, cfg);
+        }
+
+        // Filled rows keep their computed height so the row reaches canvas_w.
+        // Only the underfilled trailing row is clamped.
+        if last_row {
+            row_h = row_h.clamp(cfg.min_row_height, cfg.max_row_height);
+        }
+
+        let mut placed = Vec::with_capacity(indices.len());
+        let mut x_cursor = 0.0_f32;
+        for &idx in &indices {
+            let w = aspect(dims[idx].0, dims[idx].1) * row_h;
+            placed.push(LaidItem {
+                asset_index: idx as u32,
+                x: x_cursor,
+                w,
+            });
+            x_cursor += w + cfg.gap;
+        }
+
+        rows.push(LaidRow {
+            y: y_cursor,
+            h: row_h,
+            items: placed,
+        });
+        y_cursor += row_h + cfg.gap;
+    }
+
+    let total_height = (y_cursor - cfg.gap).max(0.0);
+    (rows, total_height)
+}
+
+fn scale_to_fit(indices: &[usize], dims: &[(u32, u32)], canvas_w: f32, cfg: LayoutConfig) -> f32 {
+    let total_gap = if indices.len() > 1 {
+        cfg.gap * (indices.len() as f32 - 1.0)
+    } else {
+        0.0
+    };
+    let sum: f32 = indices
+        .iter()
+        .map(|&idx| aspect(dims[idx].0, dims[idx].1) * cfg.max_row_height)
+        .sum();
+    if sum <= 0.0 {
+        return cfg.max_row_height;
+    }
+    let scale = ((canvas_w - total_gap) / sum).max(0.0);
+    cfg.max_row_height * scale
+}
+
+pub(super) fn row_at_y(rows: &[LaidRow], y: f32) -> Option<usize> {
+    if rows.is_empty() {
+        return None;
+    }
+    let mut lo = 0;
+    let mut hi = rows.len();
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        let r = &rows[mid];
+        if y < r.y {
+            hi = mid;
+        } else if y >= r.y + r.h {
+            lo = mid + 1;
+        } else {
+            return Some(mid);
+        }
+    }
+    None
+}
+
+pub(super) fn item_at_x(row: &LaidRow, x: f32) -> Option<&LaidItem> {
+    row.items.iter().find(|it| x >= it.x && x < it.x + it.w)
+}
+
+fn bucket_for_row_height(h: f32) -> ThumbnailSize {
+    if h <= PREVIEW_BUCKET_THRESHOLD {
+        ThumbnailSize::Thumbnail
+    } else {
+        ThumbnailSize::Preview
+    }
+}
+
+mod imp {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct MasonryCanvas {
+        pub model: OnceCell<LibraryAssetModel>,
+        pub cache: OnceCell<Arc<ThumbnailCache>>,
+        pub selection: OnceCell<gtk::MultiSelection>,
+        pub narrow: Cell<bool>,
+        pub select_mode: Cell<bool>,
+        pub rows: RefCell<Vec<LaidRow>>,
+        pub cached_width: Cell<f32>,
+        pub layout_h: Cell<f32>,
+        pub pending: RefCell<HashSet<String>>,
+        /// Textures retained per asset so re-painting after scroll never has
+        /// to re-fetch when the shared ThumbnailCache LRU evicts.
+        pub textures: RefCell<HashMap<String, Texture>>,
+        pub vadjustment: RefCell<Option<gtk::Adjustment>>,
+        pub activate_handler: RefCell<Option<ActivateHandler>>,
+        pub context_menu_handler: RefCell<Option<AssetContextMenuHandler>>,
+        pub select_mode_changer: RefCell<Option<SelectModeChanger>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MasonryCanvas {
+        const NAME: &'static str = "MimickMasonryCanvas";
+        type Type = super::MasonryCanvas;
+        type ParentType = gtk::Widget;
+    }
+
+    impl ObjectImpl for MasonryCanvas {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.obj().add_css_class("mimick-masonry-canvas");
+            self.cached_width.set(-1.0);
+        }
+    }
+
+    impl WidgetImpl for MasonryCanvas {
+        fn request_mode(&self) -> gtk::SizeRequestMode {
+            gtk::SizeRequestMode::HeightForWidth
+        }
+
+        fn measure(&self, orientation: gtk::Orientation, for_size: i32) -> (i32, i32, i32, i32) {
+            match orientation {
+                gtk::Orientation::Horizontal => (0, 0, -1, -1),
+                _ => {
+                    let width = for_size.max(0) as f32;
+                    let h = self.layout_for_width(width);
+                    let h_i = h.ceil() as i32;
+                    (h_i, h_i, -1, -1)
+                }
+            }
+        }
+
+        fn size_allocate(&self, width: i32, _height: i32, _baseline: i32) {
+            let _ = self.layout_for_width(width.max(0) as f32);
+        }
+
+        fn snapshot(&self, snapshot: &gtk::Snapshot) {
+            let widget = self.obj();
+            let canvas_w = widget.width() as f32;
+            if canvas_w <= 0.0 {
+                return;
+            }
+            let _ = self.layout_for_width(canvas_w);
+
+            let (scroll_y, viewport_h) = self.viewport();
+            let visible_top = scroll_y;
+            let visible_bottom = scroll_y + viewport_h;
+
+            let rows = self.rows.borrow();
+            let Some(model) = self.model.get() else {
+                return;
+            };
+            let Some(cache) = self.cache.get() else {
+                return;
+            };
+
+            let placeholder = gdk4::RGBA::new(0.18, 0.18, 0.18, 1.0);
+            let select_tint = gdk4::RGBA::new(0.30, 0.55, 0.95, 0.35);
+            let selection = self.selection.get();
+            let mut needs_load: Vec<(String, ThumbnailSize, String, bool)> = Vec::new();
+
+            for row in rows.iter() {
+                if row.y + row.h < visible_top {
+                    continue;
+                }
+                if row.y > visible_bottom {
+                    break;
+                }
+                for it in &row.items {
+                    let rect = Rect::new(it.x, row.y, it.w, row.h);
+                    let bucket = bucket_for_row_height(row.h);
+                    let Some(asset) = model.item(it.asset_index).and_downcast::<AssetObject>()
+                    else {
+                        continue;
+                    };
+                    let asset_id = asset.property::<String>("id");
+                    let local_path = asset.property::<String>("local-path");
+                    let is_local_only = !local_path.is_empty()
+                        && asset_id.starts_with(crate::library::LOCAL_ID_PREFIX);
+
+                    let cached = self.textures.borrow().get(&asset_id).cloned().or_else(|| {
+                        if is_local_only {
+                            None
+                        } else {
+                            cache.get_cached(&asset_id, bucket)
+                        }
+                    });
+                    let clipped = CORNER_RADIUS > 0.0;
+                    if clipped {
+                        let corner = Size::new(CORNER_RADIUS, CORNER_RADIUS);
+                        let rounded = RoundedRect::new(rect, corner, corner, corner, corner);
+                        snapshot.push_rounded_clip(&rounded);
+                    }
+                    if let Some(tex) = cached {
+                        snapshot.append_texture(&tex, &rect);
+                    } else {
+                        snapshot.append_color(&placeholder, &rect);
+                        let mut pending = self.pending.borrow_mut();
+                        if !pending.contains(&asset_id) {
+                            pending.insert(asset_id.clone());
+                            needs_load.push((asset_id, bucket, local_path, is_local_only));
+                        }
+                    }
+                    let selected = selection
+                        .map(|s| s.is_selected(it.asset_index))
+                        .unwrap_or(false);
+                    if selected {
+                        snapshot.append_color(&select_tint, &rect);
+                    }
+                    if clipped {
+                        snapshot.pop();
+                    }
+                }
+            }
+            drop(rows);
+
+            for (asset_id, bucket, local_path, is_local) in needs_load {
+                self.spawn_load(asset_id, bucket, local_path, is_local);
+            }
+        }
+    }
+
+    impl MasonryCanvas {
+        fn cfg(&self) -> LayoutConfig {
+            if self.narrow.get() {
+                LayoutConfig::narrow()
+            } else {
+                LayoutConfig::wide()
+            }
+        }
+
+        fn layout_for_width(&self, width: f32) -> f32 {
+            let cached = self.cached_width.get();
+            if (width - cached).abs() < 0.5 && cached >= 0.0 {
+                return self.layout_h.get();
+            }
+            let Some(model) = self.model.get() else {
+                self.cached_width.set(width);
+                self.layout_h.set(0.0);
+                return 0.0;
+            };
+            let dims = collect_dims(model);
+            let (rows, h) = pack_rows(&dims, width, self.cfg());
+            *self.rows.borrow_mut() = rows;
+            self.cached_width.set(width);
+            self.layout_h.set(h);
+            h
+        }
+
+        pub(super) fn invalidate_layout(&self) {
+            // Pending and textures are NOT cleared here — they are independent
+            // of layout and are owned per-asset across reflows.
+            self.cached_width.set(-1.0);
+            self.layout_h.set(0.0);
+            self.rows.borrow_mut().clear();
+            self.obj().queue_resize();
+        }
+
+        fn viewport(&self) -> (f32, f32) {
+            let adj = self.find_vadjustment();
+            if let Some(adj) = adj {
+                (adj.value() as f32, adj.page_size() as f32)
+            } else {
+                (0.0, self.obj().height() as f32)
+            }
+        }
+
+        fn find_vadjustment(&self) -> Option<gtk::Adjustment> {
+            if let Some(adj) = self.vadjustment.borrow().clone() {
+                return Some(adj);
+            }
+            let mut node: Option<gtk::Widget> = self.obj().parent();
+            while let Some(w) = node {
+                if let Some(sw) = w.downcast_ref::<gtk::ScrolledWindow>() {
+                    let adj = sw.vadjustment();
+                    *self.vadjustment.borrow_mut() = Some(adj.clone());
+                    return Some(adj);
+                }
+                node = w.parent();
+            }
+            None
+        }
+
+        fn spawn_load(
+            &self,
+            asset_id: String,
+            bucket: ThumbnailSize,
+            local_path: String,
+            is_local: bool,
+        ) {
+            let Some(cache) = self.cache.get().cloned() else {
+                return;
+            };
+            let Some(model) = self.model.get().cloned() else {
+                return;
+            };
+            let widget = self.obj().clone();
+            let id_for_remove = asset_id.clone();
+            // Off-screen loads cancel by reading the live pending set: each
+            // snapshot drops ids that are no longer visible, so backlogged
+            // loads can release their semaphore permit.
+            let cancel_widget = widget.downgrade();
+            let cancel_id = asset_id.clone();
+            let is_cancelled = move || {
+                let Some(w) = cancel_widget.upgrade() else {
+                    return true;
+                };
+                !w.imp().pending.borrow().contains(&cancel_id)
+            };
+            glib::MainContext::default().spawn_local(async move {
+                let result = if is_local {
+                    let path = std::path::PathBuf::from(&local_path);
+                    cache
+                        .load_local_thumbnail_cancellable(&asset_id, &path, is_cancelled)
+                        .await
+                } else {
+                    cache
+                        .load_thumbnail_cancellable(&asset_id, bucket, is_cancelled)
+                        .await
+                };
+                let imp = widget.imp();
+                let mut dims_changed = false;
+                if let Ok(tex) = result {
+                    dims_changed = propagate_dimensions(&model, &asset_id, &tex);
+                    imp.textures.borrow_mut().insert(asset_id.clone(), tex);
+                }
+                imp.pending.borrow_mut().remove(&id_for_remove);
+                if dims_changed {
+                    imp.invalidate_layout();
+                }
+                widget.queue_draw();
+            });
+        }
+    }
+}
+
+fn collect_dims(model: &LibraryAssetModel) -> Vec<(u32, u32)> {
+    let n = model.n_items();
+    let mut out = Vec::with_capacity(n as usize);
+    for i in 0..n {
+        if let Some(obj) = model.item(i).and_downcast::<AssetObject>() {
+            out.push((obj.property::<u32>("width"), obj.property::<u32>("height")));
+        } else {
+            out.push((0, 0));
+        }
+    }
+    out
+}
+
+/// Returns true if the AssetObject dimensions were filled in (relayout needed).
+fn propagate_dimensions(model: &LibraryAssetModel, asset_id: &str, tex: &Texture) -> bool {
+    let n = model.n_items();
+    for i in 0..n {
+        if let Some(obj) = model.item(i).and_downcast::<AssetObject>()
+            && obj.property::<String>("id") == asset_id
+        {
+            let w = obj.property::<u32>("width");
+            let h = obj.property::<u32>("height");
+            if w == 0 || h == 0 {
+                obj.set_property("width", tex.width() as u32);
+                obj.set_property("height", tex.height() as u32);
+                return true;
+            }
+            return false;
+        }
+    }
+    false
+}
+
+glib::wrapper! {
+    pub struct MasonryCanvas(ObjectSubclass<imp::MasonryCanvas>)
+        @extends gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
+}
+
+impl Default for MasonryCanvas {
+    fn default() -> Self {
+        glib::Object::new()
+    }
+}
+
+impl MasonryCanvas {
+    pub fn new(
+        cache: Arc<ThumbnailCache>,
+        model: LibraryAssetModel,
+        selection: gtk::MultiSelection,
+    ) -> Self {
+        let canvas: Self = glib::Object::new();
+        let imp = canvas.imp();
+        let _ = imp.cache.set(cache);
+        let _ = imp.model.set(model.clone());
+        let _ = imp.selection.set(selection.clone());
+
+        let weak = canvas.downgrade();
+        model.connect_items_changed(move |model, _, _, _| {
+            if let Some(canvas) = weak.upgrade() {
+                // Drop only textures whose asset_id is no longer in the model.
+                // Avoids wiping retained textures on append-pagination that
+                // emits a full-range items_changed (client-sorted modes).
+                let imp = canvas.imp();
+                let n = model.n_items();
+                let mut current_ids: HashSet<String> = HashSet::with_capacity(n as usize);
+                for i in 0..n {
+                    if let Some(obj) = model.item(i).and_downcast::<AssetObject>() {
+                        current_ids.insert(obj.property::<String>("id"));
+                    }
+                }
+                imp.textures
+                    .borrow_mut()
+                    .retain(|id, _| current_ids.contains(id));
+                imp.invalidate_layout();
+                canvas.queue_draw();
+            }
+        });
+
+        let weak = canvas.downgrade();
+        selection.connect_selection_changed(move |_, _, _| {
+            if let Some(canvas) = weak.upgrade() {
+                canvas.queue_draw();
+            }
+        });
+
+        canvas.install_gestures();
+        canvas
+    }
+
+    pub fn set_narrow(&self, narrow: bool) {
+        let imp = self.imp();
+        if imp.narrow.replace(narrow) != narrow {
+            imp.invalidate_layout();
+            self.queue_draw();
+        }
+    }
+
+    pub fn set_select_mode(&self, on: bool) {
+        self.imp().select_mode.set(on);
+    }
+
+    pub fn set_activate_handler(&self, f: impl Fn(u32) + 'static) {
+        *self.imp().activate_handler.borrow_mut() = Some(Rc::new(f));
+    }
+
+    pub fn set_context_menu_handler(&self, handler: AssetContextMenuHandler) {
+        *self.imp().context_menu_handler.borrow_mut() = Some(handler);
+    }
+
+    pub fn set_select_mode_changer(&self, f: impl Fn(bool) + 'static) {
+        *self.imp().select_mode_changer.borrow_mut() = Some(Rc::new(f));
+    }
+
+    fn hit_test(&self, x: f64, y: f64) -> Option<u32> {
+        let rows = self.imp().rows.borrow();
+        let r = row_at_y(&rows, y as f32)?;
+        let row = &rows[r];
+        item_at_x(row, x as f32).map(|it| it.asset_index)
+    }
+
+    fn install_gestures(&self) {
+        let primary = gtk::GestureClick::new();
+        primary.set_button(gtk::gdk::BUTTON_PRIMARY);
+        let weak = self.downgrade();
+        primary.connect_pressed(move |gesture, _, x, y| {
+            let Some(canvas) = weak.upgrade() else {
+                return;
+            };
+            let Some(pos) = canvas.hit_test(x, y) else {
+                return;
+            };
+            let imp = canvas.imp();
+            let ctrl = gesture
+                .current_event_state()
+                .contains(gtk::gdk::ModifierType::CONTROL_MASK);
+            let Some(sel) = imp.selection.get() else {
+                return;
+            };
+
+            if ctrl {
+                if sel.is_selected(pos) {
+                    sel.unselect_item(pos);
+                } else {
+                    sel.select_item(pos, false);
+                }
+                if !imp.select_mode.get()
+                    && let Some(changer) = imp.select_mode_changer.borrow().clone()
+                {
+                    (*changer)(true);
+                }
+                return;
+            }
+
+            if imp.select_mode.get() {
+                if sel.is_selected(pos) {
+                    sel.unselect_item(pos);
+                } else {
+                    sel.select_item(pos, false);
+                }
+                return;
+            }
+
+            if let Some(handler) = imp.activate_handler.borrow().clone() {
+                (*handler)(pos);
+            }
+        });
+        self.add_controller(primary);
+
+        let secondary = gtk::GestureClick::new();
+        secondary.set_button(gtk::gdk::BUTTON_SECONDARY);
+        let weak = self.downgrade();
+        secondary.connect_pressed(move |_, _, x, y| {
+            let Some(canvas) = weak.upgrade() else {
+                return;
+            };
+            let Some(pos) = canvas.hit_test(x, y) else {
+                return;
+            };
+            let imp = canvas.imp();
+            if let Some(handler_cell) = imp.context_menu_handler.borrow().clone()
+                && let Some(cb) = handler_cell.borrow().as_ref()
+            {
+                (cb)(pos, x, y);
+            }
+        });
+        self.add_controller(secondary);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> LayoutConfig {
+        LayoutConfig {
+            min_row_height: 100.0,
+            max_row_height: 200.0,
+            gap: 0.0,
+        }
+    }
+
+    #[test]
+    fn empty_input_yields_empty_layout() {
+        let (rows, h) = pack_rows(&[], 1000.0, cfg());
+        assert!(rows.is_empty());
+        assert_eq!(h, 0.0);
+    }
+
+    #[test]
+    fn zero_canvas_width_yields_empty() {
+        let (rows, h) = pack_rows(&[(100, 100)], 0.0, cfg());
+        assert!(rows.is_empty());
+        assert_eq!(h, 0.0);
+    }
+
+    #[test]
+    fn fallback_aspect_when_dimensions_zero() {
+        let (rows, _) = pack_rows(&[(0, 0), (0, 0), (0, 0)], 1200.0, cfg());
+        assert_eq!(rows.len(), 1);
+        assert!((rows[0].h - 200.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn full_row_fills_canvas_width_within_a_pixel() {
+        let dims = &[(1600, 900), (1600, 900), (1600, 900), (1600, 900)];
+        let (rows, _) = pack_rows(dims, 1200.0, cfg());
+        let r1 = &rows[0];
+        let last = r1.items.last().unwrap();
+        let fill = last.x + last.w;
+        assert!((fill - 1200.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn all_items_placed_across_rows() {
+        let dims: Vec<(u32, u32)> = (0..8).map(|_| (3000, 1000)).collect();
+        let (rows, _) = pack_rows(&dims, 1200.0, cfg());
+        let total: usize = rows.iter().map(|r| r.items.len()).sum();
+        assert_eq!(total, 8);
+    }
+
+    #[test]
+    fn last_row_clamped_to_max_height() {
+        let mut dims: Vec<(u32, u32)> = (0..6).map(|_| (4000, 3000)).collect();
+        dims.push((1000, 1500));
+        let (rows, _) = pack_rows(&dims, 1200.0, cfg());
+        let last = rows.last().unwrap();
+        assert!(last.h <= 200.0 + 0.01);
+    }
+
+    #[test]
+    fn binary_search_finds_correct_row() {
+        let rows = vec![
+            LaidRow {
+                y: 0.0,
+                h: 100.0,
+                items: vec![],
+            },
+            LaidRow {
+                y: 100.0,
+                h: 150.0,
+                items: vec![],
+            },
+            LaidRow {
+                y: 250.0,
+                h: 80.0,
+                items: vec![],
+            },
+        ];
+        assert_eq!(row_at_y(&rows, 0.0), Some(0));
+        assert_eq!(row_at_y(&rows, 100.0), Some(1));
+        assert_eq!(row_at_y(&rows, 329.9), Some(2));
+        assert_eq!(row_at_y(&rows, 330.0), None);
+    }
+
+    #[test]
+    fn item_hit_test_within_row() {
+        let row = LaidRow {
+            y: 0.0,
+            h: 100.0,
+            items: vec![
+                LaidItem {
+                    asset_index: 5,
+                    x: 0.0,
+                    w: 50.0,
+                },
+                LaidItem {
+                    asset_index: 6,
+                    x: 50.0,
+                    w: 80.0,
+                },
+                LaidItem {
+                    asset_index: 7,
+                    x: 130.0,
+                    w: 40.0,
+                },
+            ],
+        };
+        assert_eq!(item_at_x(&row, 0.0).map(|i| i.asset_index), Some(5));
+        assert_eq!(item_at_x(&row, 50.0).map(|i| i.asset_index), Some(6));
+        assert_eq!(item_at_x(&row, 130.0).map(|i| i.asset_index), Some(7));
+        assert!(item_at_x(&row, 200.0).is_none());
+    }
+
+    #[test]
+    fn gap_increases_total_layout_height() {
+        let dims = &[(100, 100), (100, 100), (100, 100), (100, 100)];
+        let (_, h0) = pack_rows(dims, 200.0, LayoutConfig { gap: 0.0, ..cfg() });
+        let (_, h1) = pack_rows(dims, 200.0, LayoutConfig { gap: 10.0, ..cfg() });
+        assert!(h1 > h0);
+    }
+
+    #[test]
+    fn bucket_thumbnail_under_threshold() {
+        assert!(matches!(
+            bucket_for_row_height(200.0),
+            ThumbnailSize::Thumbnail
+        ));
+        assert!(matches!(
+            bucket_for_row_height(280.0),
+            ThumbnailSize::Thumbnail
+        ));
+        assert!(matches!(
+            bucket_for_row_height(281.0),
+            ThumbnailSize::Preview
+        ));
+    }
+}

--- a/src/library/masonry_canvas.rs
+++ b/src/library/masonry_canvas.rs
@@ -197,6 +197,7 @@ pub enum GridQuality {
     Auto,
     Thumbnail,
     Preview,
+    Fullsize,
 }
 
 impl GridQuality {
@@ -204,6 +205,7 @@ impl GridQuality {
         match s {
             "thumbnail" => Self::Thumbnail,
             "preview" => Self::Preview,
+            "fullsize" => Self::Fullsize,
             _ => Self::Auto,
         }
     }
@@ -213,6 +215,7 @@ fn bucket_for_row_height(h: f32, quality: GridQuality) -> ThumbnailSize {
     match quality {
         GridQuality::Thumbnail => ThumbnailSize::Thumbnail,
         GridQuality::Preview => ThumbnailSize::Preview,
+        GridQuality::Fullsize => ThumbnailSize::Fullsize,
         GridQuality::Auto => {
             if h <= PREVIEW_BUCKET_THRESHOLD {
                 ThumbnailSize::Thumbnail
@@ -220,6 +223,14 @@ fn bucket_for_row_height(h: f32, quality: GridQuality) -> ThumbnailSize {
                 ThumbnailSize::Preview
             }
         }
+    }
+}
+
+/// Smaller size to try when a requested bucket isn't available on the server.
+fn fallback_bucket(size: ThumbnailSize) -> Option<ThumbnailSize> {
+    match size {
+        ThumbnailSize::Fullsize => Some(ThumbnailSize::Preview),
+        ThumbnailSize::Preview | ThumbnailSize::Thumbnail => None,
     }
 }
 
@@ -337,7 +348,10 @@ mod imp {
                     } else {
                         bucket
                     };
-                    let cached = cache.get_cached(&asset_id, lookup_bucket);
+                    let cached = cache.get_cached(&asset_id, lookup_bucket).or_else(|| {
+                        fallback_bucket(lookup_bucket)
+                            .and_then(|fb| cache.get_cached(&asset_id, fb))
+                    });
 
                     let rect = Rect::new(it.x, row.y, it.w, row.h);
                     let clipped = CORNER_RADIUS > 0.0;
@@ -486,12 +500,10 @@ mod imp {
                 let result = if is_local {
                     let path = std::path::PathBuf::from(&local_path);
                     cache
-                        .load_local_thumbnail_cancellable(&asset_id, &path, is_cancelled)
+                        .load_local_thumbnail_cancellable(&asset_id, &path, &is_cancelled)
                         .await
                 } else {
-                    cache
-                        .load_thumbnail_cancellable(&asset_id, bucket, is_cancelled)
-                        .await
+                    load_with_fallback(&cache, &asset_id, bucket, &is_cancelled).await
                 };
                 let imp = widget.imp();
                 let mut dims_changed = false;
@@ -533,6 +545,39 @@ fn collect_dims(model: &LibraryAssetModel) -> Vec<(u32, u32)> {
         }
     }
     out
+}
+
+/// Try requested bucket, then walk `fallback_bucket` chain on 404. Only the
+/// 404 path is retried — auth, network, etc. surface unchanged.
+async fn load_with_fallback<F: Fn() -> bool>(
+    cache: &ThumbnailCache,
+    asset_id: &str,
+    requested: ThumbnailSize,
+    is_cancelled: &F,
+) -> Result<Texture, String> {
+    let mut current = requested;
+    loop {
+        match cache
+            .load_thumbnail_cancellable(asset_id, current, is_cancelled)
+            .await
+        {
+            Ok(tex) => return Ok(tex),
+            Err(e) if e.contains("404") => match fallback_bucket(current) {
+                Some(next) => {
+                    log::debug!(
+                        "masonry fallback id={} {:?} -> {:?} ({})",
+                        asset_id,
+                        current,
+                        next,
+                        e
+                    );
+                    current = next;
+                }
+                None => return Err(e),
+            },
+            Err(e) => return Err(e),
+        }
+    }
 }
 
 /// Returns true if the AssetObject dimensions were filled in (relayout needed).
@@ -859,5 +904,27 @@ mod tests {
             bucket_for_row_height(PREVIEW_BUCKET_THRESHOLD + 1.0, GridQuality::Auto),
             ThumbnailSize::Preview
         ));
+    }
+
+    #[test]
+    fn explicit_quality_overrides_row_height() {
+        assert!(matches!(
+            bucket_for_row_height(2000.0, GridQuality::Thumbnail),
+            ThumbnailSize::Thumbnail
+        ));
+        assert!(matches!(
+            bucket_for_row_height(50.0, GridQuality::Fullsize),
+            ThumbnailSize::Fullsize
+        ));
+    }
+
+    #[test]
+    fn fallback_chain_degrades_fullsize_to_preview() {
+        assert_eq!(
+            fallback_bucket(ThumbnailSize::Fullsize),
+            Some(ThumbnailSize::Preview)
+        );
+        assert_eq!(fallback_bucket(ThumbnailSize::Preview), None);
+        assert_eq!(fallback_bucket(ThumbnailSize::Thumbnail), None);
     }
 }

--- a/src/library/masonry_canvas.rs
+++ b/src/library/masonry_canvas.rs
@@ -1,7 +1,7 @@
 //! Justified-row masonry layout for the photos grid.
 
 use std::cell::{Cell, OnceCell, RefCell};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -191,11 +191,35 @@ pub(super) fn item_at_x(row: &LaidRow, x: f32) -> Option<&LaidItem> {
     row.items.iter().find(|it| x >= it.x && x < it.x + it.w)
 }
 
-fn bucket_for_row_height(h: f32) -> ThumbnailSize {
-    if h <= PREVIEW_BUCKET_THRESHOLD {
-        ThumbnailSize::Thumbnail
-    } else {
-        ThumbnailSize::Preview
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GridQuality {
+    #[default]
+    Auto,
+    Thumbnail,
+    Preview,
+}
+
+impl GridQuality {
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "thumbnail" => Self::Thumbnail,
+            "preview" => Self::Preview,
+            _ => Self::Auto,
+        }
+    }
+}
+
+fn bucket_for_row_height(h: f32, quality: GridQuality) -> ThumbnailSize {
+    match quality {
+        GridQuality::Thumbnail => ThumbnailSize::Thumbnail,
+        GridQuality::Preview => ThumbnailSize::Preview,
+        GridQuality::Auto => {
+            if h <= PREVIEW_BUCKET_THRESHOLD {
+                ThumbnailSize::Thumbnail
+            } else {
+                ThumbnailSize::Preview
+            }
+        }
     }
 }
 
@@ -209,14 +233,13 @@ mod imp {
         pub selection: OnceCell<gtk::MultiSelection>,
         pub narrow: Cell<bool>,
         pub select_mode: Cell<bool>,
+        pub quality: Cell<GridQuality>,
         pub rows: RefCell<Vec<LaidRow>>,
         pub cached_width: Cell<f32>,
         pub layout_h: Cell<f32>,
         pub pending: RefCell<HashSet<String>>,
         /// Permanently failed ids; skipped to avoid re-queueing every frame.
         pub failed: RefCell<HashSet<String>>,
-        /// Per-canvas texture retain to survive shared cache eviction.
-        pub textures: RefCell<HashMap<String, Texture>>,
         pub vadjustment: RefCell<Option<gtk::Adjustment>>,
         pub activate_handler: RefCell<Option<ActivateHandler>>,
         pub context_menu_handler: RefCell<Option<AssetContextMenuHandler>>,
@@ -299,7 +322,7 @@ mod imp {
 
             for row in rows.iter() {
                 for it in &row.items {
-                    let bucket = bucket_for_row_height(row.h);
+                    let bucket = bucket_for_row_height(row.h, self.quality.get());
                     let Some(asset) = model.item(it.asset_index).and_downcast::<AssetObject>()
                     else {
                         continue;
@@ -309,13 +332,12 @@ mod imp {
                     let is_local_only = !local_path.is_empty()
                         && asset_id.starts_with(crate::library::LOCAL_ID_PREFIX);
 
-                    let cached = self.textures.borrow().get(&asset_id).cloned().or_else(|| {
-                        if is_local_only {
-                            None
-                        } else {
-                            cache.get_cached(&asset_id, bucket)
-                        }
-                    });
+                    let lookup_bucket = if is_local_only {
+                        ThumbnailSize::Thumbnail
+                    } else {
+                        bucket
+                    };
+                    let cached = cache.get_cached(&asset_id, lookup_bucket);
 
                     let rect = Rect::new(it.x, row.y, it.w, row.h);
                     let clipped = CORNER_RADIUS > 0.0;
@@ -357,7 +379,7 @@ mod imp {
             to_load.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
 
             log::debug!(
-                "masonry snapshot canvas=({:.0}x{:.0}) scroll_y={:.0} viewport_h={:.0} rows={} layout_h={:.0} painted={} hits={} misses={} pending={} textures={} queued={}",
+                "masonry snapshot canvas=({:.0}x{:.0}) scroll_y={:.0} viewport_h={:.0} rows={} layout_h={:.0} painted={} hits={} misses={} pending={} queued={}",
                 canvas_w,
                 canvas_h,
                 scroll_y,
@@ -368,7 +390,6 @@ mod imp {
                 hits,
                 misses,
                 self.pending.borrow().len(),
-                self.textures.borrow().len(),
                 to_load.len(),
             );
 
@@ -477,15 +498,11 @@ mod imp {
                 match &result {
                     Ok(tex) => {
                         dims_changed = propagate_dimensions(&model, &asset_id, tex);
-                        imp.textures
-                            .borrow_mut()
-                            .insert(asset_id.clone(), tex.clone());
                         log::debug!(
-                            "masonry load OK id={} dims=({}x{}) tex_total={}",
+                            "masonry load OK id={} dims=({}x{})",
                             asset_id,
                             tex.width(),
                             tex.height(),
-                            imp.textures.borrow().len()
                         );
                     }
                     Err(e) => {
@@ -573,22 +590,15 @@ impl MasonryCanvas {
                         current_ids.insert(obj.property::<String>("id"));
                     }
                 }
-                let tex_before = imp.textures.borrow().len();
-                imp.textures
-                    .borrow_mut()
-                    .retain(|id, _| current_ids.contains(id));
                 imp.failed
                     .borrow_mut()
                     .retain(|id| current_ids.contains(id));
-                let tex_after = imp.textures.borrow().len();
                 log::debug!(
-                    "masonry items_changed pos={} removed={} added={} model_n={} textures {} -> {}",
+                    "masonry items_changed pos={} removed={} added={} model_n={}",
                     position,
                     removed,
                     added,
                     n,
-                    tex_before,
-                    tex_after,
                 );
                 imp.invalidate_layout();
                 canvas.queue_draw();
@@ -616,6 +626,13 @@ impl MasonryCanvas {
 
     pub fn set_select_mode(&self, on: bool) {
         self.imp().select_mode.set(on);
+    }
+
+    pub fn set_quality(&self, quality: GridQuality) {
+        let imp = self.imp();
+        if imp.quality.replace(quality) != quality {
+            self.queue_draw();
+        }
     }
 
     pub fn set_activate_handler(&self, f: impl Fn(u32) + 'static) {
@@ -831,15 +848,15 @@ mod tests {
     #[test]
     fn bucket_thumbnail_under_threshold() {
         assert!(matches!(
-            bucket_for_row_height(200.0),
+            bucket_for_row_height(200.0, GridQuality::Auto),
             ThumbnailSize::Thumbnail
         ));
         assert!(matches!(
-            bucket_for_row_height(PREVIEW_BUCKET_THRESHOLD),
+            bucket_for_row_height(PREVIEW_BUCKET_THRESHOLD, GridQuality::Auto),
             ThumbnailSize::Thumbnail
         ));
         assert!(matches!(
-            bucket_for_row_height(PREVIEW_BUCKET_THRESHOLD + 1.0),
+            bucket_for_row_height(PREVIEW_BUCKET_THRESHOLD + 1.0, GridQuality::Auto),
             ThumbnailSize::Preview
         ));
     }

--- a/src/library/masonry_canvas.rs
+++ b/src/library/masonry_canvas.rs
@@ -32,8 +32,9 @@ pub(super) const MAX_ROW_HEIGHT_WIDE: f32 = 360.0;
 pub(super) const GAP: f32 = 0.0;
 pub(super) const CORNER_RADIUS: f32 = 0.0;
 
-/// Row height above which we request the larger Preview thumbnail.
 const PREVIEW_BUCKET_THRESHOLD: f32 = 600.0;
+const VIEWPORTS_BEHIND: f32 = 2.0;
+const VIEWPORTS_AHEAD: f32 = 4.0;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LaidItem {
@@ -165,6 +166,20 @@ fn scale_to_fit(indices: &[usize], dims: &[(u32, u32)], canvas_w: f32, cfg: Layo
     }
     let scale = ((canvas_w - total_gap) / sum).max(0.0);
     cfg.max_row_height * scale
+}
+
+fn first_row_at_or_after(rows: &[LaidRow], y: f32) -> usize {
+    let mut lo = 0;
+    let mut hi = rows.len();
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if rows[mid].y + rows[mid].h < y {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    lo
 }
 
 pub(super) fn row_at_y(rows: &[LaidRow], y: f32) -> Option<usize> {
@@ -312,6 +327,10 @@ mod imp {
 
             let (scroll_y, viewport_h) = self.viewport();
             let viewport_center = scroll_y + viewport_h * 0.5;
+            let viewport_top = scroll_y;
+            let viewport_bottom = scroll_y + viewport_h;
+            let band_top = scroll_y - viewport_h * VIEWPORTS_BEHIND;
+            let band_bottom = scroll_y + viewport_h * (1.0 + VIEWPORTS_AHEAD);
 
             let rows = self.rows.borrow();
             let Some(model) = self.model.get() else {
@@ -321,7 +340,7 @@ mod imp {
                 return;
             };
 
-            let placeholder = gdk4::RGBA::new(0.24, 0.22, 0.30, 1.0);
+            let placeholder = gdk4::RGBA::new(1.0, 0.0, 1.0, 1.0);
             let select_tint = gdk4::RGBA::new(0.30, 0.55, 0.95, 0.35);
             let selection = self.selection.get();
             let mut to_load: Vec<(f32, String, ThumbnailSize, String, bool)> = Vec::new();
@@ -330,14 +349,32 @@ mod imp {
             let mut painted = 0usize;
             let row_count = rows.len();
             let last_row_bottom = rows.last().map(|r| r.y + r.h).unwrap_or(0.0);
+            let start_idx = first_row_at_or_after(&rows, band_top);
+            let mut first_painted_y = f32::NAN;
+            let mut last_painted_y = f32::NAN;
+            let mut rows_iterated = 0usize;
 
-            for row in rows.iter() {
+            for row in rows[start_idx..].iter() {
+                if row.y > band_bottom {
+                    break;
+                }
+                let row_in_viewport = row.y + row.h > viewport_top && row.y < viewport_bottom;
+                rows_iterated += 1;
+                if first_painted_y.is_nan() {
+                    first_painted_y = row.y;
+                }
+                last_painted_y = row.y + row.h;
                 for it in &row.items {
                     let bucket = bucket_for_row_height(row.h, self.quality.get());
-                    let Some(asset) = model.item(it.asset_index).and_downcast::<AssetObject>()
-                    else {
+                    let asset = model.item(it.asset_index).and_downcast::<AssetObject>();
+                    if asset.is_none() {
+                        let rect = Rect::new(it.x, row.y, it.w, row.h);
+                        snapshot.append_color(&placeholder, &rect);
+                        misses += 1;
+                        painted += 1;
                         continue;
-                    };
+                    }
+                    let asset = asset.unwrap();
                     let asset_id = asset.property::<String>("id");
                     let local_path = asset.property::<String>("local-path");
                     let is_local_only = !local_path.is_empty()
@@ -348,10 +385,17 @@ mod imp {
                     } else {
                         bucket
                     };
-                    let cached = cache.get_cached(&asset_id, lookup_bucket).or_else(|| {
-                        fallback_bucket(lookup_bucket)
-                            .and_then(|fb| cache.get_cached(&asset_id, fb))
-                    });
+                    let cached = if row_in_viewport {
+                        cache.get_cached(&asset_id, lookup_bucket).or_else(|| {
+                            fallback_bucket(lookup_bucket)
+                                .and_then(|fb| cache.get_cached(&asset_id, fb))
+                        })
+                    } else {
+                        cache.peek_cached(&asset_id, lookup_bucket).or_else(|| {
+                            fallback_bucket(lookup_bucket)
+                                .and_then(|fb| cache.peek_cached(&asset_id, fb))
+                        })
+                    };
 
                     let rect = Rect::new(it.x, row.y, it.w, row.h);
                     let clipped = CORNER_RADIUS > 0.0;
@@ -392,19 +436,44 @@ mod imp {
             drop(rows);
             to_load.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
 
+            let adj_info = self
+                .vadjustment
+                .borrow()
+                .as_ref()
+                .map(|a| {
+                    format!(
+                        "adj.value={:.0} adj.upper={:.0} adj.page={:.0}",
+                        a.value(),
+                        a.upper(),
+                        a.page_size()
+                    )
+                })
+                .unwrap_or_else(|| "adj=none".to_string());
+            let (cache_n, cache_bytes, cache_max, cache_evicts) = cache.cache_stats();
             log::debug!(
-                "masonry snapshot canvas=({:.0}x{:.0}) scroll_y={:.0} viewport_h={:.0} rows={} layout_h={:.0} painted={} hits={} misses={} pending={} queued={}",
+                "masonry snapshot canvas=({:.0}x{:.0}) scroll_y={:.0} viewport_h={:.0} band=[{:.0},{:.0}] rows={} start_idx={} iterated={} painted_y=[{:.0},{:.0}] layout_h={:.0} painted={} hits={} misses={} pending={} queued={} cache_n={} cache_mb={}/{} evicts={} {}",
                 canvas_w,
                 canvas_h,
                 scroll_y,
                 viewport_h,
+                band_top,
+                band_bottom,
                 row_count,
+                start_idx,
+                rows_iterated,
+                first_painted_y,
+                last_painted_y,
                 last_row_bottom,
                 painted,
                 hits,
                 misses,
                 self.pending.borrow().len(),
                 to_load.len(),
+                cache_n,
+                cache_bytes / (1024 * 1024),
+                cache_max / (1024 * 1024),
+                cache_evicts,
+                adj_info,
             );
 
             for (_, asset_id, bucket, local_path, is_local) in to_load {
@@ -466,6 +535,18 @@ mod imp {
             while let Some(w) = node {
                 if let Some(sw) = w.downcast_ref::<gtk::ScrolledWindow>() {
                     let adj = sw.vadjustment();
+                    let weak = self.obj().downgrade();
+                    adj.connect_value_changed(move |a| {
+                        log::trace!(
+                            "masonry vadjustment value_changed value={:.0} upper={:.0} page={:.0}",
+                            a.value(),
+                            a.upper(),
+                            a.page_size()
+                        );
+                        if let Some(canvas) = weak.upgrade() {
+                            canvas.queue_draw();
+                        }
+                    });
                     *self.vadjustment.borrow_mut() = Some(adj.clone());
                     return Some(adj);
                 }
@@ -645,6 +726,9 @@ impl MasonryCanvas {
                     added,
                     n,
                 );
+                if added == 0 && removed > 0 && n == 0 {
+                    return;
+                }
                 imp.invalidate_layout();
                 canvas.queue_draw();
             }
@@ -916,6 +1000,32 @@ mod tests {
             bucket_for_row_height(50.0, GridQuality::Fullsize),
             ThumbnailSize::Fullsize
         ));
+    }
+
+    #[test]
+    fn first_row_skip_lands_on_intersecting_row() {
+        let rows = vec![
+            LaidRow {
+                y: 0.0,
+                h: 100.0,
+                items: vec![],
+            },
+            LaidRow {
+                y: 100.0,
+                h: 100.0,
+                items: vec![],
+            },
+            LaidRow {
+                y: 200.0,
+                h: 100.0,
+                items: vec![],
+            },
+        ];
+        assert_eq!(first_row_at_or_after(&rows, -50.0), 0);
+        assert_eq!(first_row_at_or_after(&rows, 0.0), 0);
+        assert_eq!(first_row_at_or_after(&rows, 150.0), 1);
+        assert_eq!(first_row_at_or_after(&rows, 250.0), 2);
+        assert_eq!(first_row_at_or_after(&rows, 500.0), 3);
     }
 
     #[test]

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -1926,12 +1926,6 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     connect_grid_handlers(ui.clone());
     connect_filters_button(ui.clone(), filters_button);
 
-    let close_ctx = ui.ctx.clone();
-    window.connect_close_request(move |_| {
-        close_ctx.thumbnail_cache.clear_memory();
-        glib::Propagation::Proceed
-    });
-
     bootstrap_window(ui);
     window.present();
 }

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -19,10 +19,10 @@ use crate::library::albums_view::{
     AlbumClick, AlbumsViewParts, build_albums_view, populate_albums,
 };
 use crate::library::explore_view::{ExploreViewParts, build_explore_view};
-use crate::library::grid_view::{GridViewParts, build_grid_view};
 use crate::library::local_source::{
     LocalAsset, enumerate_local, enumerate_local_for_entry, filter_by_filename,
 };
+use crate::library::masonry::{GridViewParts, build_grid_view};
 use crate::library::sidebar::{SidebarParts, build_sidebar};
 use crate::library::state::{LibraryLoadState, LibrarySource};
 use crate::state_manager::TransferDirection;
@@ -45,11 +45,9 @@ pub mod albums_view;
 pub mod asset_model;
 pub mod asset_object;
 pub mod explore_view;
-pub mod grid_view;
 pub mod local_exif;
 pub mod local_source;
 pub mod masonry;
-pub mod masonry_canvas;
 pub mod sidebar;
 pub mod state;
 pub mod style;

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -2798,6 +2798,7 @@ fn local_to_library_asset(local: LocalAsset) -> LibraryAsset {
         width: None,
         height: None,
         checksum: None,
+        exif_info: None,
     }
 }
 

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -48,6 +48,7 @@ pub mod explore_view;
 pub mod grid_view;
 pub mod local_exif;
 pub mod local_source;
+pub mod masonry_canvas;
 pub mod sidebar;
 pub mod state;
 pub mod style;
@@ -1808,12 +1809,16 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     breakpoint.add_setter(&split, "collapsed", Some(&true.to_value()));
     breakpoint.add_setter(&transfer_bar, "visible", Some(&false.to_value()));
     let narrow_apply = narrow_flag.clone();
+    let canvas_for_apply = grid.canvas.clone();
     breakpoint.connect_apply(move |_| {
         narrow_apply.set(true);
+        canvas_for_apply.set_narrow(true);
     });
     let narrow_unapply = narrow_flag.clone();
+    let canvas_for_unapply = grid.canvas.clone();
     breakpoint.connect_unapply(move |_| {
         narrow_unapply.set(false);
+        canvas_for_unapply.set_narrow(false);
     });
     window.add_breakpoint(breakpoint);
 
@@ -1907,7 +1912,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         #[strong]
         ui,
         move |position, x, y| {
-            show_asset_context_menu(ui.clone(), &ui.grid.view, position, x, y);
+            show_asset_context_menu(ui.clone(), &ui.grid.canvas, position, x, y);
         }
     )));
 

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -1926,6 +1926,12 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     connect_grid_handlers(ui.clone());
     connect_filters_button(ui.clone(), filters_button);
 
+    let close_ctx = ui.ctx.clone();
+    window.connect_close_request(move |_| {
+        close_ctx.thumbnail_cache.clear_memory();
+        glib::Propagation::Proceed
+    });
+
     bootstrap_window(ui);
     window.present();
 }

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -48,6 +48,7 @@ pub mod explore_view;
 pub mod grid_view;
 pub mod local_exif;
 pub mod local_source;
+pub mod masonry;
 pub mod masonry_canvas;
 pub mod sidebar;
 pub mod state;

--- a/src/library/state.rs
+++ b/src/library/state.rs
@@ -330,6 +330,7 @@ mod tests {
             width: Some(10.0),
             height: Some(10.0),
             checksum: None,
+            exif_info: None,
         }
     }
 

--- a/src/library/style.rs
+++ b/src/library/style.rs
@@ -132,6 +132,10 @@ box.mimick-version-badge {
     background: alpha(@accent_bg_color, 0.12);
 }
 
+.mimick-masonry-canvas {
+    background-color: @view_bg_color;
+}
+
 picture.mimick-grid-thumb {
     min-width: 114px;
     min-height: 85px;

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -463,6 +463,7 @@ fn cache_key(asset_id: &str, size: ThumbnailSize) -> String {
     match size {
         ThumbnailSize::Thumbnail => format!("thumbnail:{}", asset_id),
         ThumbnailSize::Preview => format!("preview:{}", asset_id),
+        ThumbnailSize::Fullsize => format!("fullsize:{}", asset_id),
     }
 }
 

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -290,16 +290,9 @@ impl ThumbnailCache {
         .map_err(|err| err.to_string())?;
 
         if let Some(bytes) = from_disk {
-            let byte_len = bytes.len();
             let texture = decode_to_scaled_texture(bytes, target_dim_for_bucket(size))
                 .await
                 .map_err(|err| err.to_string())?;
-            log::debug!(
-                "Thumbnail disk-cache hit for {:?} {}: {} bytes",
-                size,
-                asset_id,
-                byte_len
-            );
             self.memory.lock().insert(key.to_string(), texture.clone());
             return Ok(texture);
         }
@@ -307,10 +300,7 @@ impl ThumbnailCache {
         if is_cancelled() {
             return Err("cancelled".to_string());
         }
-        let fetch_started = std::time::Instant::now();
         let bytes = self.api_client.fetch_thumbnail(asset_id, size).await?;
-        let fetch_ms = fetch_started.elapsed().as_millis();
-        let byte_len = bytes.len();
         let cache_dir = self.cache_dir.clone();
         let cache_file_for_write = cache_file.clone();
         let bytes_for_write = bytes.clone();
@@ -322,14 +312,6 @@ impl ThumbnailCache {
         let texture = decode_to_scaled_texture(bytes, target_dim_for_bucket(size))
             .await
             .map_err(|err| err.to_string())?;
-        log::debug!(
-            "Thumbnail fetched from server for {:?} {}: {} bytes in {}ms",
-            size,
-            asset_id,
-            byte_len,
-            fetch_ms,
-        );
-
         self.memory.lock().insert(key.to_string(), texture.clone());
         Ok(texture)
     }
@@ -396,12 +378,6 @@ impl ThumbnailCache {
         .map_err(|err| err.to_string())?;
 
         if let Some(texture) = from_disk {
-            log::debug!(
-                "Local thumbnail disk-cache hit for {} ({}x{})",
-                path.display(),
-                texture.width(),
-                texture.height(),
-            );
             self.memory.lock().insert(key.to_string(), texture.clone());
             return Ok(texture);
         }

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -20,7 +20,13 @@ use lru::LruCache;
 use tokio::sync::{Semaphore, watch};
 
 use crate::api_client::{ImmichApiClient, ThumbnailSize};
-const MAX_CONCURRENT_LOADS: usize = 8;
+
+/// Fallback when total CPU count probing fails.
+const FALLBACK_CPUS: usize = 4;
+/// Hard ceiling on small (Thumbnail) decode concurrency.
+const SMALL_LOAD_MAX: usize = 16;
+/// Hard ceiling on large (Preview / Fullsize) decode concurrency.
+const LARGE_LOAD_MAX: usize = 6;
 
 type InflightSlot = Option<Result<Texture, String>>;
 type InflightRx = watch::Receiver<InflightSlot>;
@@ -66,6 +72,7 @@ struct SizedLruCache {
     inner: LruCache<String, Texture>,
     current_bytes: usize,
     max_bytes: usize,
+    evictions_since_log: usize,
 }
 
 impl SizedLruCache {
@@ -77,12 +84,28 @@ impl SizedLruCache {
             inner: LruCache::new(NonZeroUsize::new(count_cap).unwrap()),
             current_bytes: 0,
             max_bytes,
+            evictions_since_log: 0,
         }
+    }
+
+    fn stats(&mut self) -> (usize, usize, usize, usize) {
+        let evictions = self.evictions_since_log;
+        self.evictions_since_log = 0;
+        (
+            self.inner.len(),
+            self.current_bytes,
+            self.max_bytes,
+            evictions,
+        )
     }
 
     /// Retrieve a texture from the cache if present, updating LRU recency.
     fn get(&mut self, key: &str) -> Option<Texture> {
         self.inner.get(key).cloned()
+    }
+
+    fn peek(&self, key: &str) -> Option<Texture> {
+        self.inner.peek(key).cloned()
     }
 
     /// Insert a texture into the cache, evicting entries to respect the byte budget.
@@ -99,6 +122,7 @@ impl SizedLruCache {
                 self.current_bytes = self
                     .current_bytes
                     .saturating_sub(estimate_texture_bytes(&removed));
+                self.evictions_since_log += 1;
             } else {
                 break;
             }
@@ -117,7 +141,8 @@ pub struct ThumbnailCache {
     api_client: std::sync::Arc<ImmichApiClient>,
     memory: Mutex<SizedLruCache>,
     cache_dir: PathBuf,
-    load_semaphore: Arc<Semaphore>,
+    small_semaphore: Arc<Semaphore>,
+    large_semaphore: Arc<Semaphore>,
     inflight: InflightMap,
 }
 
@@ -143,17 +168,25 @@ impl ThumbnailCache {
         } else {
             (mb as usize).saturating_mul(1024 * 1024)
         };
+        let cpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(FALLBACK_CPUS);
+        let small = SMALL_LOAD_MAX.min(cpus.saturating_mul(2)).max(2);
+        let large = LARGE_LOAD_MAX.min(cpus).max(2);
         log::info!(
-            "ThumbnailCache memory budget: {} MB ({})",
+            "ThumbnailCache memory budget: {} MB ({}), concurrency small={} large={}",
             max_bytes / (1024 * 1024),
-            if mb == 0 { "auto" } else { "user-set" }
+            if mb == 0 { "auto" } else { "user-set" },
+            small,
+            large,
         );
 
         Self {
             api_client,
             memory: Mutex::new(SizedLruCache::new(max_bytes)),
             cache_dir,
-            load_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_LOADS)),
+            small_semaphore: Arc::new(Semaphore::new(small)),
+            large_semaphore: Arc::new(Semaphore::new(large)),
             inflight: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -168,15 +201,35 @@ impl ThumbnailCache {
             api_client,
             memory: Mutex::new(SizedLruCache::new(max_bytes)),
             cache_dir,
-            load_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_LOADS)),
+            small_semaphore: Arc::new(Semaphore::new(SMALL_LOAD_MAX)),
+            large_semaphore: Arc::new(Semaphore::new(LARGE_LOAD_MAX)),
             inflight: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    /// Retrieve a thumbnail texture from memory if present.
+    /// Retrieve a thumbnail texture from memory if present, updating LRU recency.
     pub fn get_cached(&self, asset_id: &str, size: ThumbnailSize) -> Option<Texture> {
         let key = cache_key(asset_id, size);
         self.memory.lock().get(&key)
+    }
+
+    /// Same as `get_cached` but does not touch LRU order. Use for read-only
+    /// per-frame paint lookups.
+    pub fn peek_cached(&self, asset_id: &str, size: ThumbnailSize) -> Option<Texture> {
+        let key = cache_key(asset_id, size);
+        self.memory.lock().peek(&key)
+    }
+
+    /// (entries, current_bytes, max_bytes, evictions_since_last_call).
+    pub fn cache_stats(&self) -> (usize, usize, usize, usize) {
+        self.memory.lock().stats()
+    }
+
+    fn semaphore_for(&self, size: ThumbnailSize) -> Arc<Semaphore> {
+        match size {
+            ThumbnailSize::Thumbnail => self.small_semaphore.clone(),
+            ThumbnailSize::Preview | ThumbnailSize::Fullsize => self.large_semaphore.clone(),
+        }
     }
 
     /// Asynchronously fetch a remote thumbnail with default non-cancellable execution.
@@ -227,8 +280,7 @@ impl ThumbnailCache {
             return Err("cancelled".to_string());
         }
         let _permit = self
-            .load_semaphore
-            .clone()
+            .semaphore_for(size)
             .acquire_owned()
             .await
             .map_err(|err| err.to_string())?;
@@ -331,8 +383,7 @@ impl ThumbnailCache {
             return Err("cancelled".to_string());
         }
         let _permit = self
-            .load_semaphore
-            .clone()
+            .semaphore_for(ThumbnailSize::Thumbnail)
             .acquire_owned()
             .await
             .map_err(|err| err.to_string())?;

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -21,11 +21,8 @@ use tokio::sync::{Semaphore, watch};
 
 use crate::api_client::{ImmichApiClient, ThumbnailSize};
 
-/// Fallback when total CPU count probing fails.
 const FALLBACK_CPUS: usize = 4;
-/// Hard ceiling on small (Thumbnail) decode concurrency.
 const SMALL_LOAD_MAX: usize = 16;
-/// Hard ceiling on large (Preview / Fullsize) decode concurrency.
 const LARGE_LOAD_MAX: usize = 6;
 
 type InflightSlot = Option<Result<Texture, String>>;
@@ -149,34 +146,26 @@ pub struct ThumbnailCache {
 impl ThumbnailCache {
     /// Floor for the auto-sized RAM budget, so very low-memory systems still
     /// hold a working set of decoded thumbnails.
-    const AUTO_MIN_BYTES: usize = 128 * 1024 * 1024;
-    /// Ceiling for the auto-sized RAM budget, so big-RAM workstations don't
-    /// crowd out other applications.
-    const AUTO_MAX_BYTES: usize = 1536 * 1024 * 1024;
-    /// Fraction of total system memory used when the user lets us auto-size.
-    const AUTO_FRACTION_PERCENT: usize = 12;
+    const AUTO_MIN_BYTES: usize = 500 * 1024 * 1024;
+    const AUTO_MAX_BYTES: usize = 3 * 1024 * 1024 * 1024;
+    const AUTO_FRACTION_PERCENT: usize = 20;
 
     /// Construct a new thumbnail cache manager. Disk pruning is handled
     /// centrally by `cache_manager` at startup, not here.
-    pub fn with_capacity_mb(api_client: std::sync::Arc<ImmichApiClient>, mb: u32) -> Self {
+    pub fn new(api_client: std::sync::Arc<ImmichApiClient>) -> Self {
         let cache_dir = crate::profile::cache_dir()
             .unwrap_or_else(|| PathBuf::from("/tmp").join(crate::profile::dir_segment()))
             .join("thumbnails");
 
-        let max_bytes = if mb == 0 {
-            auto_memory_budget()
-        } else {
-            (mb as usize).saturating_mul(1024 * 1024)
-        };
+        let max_bytes = auto_memory_budget();
         let cpus = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(FALLBACK_CPUS);
         let small = SMALL_LOAD_MAX.min(cpus.saturating_mul(2)).max(2);
         let large = LARGE_LOAD_MAX.min(cpus).max(2);
         log::info!(
-            "ThumbnailCache memory budget: {} MB ({}), concurrency small={} large={}",
+            "ThumbnailCache memory budget: {} MB (auto), concurrency small={} large={}",
             max_bytes / (1024 * 1024),
-            if mb == 0 { "auto" } else { "user-set" },
             small,
             large,
         );
@@ -302,7 +291,7 @@ impl ThumbnailCache {
 
         if let Some(bytes) = from_disk {
             let byte_len = bytes.len();
-            let texture = decode_to_scaled_texture(bytes)
+            let texture = decode_to_scaled_texture(bytes, target_dim_for_bucket(size))
                 .await
                 .map_err(|err| err.to_string())?;
             log::debug!(
@@ -330,7 +319,7 @@ impl ThumbnailCache {
             let _ = std::fs::write(&cache_file_for_write, &bytes_for_write);
         })
         .await;
-        let texture = decode_to_scaled_texture(bytes)
+        let texture = decode_to_scaled_texture(bytes, target_dim_for_bucket(size))
             .await
             .map_err(|err| err.to_string())?;
         log::debug!(
@@ -603,14 +592,22 @@ fn custom_decode_to_thumbnail(path: &std::path::Path) -> Result<gtk::gdk_pixbuf:
         .ok_or_else(|| "Failed to scale pixbuf".to_string())
 }
 
+fn target_dim_for_bucket(size: ThumbnailSize) -> i32 {
+    match size {
+        ThumbnailSize::Thumbnail => 256,
+        ThumbnailSize::Preview => 1440,
+        ThumbnailSize::Fullsize => 2560,
+    }
+}
+
 /// Asynchronously decode image bytes into a scaled texture.
-async fn decode_to_scaled_texture(bytes: Vec<u8>) -> Result<Texture, String> {
+async fn decode_to_scaled_texture(bytes: Vec<u8>, max_dim: i32) -> Result<Texture, String> {
     tokio::task::spawn_blocking(move || -> Result<Texture, String> {
         let stream = gtk::gio::MemoryInputStream::from_bytes(&Bytes::from_owned(bytes));
         let pixbuf = gtk::gdk_pixbuf::Pixbuf::from_stream_at_scale(
             &stream,
-            256,
-            256,
+            max_dim,
+            max_dim,
             true,
             gtk::gio::Cancellable::NONE,
         )

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -122,7 +122,14 @@ pub struct ThumbnailCache {
 }
 
 impl ThumbnailCache {
-    const DEFAULT_MAX_BYTES: usize = 80 * 1024 * 1024;
+    /// Floor for the auto-sized RAM budget, so very low-memory systems still
+    /// hold a working set of decoded thumbnails.
+    const AUTO_MIN_BYTES: usize = 128 * 1024 * 1024;
+    /// Ceiling for the auto-sized RAM budget, so big-RAM workstations don't
+    /// crowd out other applications.
+    const AUTO_MAX_BYTES: usize = 1536 * 1024 * 1024;
+    /// Fraction of total system memory used when the user lets us auto-size.
+    const AUTO_FRACTION_PERCENT: usize = 12;
 
     /// Construct a new thumbnail cache manager. Disk pruning is handled
     /// centrally by `cache_manager` at startup, not here.
@@ -132,10 +139,15 @@ impl ThumbnailCache {
             .join("thumbnails");
 
         let max_bytes = if mb == 0 {
-            Self::DEFAULT_MAX_BYTES
+            auto_memory_budget()
         } else {
             (mb as usize).saturating_mul(1024 * 1024)
         };
+        log::info!(
+            "ThumbnailCache memory budget: {} MB ({})",
+            max_bytes / (1024 * 1024),
+            if mb == 0 { "auto" } else { "user-set" }
+        );
 
         Self {
             api_client,
@@ -477,6 +489,32 @@ fn local_cache_key(asset_id: &str) -> String {
 /// Estimate memory byte size occupied by a texture.
 fn estimate_texture_bytes(texture: &Texture) -> usize {
     texture.width().max(1) as usize * texture.height().max(1) as usize * 4
+}
+
+/// Pick a thumbnail-cache RAM budget from `MemTotal` in `/proc/meminfo`,
+/// clamped to `[AUTO_MIN_BYTES, AUTO_MAX_BYTES]`. Falls back to the floor
+/// if the file can't be read.
+fn auto_memory_budget() -> usize {
+    let total = read_meminfo_total_bytes().unwrap_or(0);
+    if total == 0 {
+        return ThumbnailCache::AUTO_MIN_BYTES;
+    }
+    let fraction = total / 100 * ThumbnailCache::AUTO_FRACTION_PERCENT;
+    fraction.clamp(
+        ThumbnailCache::AUTO_MIN_BYTES,
+        ThumbnailCache::AUTO_MAX_BYTES,
+    )
+}
+
+fn read_meminfo_total_bytes() -> Option<usize> {
+    let text = std::fs::read_to_string("/proc/meminfo").ok()?;
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            let kb: usize = rest.trim().split_whitespace().next()?.parse().ok()?;
+            return Some(kb.saturating_mul(1024));
+        }
+    }
+    None
 }
 
 /// Decode a file through the custom pipeline (RAW / non-pixbuf formats) and

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -510,7 +510,7 @@ fn read_meminfo_total_bytes() -> Option<usize> {
     let text = std::fs::read_to_string("/proc/meminfo").ok()?;
     for line in text.lines() {
         if let Some(rest) = line.strip_prefix("MemTotal:") {
-            let kb: usize = rest.trim().split_whitespace().next()?.parse().ok()?;
+            let kb: usize = rest.split_whitespace().next()?.parse().ok()?;
             return Some(kb.saturating_mul(1024));
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -467,10 +467,7 @@ async fn main() {
         let startup_paths = config.data.watch_paths.clone();
         let startup_sync_index = sync_index.clone();
         let (manual_sync_tx, mut manual_sync_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
-        let thumbnail_cache = Arc::new(ThumbnailCache::with_capacity_mb(
-            api_client.clone(),
-            config.data.library_thumbnail_cache_mb,
-        ));
+        let thumbnail_cache = Arc::new(ThumbnailCache::new(api_client.clone()));
         // One-shot startup prune across every cache directory. Runs on a
         // blocking thread after a short delay so it does not contend with
         // window setup or initial sync work.

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -589,6 +589,33 @@ pub fn build_settings_window_with_parent(
         }
     });
 
+    let quality_options = gtk::StringList::new(&["Auto (per cell size)", "Thumbnail", "Preview"]);
+    let grid_quality_row = adw::ComboRow::builder()
+        .title("Library Thumbnail Quality")
+        .subtitle("Auto picks Thumbnail for small cells and Preview for large ones.")
+        .model(&quality_options)
+        .build();
+    library_group.add(&grid_quality_row);
+    let initial_quality_idx = match ctx.config.read().data.library_grid_quality.as_str() {
+        "thumbnail" => 1,
+        "preview" => 2,
+        _ => 0,
+    };
+    grid_quality_row.set_selected(initial_quality_idx);
+    let ctx_for_quality = ctx.clone();
+    grid_quality_row.connect_selected_notify(move |row| {
+        let value = match row.selected() {
+            1 => "thumbnail",
+            2 => "preview",
+            _ => "auto",
+        };
+        let mut cfg = ctx_for_quality.config.write();
+        if cfg.data.library_grid_quality != value {
+            cfg.data.library_grid_quality = value.to_string();
+            cfg.save();
+        }
+    });
+
     let raw_full_decode_row = adw::SwitchRow::builder()
         .title("Full RAW Decoding")
         .subtitle(

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -439,39 +439,37 @@ pub fn build_settings_window_with_parent(
 
     let startup_row = adw::SwitchRow::builder()
         .title("Run on Startup")
-        .subtitle("Start Mimick automatically when you log in.")
+        .subtitle("Start Mimick at login.")
         .build();
     behavior_group.add(&startup_row);
 
     let background_sync_row = adw::SwitchRow::builder()
         .title("Background Sync")
-        .subtitle("Automatically watch folders in the background after launch.")
+        .subtitle("Watch folders in the background after launch.")
         .build();
     behavior_group.add(&background_sync_row);
 
     let metered_row = adw::SwitchRow::builder()
         .title("Pause on Metered Network")
-        .subtitle("Defer uploads while the active connection is marked as metered.")
+        .subtitle("Pause uploads on metered connections.")
         .build();
     behavior_group.add(&metered_row);
 
     let battery_row = adw::SwitchRow::builder()
         .title("Pause on Battery Power")
-        .subtitle("Defer uploads while the system appears to be running on battery.")
+        .subtitle("Pause uploads while on battery.")
         .build();
     behavior_group.add(&battery_row);
 
     let notifications_row = adw::SwitchRow::builder()
         .title("Enable Notifications")
-        .subtitle("Show desktop notifications for sync events and connectivity issues.")
+        .subtitle("Desktop notifications for sync events.")
         .build();
     behavior_group.add(&notifications_row);
 
     let library_view_row = adw::SwitchRow::builder()
         .title("Enable Library View")
-        .subtitle(
-            "Turn on the in-app library browser. Restart Mimick to switch which window opens.",
-        )
+        .subtitle("In-app library browser. Requires restart.")
         .build();
     behavior_group.add(&library_view_row);
 
@@ -486,9 +484,9 @@ pub fn build_settings_window_with_parent(
         let active = row.is_active();
         let needs_restart = active != initial_library_view;
         let subtitle = if needs_restart {
-            "Restart Mimick to apply the new window layout."
+            "Restart Mimick to apply."
         } else {
-            "Turn on the in-app library browser. Restart Mimick to switch which window opens."
+            "In-app library browser. Requires restart."
         };
         row.set_subtitle(subtitle);
         let mut cfg = ctx_for_lib_view.config.write();
@@ -501,7 +499,7 @@ pub fn build_settings_window_with_parent(
     let catchup_model = gtk::StringList::new(&["Full Scan", "Recent Only (7d)", "New Files Only"]);
     let catchup_row = adw::ComboRow::builder()
         .title("Default Startup Catch-up Mode")
-        .subtitle("Used by folders that do not have their own startup scan setting.")
+        .subtitle("Used when a folder has no override.")
         .model(&catchup_model)
         .build();
     behavior_group.add(&catchup_row);
@@ -510,21 +508,20 @@ pub fn build_settings_window_with_parent(
     let concurrency_adj = gtk::Adjustment::new(3.0, 1.0, 10.0, 1.0, 1.0, 0.0);
     let concurrency_row = adw::SpinRow::builder()
         .title("Upload Workers")
-        .subtitle("Number of parallel upload workers (1–10). More workers = faster batch uploads.")
+        .subtitle("Parallel uploads. More = faster batches.")
         .adjustment(&concurrency_adj)
         .build();
     behavior_group.add(&concurrency_row);
 
     let xmp_sidecar_row = adw::SwitchRow::builder()
         .title("Upload XMP Sidecars")
-        .subtitle("Attach companion .xmp sidecar files alongside media during upload.")
+        .subtitle("Attach .xmp sidecars with uploads.")
         .build();
     behavior_group.add(&xmp_sidecar_row);
 
-    // Quiet hours — enable switch + two hour spinners
     let quiet_hours_row = adw::SwitchRow::builder()
         .title("Quiet Hours")
-        .subtitle("Pause uploads during a nightly window using your local clock.")
+        .subtitle("Pause uploads on a nightly schedule.")
         .build();
     behavior_group.add(&quiet_hours_row);
 
@@ -559,7 +556,7 @@ pub fn build_settings_window_with_parent(
     // group reveals/hides in step with the `library_view_row` toggle.
     let library_group = adw::PreferencesGroup::builder()
         .title("Library")
-        .description("Settings that affect the in-app library browser.")
+        .description("Library browser settings.")
         .visible(config.data.library_view_enabled)
         .build();
     settings_page.add(&library_group);
@@ -573,9 +570,7 @@ pub fn build_settings_window_with_parent(
 
     let preview_full_row = adw::SwitchRow::builder()
         .title("Open Originals in Lightbox")
-        .subtitle(
-            "When on, the library lightbox loads full-resolution originals instead of the ~1440px preview.",
-        )
+        .subtitle("Use full-resolution instead of the 1440px preview.")
         .build();
     library_group.add(&preview_full_row);
 
@@ -593,7 +588,7 @@ pub fn build_settings_window_with_parent(
         gtk::StringList::new(&["Auto (per cell size)", "Thumbnail", "Preview", "Full Size"]);
     let grid_quality_row = adw::ComboRow::builder()
         .title("Library Thumbnail Quality")
-        .subtitle("Auto picks Thumbnail for small cells and Preview for large ones.")
+        .subtitle("Higher quality uses more memory.")
         .model(&quality_options)
         .build();
     library_group.add(&grid_quality_row);
@@ -621,19 +616,13 @@ pub fn build_settings_window_with_parent(
 
     let raw_full_decode_row = adw::SwitchRow::builder()
         .title("Full RAW Decoding")
-        .subtitle(
-            "Decode high-resolution sensor data instead of using \
-             embedded previews (slower).",
-        )
+        .subtitle("Sensor data instead of embedded previews. Slower.")
         .build();
     library_group.add(&raw_full_decode_row);
 
     let raw_cache_row = adw::SwitchRow::builder()
         .title("Cache Decoded RAW Files")
-        .subtitle(
-            "Store demosaiced RAW images on disk so re-opens are instant. \
-             Disable to save storage.",
-        )
+        .subtitle("Instant re-opens. Uses disk space.")
         .build();
     library_group.add(&raw_cache_row);
 
@@ -664,51 +653,13 @@ pub fn build_settings_window_with_parent(
         }
     });
 
-    let cache_adj = gtk::Adjustment::new(0.0, 0.0, 4096.0, 64.0, 256.0, 0.0);
-    let cache_size_row = adw::SpinRow::builder()
-        .title("Thumbnail Memory Cache (MB)")
-        .subtitle(
-            "Cap on decoded thumbnails kept in RAM. 0 = Auto (sized from \
-             system memory, capped at 1.5 GB).",
-        )
-        .adjustment(&cache_adj)
-        .build();
-    library_group.add(&cache_size_row);
-
     let disk_cache_adj = gtk::Adjustment::new(2000.0, 200.0, 10000.0, 100.0, 500.0, 0.0);
     let disk_cache_row = adw::SpinRow::builder()
         .title("Disk Cache Size (MB)")
-        .subtitle(
-            "Total on-disk cap across thumbnails, decoded RAW previews, EXIF, \
-             video, and preview caches. Pruning runs once at startup.",
-        )
+        .subtitle("Cap across all on-disk caches. Pruned at startup.")
         .adjustment(&disk_cache_adj)
         .build();
     library_group.add(&disk_cache_row);
-
-    // Debounce the spinner save: a held-down arrow fires connect_value_notify
-    // many times per second, and each save takes the config write lock + does
-    // synchronous JSON serialise + atomic_write on the UI thread. We coalesce
-    // bursts by scheduling the save after 400 ms of quiet.
-    let pending_cache_save: Rc<Cell<Option<glib::SourceId>>> = Rc::new(Cell::new(None));
-    let ctx_for_cache = ctx.clone();
-    cache_size_row.connect_value_notify(move |row| {
-        let new_value = row.value() as u32;
-        if let Some(id) = pending_cache_save.take() {
-            id.remove();
-        }
-        let ctx_for_save = ctx_for_cache.clone();
-        let pending = pending_cache_save.clone();
-        let id = glib::timeout_add_local_once(Duration::from_millis(400), move || {
-            pending.set(None);
-            let mut cfg = ctx_for_save.config.write();
-            if cfg.data.library_thumbnail_cache_mb != new_value {
-                cfg.data.library_thumbnail_cache_mb = new_value;
-                cfg.save();
-            }
-        });
-        pending_cache_save.set(Some(id));
-    });
 
     let pending_disk_cache_save: Rc<Cell<Option<glib::SourceId>>> = Rc::new(Cell::new(None));
     let ctx_for_disk_cache = ctx.clone();
@@ -733,7 +684,7 @@ pub fn build_settings_window_with_parent(
     // --- WATCH FOLDERS GROUP ---
     let folders_group = adw::PreferencesGroup::builder()
         .title("Watch Folders")
-        .description("Add folders with the picker so Mimick can keep access to them.")
+        .description("Pick folders to sync.")
         .build();
     settings_page.add(&folders_group);
 
@@ -772,8 +723,6 @@ pub fn build_settings_window_with_parent(
         raw_full_decode_row,
         #[weak]
         raw_cache_row,
-        #[weak]
-        cache_size_row,
         #[weak]
         disk_cache_row,
         #[weak]
@@ -869,7 +818,6 @@ pub fn build_settings_window_with_parent(
             let library_preview_full_resolution = preview_full_row.is_active();
             let raw_decode_cache_enabled = raw_cache_row.is_active();
             let raw_full_decode = raw_full_decode_row.is_active();
-            let library_thumbnail_cache_mb = cache_size_row.value() as u32;
             let cache_disk_cap_mb = disk_cache_row.value() as u32;
             let upload_concurrency = concurrency_row.value() as u8;
             let quiet_hours_enabled = quiet_hours_row.is_active();
@@ -1001,7 +949,6 @@ pub fn build_settings_window_with_parent(
                         crate::library::set_raw_cache_enabled(raw_decode_cache_enabled);
                         new_config.data.raw_full_decode = raw_full_decode;
                         crate::library::set_raw_full_decode(raw_full_decode);
-                        new_config.data.library_thumbnail_cache_mb = library_thumbnail_cache_mb;
                         new_config.data.cache_disk_cap_mb = cache_disk_cap_mb;
                         new_config.data.startup_catchup_mode = catchup_mode;
                         new_config.data.upload_concurrency = upload_concurrency;
@@ -1449,7 +1396,6 @@ pub fn build_settings_window_with_parent(
     raw_cache_row.set_active(config.data.raw_decode_cache_enabled);
     raw_full_decode_row.set_active(config.data.raw_full_decode);
     raw_cache_row.set_sensitive(config.data.raw_full_decode);
-    cache_size_row.set_value(config.data.library_thumbnail_cache_mb as f64);
     if config.data.cache_disk_cap_mb > 0 {
         disk_cache_row.set_value(config.data.cache_disk_cap_mb as f64);
     }

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -664,10 +664,13 @@ pub fn build_settings_window_with_parent(
         }
     });
 
-    let cache_adj = gtk::Adjustment::new(80.0, 16.0, 1024.0, 16.0, 64.0, 0.0);
+    let cache_adj = gtk::Adjustment::new(0.0, 0.0, 4096.0, 64.0, 256.0, 0.0);
     let cache_size_row = adw::SpinRow::builder()
         .title("Thumbnail Memory Cache (MB)")
-        .subtitle("Approximate cap on decoded thumbnails kept in RAM.")
+        .subtitle(
+            "Cap on decoded thumbnails kept in RAM. 0 = Auto (sized from \
+             system memory, capped at 1.5 GB).",
+        )
         .adjustment(&cache_adj)
         .build();
     library_group.add(&cache_size_row);
@@ -1446,9 +1449,7 @@ pub fn build_settings_window_with_parent(
     raw_cache_row.set_active(config.data.raw_decode_cache_enabled);
     raw_full_decode_row.set_active(config.data.raw_full_decode);
     raw_cache_row.set_sensitive(config.data.raw_full_decode);
-    if config.data.library_thumbnail_cache_mb > 0 {
-        cache_size_row.set_value(config.data.library_thumbnail_cache_mb as f64);
-    }
+    cache_size_row.set_value(config.data.library_thumbnail_cache_mb as f64);
     if config.data.cache_disk_cap_mb > 0 {
         disk_cache_row.set_value(config.data.cache_disk_cap_mb as f64);
     }

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -593,9 +593,7 @@ pub fn build_settings_window_with_parent(
         gtk::StringList::new(&["Auto (per cell size)", "Thumbnail", "Preview", "Full Size"]);
     let grid_quality_row = adw::ComboRow::builder()
         .title("Library Thumbnail Quality")
-        .subtitle(
-            "Auto picks Thumbnail for small cells and Preview for large ones.",
-        )
+        .subtitle("Auto picks Thumbnail for small cells and Preview for large ones.")
         .model(&quality_options)
         .build();
     library_group.add(&grid_quality_row);

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -589,16 +589,20 @@ pub fn build_settings_window_with_parent(
         }
     });
 
-    let quality_options = gtk::StringList::new(&["Auto (per cell size)", "Thumbnail", "Preview"]);
+    let quality_options =
+        gtk::StringList::new(&["Auto (per cell size)", "Thumbnail", "Preview", "Full Size"]);
     let grid_quality_row = adw::ComboRow::builder()
         .title("Library Thumbnail Quality")
-        .subtitle("Auto picks Thumbnail for small cells and Preview for large ones.")
+        .subtitle(
+            "Auto picks Thumbnail for small cells and Preview for large ones.",
+        )
         .model(&quality_options)
         .build();
     library_group.add(&grid_quality_row);
     let initial_quality_idx = match ctx.config.read().data.library_grid_quality.as_str() {
         "thumbnail" => 1,
         "preview" => 2,
+        "fullsize" => 3,
         _ => 0,
     };
     grid_quality_row.set_selected(initial_quality_idx);
@@ -607,6 +611,7 @@ pub fn build_settings_window_with_parent(
         let value = match row.selected() {
             1 => "thumbnail",
             2 => "preview",
+            3 => "fullsize",
             _ => "auto",
         };
         let mut cfg = ctx_for_quality.config.write();


### PR DESCRIPTION
Closes #146.

Replaces the GridView with a justified-row masonry canvas backed by `pack_rows`.

Layout direction and visual reference inspired by [@naruaika](https://github.com/naruaika)'s [alusin-studio](https://github.com/naruaika/alusin-studio) #146.

## Highlights
- **Correct cell aspects from the first paint.** `LibraryAsset` now carries `exifInfo`, requested via `withExif=true` in `fetch_search_assets`, so cells size correctly before any thumbnail arrives. Eliminates the relayout-on-load scroll drift.
- **Paint-everything snapshot.** Avoids GSK stale-render-tree gaps on scroll-back; viewport state is used only to prioritize loads.
- **Priority-sorted load queue.** Every uncached cell is queued each snapshot, sorted by distance from viewport center; the FIFO semaphore serves visible cells first while the rest stream in.
- **Single-owner texture cache.** Dropped the per-canvas `HashMap<String, Texture>` — the shared `SizedLruCache` is the only owner, eviction governed by `library_thumbnail_cache_mb`.
- **Quality setting.** New `library_grid_quality` config + ComboRow in library settings: `Auto` (per-row heuristic), `Thumbnail`, `Preview`, `Fullsize`. `Fullsize` falls back to Preview on 404 so it works on servers without full-size generation.