### PR TITLE
feat: file associations, staging view, and upload-with-Mimick action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Context menu "Open With Mimick" upload flow. Right-clicking supported media files in a file manager and choosing Mimick opens a dedicated staging window with a masonry grid preview, select-all toggle, and Upload / Album buttons.
+- Video thumbnail extraction in the staging grid using ffmpeg, with secure temporary file handling via `tempfile::NamedTempFile`.
+- Selection checkboxes on grid tiles in both the staging view and library view. Unchecked tiles show a bordered square outline; checked tiles show an accent-coloured filled square with a checkmark icon.
+- Responsive narrow layout for the staging window via a 600sp libadwaita Breakpoint, matching the main library grid behaviour on small screens.
+- `.desktop` file now declares supported image and video MIME types so the system file manager offers "Open With Mimick" in its context menu.
+
+### Changed
+
+- Library view enable/disable toggle in Settings now auto-saves immediately on toggle, matching the behaviour of all other settings toggles. Previously it required clicking "Save Credentials".
+
+### Refactored
+
+- Split `paint_checkbox` into `paint_checked_box` and `paint_unchecked_box` helpers.
+- Split `build_staging_window` into `build_staging_ui`, `build_staging_header`, `setup_narrow_breakpoint`, `connect_select_all`, `connect_selection_tracking`, and `connect_upload_buttons`.
+- Split `present_album_list` into `present_album_list`, `handle_album_upload`, and `build_album_listbox`.
+- Split `spawn_enqueue_with_callback` by extracting `build_file_task` for per-path FileTask construction.
+- Split `ffmpeg_extract_thumbnail` into `run_ffmpeg_frame`, `scale_pixbuf_to_thumbnail`, and `decode_local_pixbuf`.
+- Extracted `status_text` and `simple_alert` shared helpers to reduce code duplication across the staging view.
+
 ## [9.7.0] - 2026-06-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -82,22 +82,22 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "ashpd"
-version = "0.13.11"
+version = "0.13.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340e0f6bf7f9ee78549c61454f1460a3ed97c011902ee76b58301bbc6d502a32"
+checksum = "281e6645758940dee594495e28807a7672ce40f11ebf4df6c22c4fcd59e2689f"
 dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
  "gdk4-wayland",
  "gdk4-x11",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "glib",
  "gtk4",
  "serde",
@@ -235,9 +235,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cairo-rs"
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -694,12 +694,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1008,15 +1002,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1266,22 +1258,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1550,12 +1533,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,9 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1699,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1932,12 +1907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libadwaita"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -2068,7 +2037,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2402,7 +2371,7 @@ dependencies = [
  "digest 0.10.7",
  "endi",
  "futures-util",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hkdf",
  "hmac",
  "md-5",
@@ -2666,16 +2635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,9 +2675,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2955,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -3259,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3314,7 +3273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3718,12 +3677,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3777,9 +3730,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -3835,23 +3788,14 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3862,9 +3806,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3872,9 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3882,9 +3826,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3895,33 +3839,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -3938,22 +3860,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4209,97 +4119,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,9 +80,9 @@ turbojpeg = { version = "1.4.0", default-features = false, features = [
 ] }
 webp = { version = "0.3.1", default-features = false }
 psd = "0.3.5"
+tempfile = "3.27.0"
 
 [dev-dependencies]
-tempfile = "3.27.0"
 
 [build-dependencies]
 glib-build-tools = "0.22"

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -93,14 +93,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.102.crate",
-        "sha256": "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c",
-        "dest": "cargo/vendor/anyhow-1.0.102"
+        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.103.crate",
+        "sha256": "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3",
+        "dest": "cargo/vendor/anyhow-1.0.103"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c\", \"files\": {}}",
-        "dest": "cargo/vendor/anyhow-1.0.102",
+        "contents": "{\"package\": \"2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3\", \"files\": {}}",
+        "dest": "cargo/vendor/anyhow-1.0.103",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -132,27 +132,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.6.crate",
-        "sha256": "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50",
-        "dest": "cargo/vendor/arrayvec-0.7.6"
+        "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.7.crate",
+        "sha256": "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe",
+        "dest": "cargo/vendor/arrayvec-0.7.7"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50\", \"files\": {}}",
-        "dest": "cargo/vendor/arrayvec-0.7.6",
+        "contents": "{\"package\": \"f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe\", \"files\": {}}",
+        "dest": "cargo/vendor/arrayvec-0.7.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ashpd/ashpd-0.13.11.crate",
-        "sha256": "340e0f6bf7f9ee78549c61454f1460a3ed97c011902ee76b58301bbc6d502a32",
-        "dest": "cargo/vendor/ashpd-0.13.11"
+        "url": "https://static.crates.io/crates/ashpd/ashpd-0.13.12.crate",
+        "sha256": "281e6645758940dee594495e28807a7672ce40f11ebf4df6c22c4fcd59e2689f",
+        "dest": "cargo/vendor/ashpd-0.13.12"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"340e0f6bf7f9ee78549c61454f1460a3ed97c011902ee76b58301bbc6d502a32\", \"files\": {}}",
-        "dest": "cargo/vendor/ashpd-0.13.11",
+        "contents": "{\"package\": \"281e6645758940dee594495e28807a7672ce40f11ebf4df6c22c4fcd59e2689f\", \"files\": {}}",
+        "dest": "cargo/vendor/ashpd-0.13.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -353,14 +353,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bytes/bytes-1.11.1.crate",
-        "sha256": "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33",
-        "dest": "cargo/vendor/bytes-1.11.1"
+        "url": "https://static.crates.io/crates/bytes/bytes-1.12.0.crate",
+        "sha256": "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593",
+        "dest": "cargo/vendor/bytes-1.12.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33\", \"files\": {}}",
-        "dest": "cargo/vendor/bytes-1.11.1",
+        "contents": "{\"package\": \"8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593\", \"files\": {}}",
+        "dest": "cargo/vendor/bytes-1.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -405,14 +405,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cc/cc-1.2.64.crate",
-        "sha256": "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f",
-        "dest": "cargo/vendor/cc-1.2.64"
+        "url": "https://static.crates.io/crates/cc/cc-1.2.65.crate",
+        "sha256": "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96",
+        "dest": "cargo/vendor/cc-1.2.65"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f\", \"files\": {}}",
-        "dest": "cargo/vendor/cc-1.2.64",
+        "contents": "{\"package\": \"e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.2.65",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1029,19 +1029,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/foldhash/foldhash-0.1.5.crate",
-        "sha256": "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2",
-        "dest": "cargo/vendor/foldhash-0.1.5"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2\", \"files\": {}}",
-        "dest": "cargo/vendor/foldhash-0.1.5",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/foldhash/foldhash-0.2.0.crate",
         "sha256": "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb",
         "dest": "cargo/vendor/foldhash-0.2.0"
@@ -1432,14 +1419,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/getrandom/getrandom-0.4.2.crate",
-        "sha256": "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555",
-        "dest": "cargo/vendor/getrandom-0.4.2"
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.4.3.crate",
+        "sha256": "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099",
+        "dest": "cargo/vendor/getrandom-0.4.3"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555\", \"files\": {}}",
-        "dest": "cargo/vendor/getrandom-0.4.2",
+        "contents": "{\"package\": \"300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1674,19 +1661,6 @@
         "type": "inline",
         "contents": "{\"package\": \"6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b\", \"files\": {}}",
         "dest": "cargo/vendor/half-2.7.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.15.5.crate",
-        "sha256": "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1",
-        "dest": "cargo/vendor/hashbrown-0.15.5"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1\", \"files\": {}}",
-        "dest": "cargo/vendor/hashbrown-0.15.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2004,19 +1978,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/id-arena/id-arena-2.3.0.crate",
-        "sha256": "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954",
-        "dest": "cargo/vendor/id-arena-2.3.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954\", \"files\": {}}",
-        "dest": "cargo/vendor/id-arena-2.3.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/idna/idna-1.1.0.crate",
         "sha256": "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de",
         "dest": "cargo/vendor/idna-1.1.0"
@@ -2199,14 +2160,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.102.crate",
-        "sha256": "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31",
-        "dest": "cargo/vendor/js-sys-0.3.102"
+        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.103.crate",
+        "sha256": "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102",
+        "dest": "cargo/vendor/js-sys-0.3.103"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31\", \"files\": {}}",
-        "dest": "cargo/vendor/js-sys-0.3.102",
+        "contents": "{\"package\": \"53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102\", \"files\": {}}",
+        "dest": "cargo/vendor/js-sys-0.3.103",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2433,19 +2394,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/leb128fmt/leb128fmt-0.1.0.crate",
-        "sha256": "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2",
-        "dest": "cargo/vendor/leb128fmt-0.1.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2\", \"files\": {}}",
-        "dest": "cargo/vendor/leb128fmt-0.1.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/libadwaita/libadwaita-0.9.1.crate",
         "sha256": "bc0da4e27b20d3e71f830e5b0f0188d22c257986bf421c02cfde777fe07932a4",
         "dest": "cargo/vendor/libadwaita-0.9.1"
@@ -2602,14 +2550,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/log/log-0.4.32.crate",
-        "sha256": "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a",
-        "dest": "cargo/vendor/log-0.4.32"
+        "url": "https://static.crates.io/crates/log/log-0.4.33.crate",
+        "sha256": "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad",
+        "dest": "cargo/vendor/log-0.4.33"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a\", \"files\": {}}",
-        "dest": "cargo/vendor/log-0.4.32",
+        "contents": "{\"package\": \"0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad\", \"files\": {}}",
+        "dest": "cargo/vendor/log-0.4.33",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3317,19 +3265,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/prettyplease/prettyplease-0.2.37.crate",
-        "sha256": "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b",
-        "dest": "cargo/vendor/prettyplease-0.2.37"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b\", \"files\": {}}",
-        "dest": "cargo/vendor/prettyplease-0.2.37",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.5.0.crate",
         "sha256": "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f",
         "dest": "cargo/vendor/proc-macro-crate-3.5.0"
@@ -3395,14 +3330,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quote/quote-1.0.45.crate",
-        "sha256": "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924",
-        "dest": "cargo/vendor/quote-1.0.45"
+        "url": "https://static.crates.io/crates/quote/quote-1.0.46.crate",
+        "sha256": "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368",
+        "dest": "cargo/vendor/quote-1.0.46"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924\", \"files\": {}}",
-        "dest": "cargo/vendor/quote-1.0.45",
+        "contents": "{\"package\": \"dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368\", \"files\": {}}",
+        "dest": "cargo/vendor/quote-1.0.46",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3668,14 +3603,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustls/rustls-0.23.40.crate",
-        "sha256": "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b",
-        "dest": "cargo/vendor/rustls-0.23.40"
+        "url": "https://static.crates.io/crates/rustls/rustls-0.23.41.crate",
+        "sha256": "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f",
+        "dest": "cargo/vendor/rustls-0.23.41"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b\", \"files\": {}}",
-        "dest": "cargo/vendor/rustls-0.23.40",
+        "contents": "{\"package\": \"6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-0.23.41",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4097,14 +4032,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/syn/syn-2.0.117.crate",
-        "sha256": "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99",
-        "dest": "cargo/vendor/syn-2.0.117"
+        "url": "https://static.crates.io/crates/syn/syn-2.0.118.crate",
+        "sha256": "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422",
+        "dest": "cargo/vendor/syn-2.0.118"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99\", \"files\": {}}",
-        "dest": "cargo/vendor/syn-2.0.117",
+        "contents": "{\"package\": \"1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-2.0.118",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4708,19 +4643,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.6.crate",
-        "sha256": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853",
-        "dest": "cargo/vendor/unicode-xid-0.2.6"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853\", \"files\": {}}",
-        "dest": "cargo/vendor/unicode-xid-0.2.6",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/untrusted/untrusted-0.9.0.crate",
         "sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1",
         "dest": "cargo/vendor/untrusted-0.9.0"
@@ -4773,14 +4695,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/uuid/uuid-1.23.3.crate",
-        "sha256": "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7",
-        "dest": "cargo/vendor/uuid-1.23.3"
+        "url": "https://static.crates.io/crates/uuid/uuid-1.23.4.crate",
+        "sha256": "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53",
+        "dest": "cargo/vendor/uuid-1.23.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7\", \"files\": {}}",
-        "dest": "cargo/vendor/uuid-1.23.3",
+        "contents": "{\"package\": \"bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53\", \"files\": {}}",
+        "dest": "cargo/vendor/uuid-1.23.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4877,105 +4799,66 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasip3/wasip3-0.4.0+wasi-0.3.0-rc-2026-01-06.crate",
-        "sha256": "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5",
-        "dest": "cargo/vendor/wasip3-0.4.0+wasi-0.3.0-rc-2026-01-06"
+        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.126.crate",
+        "sha256": "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.126"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5\", \"files\": {}}",
-        "dest": "cargo/vendor/wasip3-0.4.0+wasi-0.3.0-rc-2026-01-06",
+        "contents": "{\"package\": \"4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.126",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.125.crate",
-        "sha256": "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a",
-        "dest": "cargo/vendor/wasm-bindgen-0.2.125"
+        "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.76.crate",
+        "sha256": "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.76"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-0.2.125",
+        "contents": "{\"package\": \"c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.76",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.75.crate",
-        "sha256": "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280",
-        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.75"
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.126.crate",
+        "sha256": "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.126"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.75",
+        "contents": "{\"package\": \"167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.126",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.125.crate",
-        "sha256": "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d",
-        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.125"
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.126.crate",
+        "sha256": "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.126"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.125",
+        "contents": "{\"package\": \"f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.126",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.125.crate",
-        "sha256": "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd",
-        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.125"
+        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.126.crate",
+        "sha256": "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.126"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.125",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.125.crate",
-        "sha256": "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f",
-        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.125"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.125",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-encoder/wasm-encoder-0.244.0.crate",
-        "sha256": "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319",
-        "dest": "cargo/vendor/wasm-encoder-0.244.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-encoder-0.244.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasm-metadata/wasm-metadata-0.244.0.crate",
-        "sha256": "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909",
-        "dest": "cargo/vendor/wasm-metadata-0.244.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909\", \"files\": {}}",
-        "dest": "cargo/vendor/wasm-metadata-0.244.0",
+        "contents": "{\"package\": \"dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.126",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -4994,27 +4877,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasmparser/wasmparser-0.244.0.crate",
-        "sha256": "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe",
-        "dest": "cargo/vendor/wasmparser-0.244.0"
+        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.103.crate",
+        "sha256": "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141",
+        "dest": "cargo/vendor/web-sys-0.3.103"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe\", \"files\": {}}",
-        "dest": "cargo/vendor/wasmparser-0.244.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.102.crate",
-        "sha256": "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d",
-        "dest": "cargo/vendor/web-sys-0.3.102"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d\", \"files\": {}}",
-        "dest": "cargo/vendor/web-sys-0.3.102",
+        "contents": "{\"package\": \"8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141\", \"files\": {}}",
+        "dest": "cargo/vendor/web-sys-0.3.103",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5423,19 +5293,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wit-bindgen/wit-bindgen-0.51.0.crate",
-        "sha256": "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5",
-        "dest": "cargo/vendor/wit-bindgen-0.51.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5\", \"files\": {}}",
-        "dest": "cargo/vendor/wit-bindgen-0.51.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wit-bindgen/wit-bindgen-0.57.1.crate",
         "sha256": "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e",
         "dest": "cargo/vendor/wit-bindgen-0.57.1"
@@ -5444,71 +5301,6 @@
         "type": "inline",
         "contents": "{\"package\": \"1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e\", \"files\": {}}",
         "dest": "cargo/vendor/wit-bindgen-0.57.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wit-bindgen-core/wit-bindgen-core-0.51.0.crate",
-        "sha256": "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc",
-        "dest": "cargo/vendor/wit-bindgen-core-0.51.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc\", \"files\": {}}",
-        "dest": "cargo/vendor/wit-bindgen-core-0.51.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wit-bindgen-rust/wit-bindgen-rust-0.51.0.crate",
-        "sha256": "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21",
-        "dest": "cargo/vendor/wit-bindgen-rust-0.51.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21\", \"files\": {}}",
-        "dest": "cargo/vendor/wit-bindgen-rust-0.51.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wit-bindgen-rust-macro/wit-bindgen-rust-macro-0.51.0.crate",
-        "sha256": "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a",
-        "dest": "cargo/vendor/wit-bindgen-rust-macro-0.51.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a\", \"files\": {}}",
-        "dest": "cargo/vendor/wit-bindgen-rust-macro-0.51.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wit-component/wit-component-0.244.0.crate",
-        "sha256": "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2",
-        "dest": "cargo/vendor/wit-component-0.244.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2\", \"files\": {}}",
-        "dest": "cargo/vendor/wit-component-0.244.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wit-parser/wit-parser-0.244.0.crate",
-        "sha256": "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736",
-        "dest": "cargo/vendor/wit-parser-0.244.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736\", \"files\": {}}",
-        "dest": "cargo/vendor/wit-parser-0.244.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/setup/dev.nicx.mimick.desktop
+++ b/setup/dev.nicx.mimick.desktop
@@ -1,16 +1,17 @@
 [Desktop Entry]
 Name=Mimick
 Comment=Unofficial Immich desktop client and auto-sync agent
-Exec=mimick
+Exec=mimick %F
 Icon=dev.nicx.mimick
 Terminal=false
 Type=Application
 Categories=Utility;
-Actions=Library;Settings;Quit;
+Actions=Library;Settings;Upload;Quit;
 Keywords=Photo;Sync;Backup;Immich;
 StartupNotify=true
 StartupWMClass=dev.nicx.mimick
 SingleMainWindow=true
+MimeType=application/mxf;image/avif;image/bmp;image/cineon;image/gif;image/heic;image/heif;image/jp2;image/jpeg;image/jxl;image/png;image/svg+xml;image/tiff;image/vnd.adobe.photoshop;image/webp;image/x-adobe-dng;image/x-arriflex-ari;image/x-canon-cr2;image/x-canon-cr3;image/x-canon-crw;image/x-epson-erf;image/x-fuji-raf;image/x-hasselblad-3fr;image/x-hasselblad-fff;image/x-kodak-dcr;image/x-kodak-k25;image/x-kodak-kdc;image/x-leica-rwl;image/x-minolta-mrw;image/x-nikon-nef;image/x-nikon-nrw;image/x-olympus-orf;image/x-panasonic-raw;image/x-panasonic-rw2;image/x-pentax-pef;image/x-phaseone-cap;image/x-phaseone-iiq;image/x-samsung-srw;image/x-sigma-x3f;image/x-sony-arw;image/x-sony-sr2;video/3gpp;video/dvd;video/mp2t;video/mp4;video/mpeg;video/quicktime;video/webm;video/x-flv;video/x-m4v;video/x-matroska;video/x-ms-wmv;video/x-msvideo;
 
 [Desktop Action Library]
 Name=Open Library
@@ -19,6 +20,10 @@ Exec=mimick --library
 [Desktop Action Settings]
 Name=Open Settings
 Exec=mimick --settings
+
+[Desktop Action Upload]
+Name=Upload with Mimick
+Exec=mimick --upload %F
 
 [Desktop Action Quit]
 Name=Quit Mimick

--- a/src/library/asset_model.rs
+++ b/src/library/asset_model.rs
@@ -105,6 +105,17 @@ impl LibraryAssetModel {
             self.items_changed(0, prev_n, new_n);
         }
     }
+
+    /// Replace all items with pre-built `AssetObject`s and emit a full reset.
+    ///
+    /// Used by the staging view which constructs local-only `AssetObject`s
+    /// from file paths rather than going through the `LibraryAsset` pipeline.
+    pub fn reset_with_objects(&self, objects: Vec<AssetObject>) {
+        let prev_n = self.imp().items.borrow().len() as u32;
+        let new_n = objects.len() as u32;
+        *self.imp().items.borrow_mut() = objects;
+        self.items_changed(0, prev_n, new_n);
+    }
 }
 
 fn build_sorted_asset_objects(

--- a/src/library/masonry/canvas.rs
+++ b/src/library/masonry/canvas.rs
@@ -383,9 +383,6 @@ mod imp {
         }
 
         /// Paint a checkbox indicator in the top-left corner of a tile.
-        ///
-        /// Unchecked: semi-transparent bordered square (outline only).
-        /// Checked: accent-coloured filled square with a checkmark icon.
         fn paint_checkbox(
             &self,
             snapshot: &gtk::Snapshot,
@@ -398,63 +395,62 @@ mod imp {
             let margin = 6.0_f32;
             let bx = cell_x + margin;
             let by = cell_y + margin;
+            if selected {
+                self.paint_checked_box(snapshot, bx, by, box_size);
+            } else {
+                Self::paint_unchecked_box(snapshot, bx, by, box_size);
+            }
+        }
 
+        /// Accent-filled square with a checkmark icon.
+        fn paint_checked_box(&self, snapshot: &gtk::Snapshot, bx: f32, by: f32, box_size: f32) {
             let r = 4.0_f32;
+            let corner = Size::new(r, r);
+            let rect = Rect::new(bx, by, box_size, box_size);
+            let rounded = RoundedRect::new(rect, corner, corner, corner, corner);
+            snapshot.push_rounded_clip(&rounded);
+            snapshot.append_color(&accent_bg_color(), &rect);
+            snapshot.pop();
+
+            let icon = self
+                .check_icon
+                .get_or_init(|| resolve_symbolic_icon(&self.obj(), "object-select-symbolic"));
+            let inset = 3.0_f32;
+            let icon_size = box_size - inset * 2.0;
+            snapshot.save();
+            snapshot.translate(&gtk::graphene::Point::new(bx + inset, by + inset));
+            icon.snapshot(
+                snapshot.upcast_ref::<gdk4::Snapshot>(),
+                icon_size as f64,
+                icon_size as f64,
+            );
+            snapshot.restore();
+        }
+
+        /// Bordered empty square (outline only).
+        fn paint_unchecked_box(snapshot: &gtk::Snapshot, bx: f32, by: f32, box_size: f32) {
+            let r = 4.0_f32;
+            let border_w = 2.0_f32;
             let corner = Size::new(r, r);
             let outer_rect = Rect::new(bx, by, box_size, box_size);
             let outer_round = RoundedRect::new(outer_rect, corner, corner, corner, corner);
 
-            if selected {
-                // Filled square with theme accent colour.
-                let accent = accent_bg_color();
-                snapshot.push_rounded_clip(&outer_round);
-                snapshot.append_color(&accent, &outer_rect);
-                snapshot.pop();
+            snapshot.push_rounded_clip(&outer_round);
+            snapshot.append_color(&gdk4::RGBA::new(1.0, 1.0, 1.0, 0.8), &outer_rect);
 
-                // Checkmark icon inside.
-                let icon = self
-                    .check_icon
-                    .get_or_init(|| resolve_symbolic_icon(&self.obj(), "object-select-symbolic"));
-                let icon_inset = 3.0_f32;
-                let icon_size = box_size - icon_inset * 2.0;
-                snapshot.save();
-                snapshot.translate(&gtk::graphene::Point::new(bx + icon_inset, by + icon_inset));
-                icon.snapshot(
-                    snapshot.upcast_ref::<gdk4::Snapshot>(),
-                    icon_size as f64,
-                    icon_size as f64,
-                );
-                snapshot.restore();
-            } else {
-                // Outlined square: draw outer bg then inner cutout for border effect.
-                let border_w = 2.0_f32;
-                let border_color = gdk4::RGBA::new(1.0, 1.0, 1.0, 0.8);
-                let inner_color = gdk4::RGBA::new(0.0, 0.0, 0.0, 0.3);
-
-                snapshot.push_rounded_clip(&outer_round);
-                snapshot.append_color(&border_color, &outer_rect);
-
-                let inner_rect = Rect::new(
-                    bx + border_w,
-                    by + border_w,
-                    box_size - border_w * 2.0,
-                    box_size - border_w * 2.0,
-                );
-                let ir = (r - border_w).max(0.0);
-                let inner_corner = Size::new(ir, ir);
-                let inner_round = RoundedRect::new(
-                    inner_rect,
-                    inner_corner,
-                    inner_corner,
-                    inner_corner,
-                    inner_corner,
-                );
-                snapshot.push_rounded_clip(&inner_round);
-                snapshot.append_color(&inner_color, &inner_rect);
-                snapshot.pop();
-
-                snapshot.pop();
-            }
+            let ir = (r - border_w).max(0.0);
+            let ic = Size::new(ir, ir);
+            let inner = Rect::new(
+                bx + border_w,
+                by + border_w,
+                box_size - border_w * 2.0,
+                box_size - border_w * 2.0,
+            );
+            let inner_round = RoundedRect::new(inner, ic, ic, ic, ic);
+            snapshot.push_rounded_clip(&inner_round);
+            snapshot.append_color(&gdk4::RGBA::new(0.0, 0.0, 0.0, 0.3), &inner);
+            snapshot.pop();
+            snapshot.pop();
         }
 
         fn queue_load_if_needed(

--- a/src/library/masonry/canvas.rs
+++ b/src/library/masonry/canvas.rs
@@ -97,6 +97,10 @@ mod imp {
         pub permission_warned: Cell<bool>,
         /// Cached video badge icon paintable, resolved lazily from the icon theme.
         pub video_icon: OnceCell<gdk4::Paintable>,
+        /// Cached checkbox icon (selected state).
+        pub check_icon: OnceCell<gdk4::Paintable>,
+        /// Cached checkbox icon (unselected state).
+        pub uncheck_icon: OnceCell<gdk4::Paintable>,
     }
 
     #[glib::object_subclass]
@@ -314,6 +318,11 @@ mod imp {
                 snapshot.append_color(&sctx.select_tint, &rect);
             }
 
+            // Checkbox badge in select mode.
+            if self.select_mode.get() {
+                self.paint_checkbox(snapshot, it.x, row.y, row.h, selected);
+            }
+
             // Video badge: paint a centred play icon over video asset cells.
             let is_video = asset
                 .property::<String>("asset-type")
@@ -365,6 +374,53 @@ mod imp {
             let icon_y = cell_y + (cell_h - icon_size) * 0.5;
             snapshot.save();
             snapshot.translate(&gtk::graphene::Point::new(icon_x, icon_y));
+            icon.snapshot(
+                snapshot.upcast_ref::<gdk4::Snapshot>(),
+                icon_size as f64,
+                icon_size as f64,
+            );
+            snapshot.restore();
+        }
+
+        /// Paint a checkbox icon in the top-left corner of a tile.
+        fn paint_checkbox(
+            &self,
+            snapshot: &gtk::Snapshot,
+            cell_x: f32,
+            cell_y: f32,
+            cell_h: f32,
+            selected: bool,
+        ) {
+            let icon = if selected {
+                self.check_icon
+                    .get_or_init(|| resolve_symbolic_icon(&self.obj(), "object-select-symbolic"))
+            } else {
+                self.uncheck_icon
+                    .get_or_init(|| resolve_symbolic_icon(&self.obj(), "checkbox-symbolic"))
+            };
+
+            let icon_size = (cell_h * 0.16).clamp(14.0, 28.0);
+            let padding = 4.0_f32;
+            let ix = cell_x + padding;
+            let iy = cell_y + padding;
+
+            // Semi-transparent background pill for contrast.
+            let bg_size = icon_size + padding * 2.0;
+            let bg_rect = Rect::new(ix - padding, iy - padding, bg_size, bg_size);
+            let half = bg_size * 0.5;
+            let corner = Size::new(half, half);
+            let rounded = RoundedRect::new(bg_rect, corner, corner, corner, corner);
+            let bg_color = if selected {
+                gdk4::RGBA::new(0.2, 0.6, 1.0, 0.7)
+            } else {
+                gdk4::RGBA::new(0.0, 0.0, 0.0, 0.45)
+            };
+            snapshot.push_rounded_clip(&rounded);
+            snapshot.append_color(&bg_color, &bg_rect);
+            snapshot.pop();
+
+            snapshot.save();
+            snapshot.translate(&gtk::graphene::Point::new(ix, iy));
             icon.snapshot(
                 snapshot.upcast_ref::<gdk4::Snapshot>(),
                 icon_size as f64,
@@ -541,13 +597,17 @@ fn placeholder_color() -> gdk4::RGBA {
 /// Resolve the video badge icon from the icon theme. The result is cached
 /// per-canvas via a `OnceCell` so the theme lookup only happens once.
 fn resolve_video_icon(widget: &MasonryCanvas) -> gdk4::Paintable {
+    resolve_symbolic_icon(widget, "mimick-video-symbolic")
+}
+
+fn resolve_symbolic_icon(widget: &MasonryCanvas, icon_name: &str) -> gdk4::Paintable {
     let display = widget
         .native()
         .map(|n| n.display())
         .unwrap_or_else(|| gtk::gdk::Display::default().expect("default GDK display"));
     let theme = gtk::IconTheme::for_display(&display);
     let icon = theme.lookup_icon(
-        "mimick-video-symbolic",
+        icon_name,
         &[],
         48,
         1,

--- a/src/library/masonry/canvas.rs
+++ b/src/library/masonry/canvas.rs
@@ -382,7 +382,10 @@ mod imp {
             snapshot.restore();
         }
 
-        /// Paint a checkbox icon in the top-left corner of a tile.
+        /// Paint a checkbox indicator in the top-left corner of a tile.
+        ///
+        /// Unchecked: semi-transparent bordered square (outline only).
+        /// Checked: accent-coloured filled square with a checkmark icon.
         fn paint_checkbox(
             &self,
             snapshot: &gtk::Snapshot,
@@ -391,42 +394,67 @@ mod imp {
             cell_h: f32,
             selected: bool,
         ) {
-            let icon = if selected {
-                self.check_icon
-                    .get_or_init(|| resolve_symbolic_icon(&self.obj(), "object-select-symbolic"))
+            let box_size = (cell_h * 0.14).clamp(16.0, 26.0);
+            let margin = 6.0_f32;
+            let bx = cell_x + margin;
+            let by = cell_y + margin;
+
+            let r = 4.0_f32;
+            let corner = Size::new(r, r);
+            let outer_rect = Rect::new(bx, by, box_size, box_size);
+            let outer_round = RoundedRect::new(outer_rect, corner, corner, corner, corner);
+
+            if selected {
+                // Filled square with theme accent colour.
+                let accent = accent_bg_color();
+                snapshot.push_rounded_clip(&outer_round);
+                snapshot.append_color(&accent, &outer_rect);
+                snapshot.pop();
+
+                // Checkmark icon inside.
+                let icon = self
+                    .check_icon
+                    .get_or_init(|| resolve_symbolic_icon(&self.obj(), "object-select-symbolic"));
+                let icon_inset = 3.0_f32;
+                let icon_size = box_size - icon_inset * 2.0;
+                snapshot.save();
+                snapshot.translate(&gtk::graphene::Point::new(bx + icon_inset, by + icon_inset));
+                icon.snapshot(
+                    snapshot.upcast_ref::<gdk4::Snapshot>(),
+                    icon_size as f64,
+                    icon_size as f64,
+                );
+                snapshot.restore();
             } else {
-                self.uncheck_icon
-                    .get_or_init(|| resolve_symbolic_icon(&self.obj(), "checkbox-symbolic"))
-            };
+                // Outlined square: draw outer bg then inner cutout for border effect.
+                let border_w = 2.0_f32;
+                let border_color = gdk4::RGBA::new(1.0, 1.0, 1.0, 0.8);
+                let inner_color = gdk4::RGBA::new(0.0, 0.0, 0.0, 0.3);
 
-            let icon_size = (cell_h * 0.16).clamp(14.0, 28.0);
-            let padding = 4.0_f32;
-            let ix = cell_x + padding;
-            let iy = cell_y + padding;
+                snapshot.push_rounded_clip(&outer_round);
+                snapshot.append_color(&border_color, &outer_rect);
 
-            // Semi-transparent background pill for contrast.
-            let bg_size = icon_size + padding * 2.0;
-            let bg_rect = Rect::new(ix - padding, iy - padding, bg_size, bg_size);
-            let half = bg_size * 0.5;
-            let corner = Size::new(half, half);
-            let rounded = RoundedRect::new(bg_rect, corner, corner, corner, corner);
-            let bg_color = if selected {
-                gdk4::RGBA::new(0.2, 0.6, 1.0, 0.7)
-            } else {
-                gdk4::RGBA::new(0.0, 0.0, 0.0, 0.45)
-            };
-            snapshot.push_rounded_clip(&rounded);
-            snapshot.append_color(&bg_color, &bg_rect);
-            snapshot.pop();
+                let inner_rect = Rect::new(
+                    bx + border_w,
+                    by + border_w,
+                    box_size - border_w * 2.0,
+                    box_size - border_w * 2.0,
+                );
+                let ir = (r - border_w).max(0.0);
+                let inner_corner = Size::new(ir, ir);
+                let inner_round = RoundedRect::new(
+                    inner_rect,
+                    inner_corner,
+                    inner_corner,
+                    inner_corner,
+                    inner_corner,
+                );
+                snapshot.push_rounded_clip(&inner_round);
+                snapshot.append_color(&inner_color, &inner_rect);
+                snapshot.pop();
 
-            snapshot.save();
-            snapshot.translate(&gtk::graphene::Point::new(ix, iy));
-            icon.snapshot(
-                snapshot.upcast_ref::<gdk4::Snapshot>(),
-                icon_size as f64,
-                icon_size as f64,
-            );
-            snapshot.restore();
+                snapshot.pop();
+            }
         }
 
         fn queue_load_if_needed(
@@ -584,6 +612,12 @@ impl imp::SnapshotStats {
         }
         self.painted += 1;
     }
+}
+
+/// Get the current theme accent background colour from libadwaita.
+fn accent_bg_color() -> gdk4::RGBA {
+    let accent = libadwaita::StyleManager::default().accent_color();
+    accent.to_rgba()
 }
 
 fn placeholder_color() -> gdk4::RGBA {

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -61,6 +61,7 @@ mod download;
 mod filters;
 mod lightbox;
 mod server_stats_dialog;
+pub mod staging_view;
 mod upload_picker;
 
 const PAGE_SIZE: u32 = 50;
@@ -70,7 +71,7 @@ use texture_decode::{decode_raw_thumbnail_texture, load_texture_blocking};
 pub use texture_decode::{set_raw_cache_enabled, set_raw_full_decode};
 
 /// Register application custom icons with the Gtk icon theme system.
-fn register_app_icons() {
+pub(crate) fn register_app_icons() {
     if let Some(display) = gtk::gdk::Display::default() {
         let theme = gtk::IconTheme::for_display(&display);
         theme.add_resource_path("/dev/nicx/mimick/icons");
@@ -79,7 +80,7 @@ fn register_app_icons() {
 
 /// Load a local texture, preferring decoders that cover formats outside the
 /// GDK-Pixbuf runtime loader set before falling back to pixbuf and image-rs.
-async fn load_texture_oriented(path: &std::path::Path) -> Option<gdk4::Texture> {
+pub(crate) async fn load_texture_oriented(path: &std::path::Path) -> Option<gdk4::Texture> {
     let path_buf = path.to_path_buf();
     tokio::task::spawn_blocking(move || load_texture_blocking(&path_buf))
         .await

--- a/src/library/staging_view.rs
+++ b/src/library/staging_view.rs
@@ -62,7 +62,7 @@ pub fn build_staging_window(
         .css_classes(["mimick-pressable"])
         .build();
     let select_all_btn = gtk::Button::builder()
-        .label("All")
+        .icon_name("edit-select-all-symbolic")
         .tooltip_text("Select all / Deselect all")
         .css_classes(["mimick-pressable"])
         .build();

--- a/src/library/staging_view.rs
+++ b/src/library/staging_view.rs
@@ -1,9 +1,9 @@
 //! Staging view for files opened via "Open With" or the `--upload` CLI flag.
 //!
 //! Presents externally-provided file paths in a masonry grid with selection
-//! checkboxes, a right-side preview pane, and Upload / Upload to Album
-//! actions. Reuses the existing `MasonryCanvas`, `LibraryAssetModel`,
-//! `AssetObject`, `ThumbnailCache`, and `spawn_enqueue` infrastructure.
+//! checkboxes and Upload / Upload to Album actions. Reuses the existing
+//! `MasonryCanvas`, `LibraryAssetModel`, `AssetObject`, `ThumbnailCache`,
+//! and `spawn_enqueue` infrastructure.
 
 use std::cell::Cell;
 use std::path::PathBuf;
@@ -46,24 +46,23 @@ pub fn build_staging_window(
         .build();
 
     // --- Header bar ---
-    // Use icon+tooltip buttons so the header fits at 360px without overflow.
     let header = libadwaita::HeaderBar::builder()
         .show_start_title_buttons(true)
         .show_end_title_buttons(true)
         .build();
 
     let upload_btn = gtk::Button::builder()
-        .icon_name("document-send-symbolic")
+        .label("Upload")
         .tooltip_text("Upload selected files to library")
         .css_classes(["suggested-action", "mimick-pressable"])
         .build();
     let upload_album_btn = gtk::Button::builder()
-        .icon_name("folder-pictures-symbolic")
+        .label("Album")
         .tooltip_text("Upload selected files to an album")
         .css_classes(["mimick-pressable"])
         .build();
     let select_all_btn = gtk::Button::builder()
-        .icon_name("edit-select-all-symbolic")
+        .label("All")
         .tooltip_text("Select all / Deselect all")
         .css_classes(["mimick-pressable"])
         .build();
@@ -88,61 +87,6 @@ pub fn build_staging_window(
     let assets = build_staging_assets(&files);
     grid.model.reset_with_objects(assets);
 
-    // --- Preview split pane ---
-    let preview_picture = gtk::Picture::builder()
-        .content_fit(gtk::ContentFit::Contain)
-        .vexpand(true)
-        .hexpand(true)
-        .build();
-    let preview_filename = gtk::Label::builder()
-        .halign(gtk::Align::Start)
-        .ellipsize(gtk::pango::EllipsizeMode::Middle)
-        .css_classes(["title-4"])
-        .build();
-    let preview_info = gtk::Label::builder()
-        .halign(gtk::Align::Start)
-        .css_classes(["dim-label"])
-        .build();
-    let preview_box = gtk::Box::builder()
-        .orientation(gtk::Orientation::Vertical)
-        .spacing(8)
-        .margin_top(12)
-        .margin_bottom(12)
-        .margin_start(12)
-        .margin_end(12)
-        .build();
-    preview_box.append(&preview_picture);
-    preview_box.append(&preview_filename);
-    preview_box.append(&preview_info);
-
-    let preview_scroll = gtk::ScrolledWindow::builder()
-        .child(&preview_box)
-        .hscrollbar_policy(gtk::PolicyType::Never)
-        .vexpand(true)
-        .build();
-
-    let split = libadwaita::OverlaySplitView::builder()
-        .sidebar_position(gtk::PackType::End)
-        .show_sidebar(false)
-        .collapsed(true) // overlay mode at narrow widths
-        .enable_show_gesture(true)
-        .enable_hide_gesture(true)
-        .min_sidebar_width(200.0)
-        .max_sidebar_width(400.0)
-        .sidebar_width_fraction(0.40)
-        .build();
-    split.set_content(Some(&grid.scrolled));
-    split.set_sidebar(Some(&preview_scroll));
-
-    // Track narrow state and collapse the split pane when the window is small.
-    {
-        let split_ref = split.clone();
-        window.connect_default_width_notify(move |win| {
-            let is_narrow = win.default_width() < 600;
-            split_ref.set_collapsed(is_narrow);
-        });
-    }
-
     // --- Status bar ---
     let status_label = gtk::Label::builder()
         .halign(gtk::Align::Start)
@@ -155,51 +99,13 @@ pub fn build_staging_window(
     let file_count = grid.model.n_items();
     status_label.set_text(&format!("{} file(s) staged", file_count));
 
-    toolbar.set_content(Some(&split));
+    toolbar.set_content(Some(&grid.scrolled));
     toolbar.add_bottom_bar(&status_label);
     window.set_content(Some(&toolbar));
 
     // --- Clone captures for closures ---
     let files_rc = Rc::new(files);
     let selection = grid.selection.clone();
-    let model_for_click = grid.model.clone();
-    let split_ref = split.clone();
-    let preview_picture_ref = preview_picture.clone();
-    let preview_filename_ref = preview_filename.clone();
-    let preview_info_ref = preview_info.clone();
-
-    // --- Tile click -> preview ---
-    grid.canvas.set_activate_handler(move |position| {
-        let Some(item) = model_for_click.item(position).and_downcast::<AssetObject>() else {
-            return;
-        };
-        let filename = item.property::<String>("filename");
-        let local_path = item.property::<String>("local-path");
-        let asset_type = item.property::<String>("asset-type");
-        let is_video = asset_type.eq_ignore_ascii_case("VIDEO");
-
-        preview_filename_ref.set_text(&filename);
-        split_ref.set_show_sidebar(true);
-
-        if is_video {
-            preview_picture_ref.set_paintable(None::<&gdk4::Paintable>);
-            preview_info_ref.set_text("Video file - upload to view on server");
-        } else {
-            let picture = preview_picture_ref.clone();
-            let info = preview_info_ref.clone();
-            let path = PathBuf::from(&local_path);
-            glib::MainContext::default().spawn_local(async move {
-                if let Some(texture) = crate::library::load_texture_oriented(&path).await {
-                    let dims = format!("{} x {} px", texture.width(), texture.height());
-                    info.set_text(&dims);
-                    picture.set_paintable(Some(&texture));
-                } else {
-                    info.set_text("Could not decode image");
-                    picture.set_paintable(None::<&gdk4::Paintable>);
-                }
-            });
-        }
-    });
 
     // --- Select All / Deselect All ---
     {

--- a/src/library/staging_view.rs
+++ b/src/library/staging_view.rs
@@ -103,6 +103,27 @@ pub fn build_staging_window(
     toolbar.add_bottom_bar(&status_label);
     window.set_content(Some(&toolbar));
 
+    // --- Responsive narrow breakpoint (matches main library window at 600sp) ---
+    {
+        let breakpoint = libadwaita::Breakpoint::new(
+            libadwaita::BreakpointCondition::parse("max-width: 600sp")
+                .expect("valid breakpoint condition"),
+        );
+        let narrow_flag = narrow.clone();
+        let canvas_for_apply = grid.canvas.clone();
+        breakpoint.connect_apply(move |_| {
+            narrow_flag.set(true);
+            canvas_for_apply.set_narrow(true);
+        });
+        let narrow_flag = narrow.clone();
+        let canvas_for_unapply = grid.canvas.clone();
+        breakpoint.connect_unapply(move |_| {
+            narrow_flag.set(false);
+            canvas_for_unapply.set_narrow(false);
+        });
+        window.add_breakpoint(breakpoint);
+    }
+
     // --- Clone captures for closures ---
     let files_rc = Rc::new(files);
     let selection = grid.selection.clone();

--- a/src/library/staging_view.rs
+++ b/src/library/staging_view.rs
@@ -45,169 +45,29 @@ pub fn build_staging_window(
         .height_request(400)
         .build();
 
-    // --- Header bar ---
-    let header = libadwaita::HeaderBar::builder()
-        .show_start_title_buttons(true)
-        .show_end_title_buttons(true)
-        .build();
+    let (upload_btn, upload_album_btn, select_all_btn, grid, status_label) =
+        build_staging_ui(&window, &ctx, &files);
+    setup_narrow_breakpoint(&window, &grid);
 
-    let upload_btn = gtk::Button::builder()
-        .label("Upload")
-        .tooltip_text("Upload selected files to library")
-        .css_classes(["suggested-action", "mimick-pressable"])
-        .build();
-    let upload_album_btn = gtk::Button::builder()
-        .label("Album")
-        .tooltip_text("Upload selected files to an album")
-        .css_classes(["mimick-pressable"])
-        .build();
-    let select_all_btn = gtk::Button::builder()
-        .icon_name("edit-select-all-symbolic")
-        .tooltip_text("Select all / Deselect all")
-        .css_classes(["mimick-pressable"])
-        .build();
-
-    header.pack_start(&upload_btn);
-    header.pack_start(&upload_album_btn);
-    header.pack_end(&select_all_btn);
-
-    let toolbar = libadwaita::ToolbarView::builder().build();
-    toolbar.add_top_bar(&header);
-
-    // --- Grid ---
-    let select_toggle = gtk::ToggleButton::builder()
-        .active(true) // staging view starts in select mode
-        .build();
-    let narrow = Rc::new(Cell::new(false));
-    let grid = build_grid_view(ctx.clone(), select_toggle.clone(), narrow.clone());
-    // Always show select checkboxes in staging view.
-    grid.canvas.set_select_mode(true);
-
-    // Populate model from file paths.
-    let assets = build_staging_assets(&files);
-    grid.model.reset_with_objects(assets);
-
-    // --- Status bar ---
-    let status_label = gtk::Label::builder()
-        .halign(gtk::Align::Start)
-        .hexpand(true)
-        .margin_start(12)
-        .margin_end(12)
-        .margin_top(4)
-        .margin_bottom(4)
-        .build();
     let file_count = grid.model.n_items();
-    status_label.set_text(&format!("{} file(s) staged", file_count));
-
-    toolbar.set_content(Some(&grid.scrolled));
-    toolbar.add_bottom_bar(&status_label);
-    window.set_content(Some(&toolbar));
-
-    // --- Responsive narrow breakpoint (matches main library window at 600sp) ---
-    {
-        let breakpoint = libadwaita::Breakpoint::new(
-            libadwaita::BreakpointCondition::parse("max-width: 600sp")
-                .expect("valid breakpoint condition"),
-        );
-        let narrow_flag = narrow.clone();
-        let canvas_for_apply = grid.canvas.clone();
-        breakpoint.connect_apply(move |_| {
-            narrow_flag.set(true);
-            canvas_for_apply.set_narrow(true);
-        });
-        let narrow_flag = narrow.clone();
-        let canvas_for_unapply = grid.canvas.clone();
-        breakpoint.connect_unapply(move |_| {
-            narrow_flag.set(false);
-            canvas_for_unapply.set_narrow(false);
-        });
-        window.add_breakpoint(breakpoint);
-    }
-
-    // --- Clone captures for closures ---
     let files_rc = Rc::new(files);
     let selection = grid.selection.clone();
 
-    // --- Select All / Deselect All ---
-    {
-        let sel = selection.clone();
-        let lbl = status_label.clone();
-        let n = file_count;
-        let all_selected = Rc::new(Cell::new(false));
-        select_all_btn.connect_clicked(move |btn| {
-            if all_selected.get() {
-                sel.unselect_all();
-                btn.set_icon_name("edit-select-all-symbolic");
-                btn.set_tooltip_text(Some("Select all"));
-                all_selected.set(false);
-                lbl.set_text(&format!("{} file(s) staged", n));
-            } else {
-                sel.select_all();
-                btn.set_icon_name("edit-clear-all-symbolic");
-                btn.set_tooltip_text(Some("Deselect all"));
-                all_selected.set(true);
-                lbl.set_text(&format!("{} of {} selected", n, n));
-            }
-        });
-    }
-
-    // --- Track selection count ---
-    {
-        let sel = selection.clone();
-        let lbl = status_label.clone();
-        sel.connect_selection_changed(move |sel, _, _| {
-            let total = sel.n_items();
-            let selected = count_selected(sel);
-            if selected == 0 {
-                lbl.set_text(&format!("{} file(s) staged", total));
-            } else {
-                lbl.set_text(&format!("{} of {} selected", selected, total));
-            }
-        });
-    }
-
-    // --- Upload (library, no album) ---
-    {
-        let ctx_c = ctx.clone();
-        let sel = selection.clone();
-        let files_c = files_rc.clone();
-        let win = window.clone();
-        upload_btn.connect_clicked(move |_| {
-            let paths = selected_paths(&sel, &files_c);
-            if paths.is_empty() {
-                return;
-            }
-            let win_c = win.clone();
-            upload_picker::spawn_enqueue_with_callback(
-                ctx_c.clone(),
-                None,
-                paths,
-                move |queued, skipped| show_upload_result(&win_c, queued, skipped),
-            );
-        });
-    }
-
-    // --- Upload to Album ---
-    {
-        let ctx_c = ctx.clone();
-        let sel = selection.clone();
-        let files_c = files_rc.clone();
-        let win = window.clone();
-        upload_album_btn.connect_clicked(move |_| {
-            let paths = selected_paths(&sel, &files_c);
-            if paths.is_empty() {
-                return;
-            }
-            show_album_picker(win.clone(), ctx_c.clone(), paths);
-        });
-    }
+    connect_select_all(&select_all_btn, &selection, &status_label, file_count);
+    connect_selection_tracking(&selection, &status_label);
+    connect_upload_buttons(
+        &upload_btn,
+        &upload_album_btn,
+        &ctx,
+        &selection,
+        &files_rc,
+        &window,
+    );
 
     window.present();
 
-    // Auto-upload mode: immediately trigger album picker.
     if auto_upload {
         let all_paths = files_rc.to_vec();
-        // Select all items first.
         selection.select_all();
         glib::idle_add_local_once(clone!(
             #[strong]
@@ -219,6 +79,185 @@ pub fn build_staging_window(
             }
         ));
     }
+}
+
+/// Build header, grid, toolbar, status bar and return the interactive widgets.
+#[allow(clippy::type_complexity)]
+fn build_staging_ui(
+    window: &libadwaita::ApplicationWindow,
+    ctx: &Arc<AppContext>,
+    files: &[PathBuf],
+) -> (
+    gtk::Button,
+    gtk::Button,
+    gtk::Button,
+    crate::library::masonry::grid_view::GridViewParts,
+    gtk::Label,
+) {
+    let (header, upload_btn, upload_album_btn, select_all_btn) = build_staging_header();
+    let toolbar = libadwaita::ToolbarView::builder().build();
+    toolbar.add_top_bar(&header);
+
+    let select_toggle = gtk::ToggleButton::builder().active(true).build();
+    let narrow = Rc::new(Cell::new(false));
+    let grid = build_grid_view(ctx.clone(), select_toggle.clone(), narrow.clone());
+    grid.canvas.set_select_mode(true);
+    grid.model.reset_with_objects(build_staging_assets(files));
+
+    let status_label = gtk::Label::builder()
+        .halign(gtk::Align::Start)
+        .hexpand(true)
+        .margin_start(12)
+        .margin_end(12)
+        .margin_top(4)
+        .margin_bottom(4)
+        .build();
+    status_label.set_text(&status_text(0, grid.model.n_items()));
+
+    toolbar.set_content(Some(&grid.scrolled));
+    toolbar.add_bottom_bar(&status_label);
+    window.set_content(Some(&toolbar));
+
+    (
+        upload_btn,
+        upload_album_btn,
+        select_all_btn,
+        grid,
+        status_label,
+    )
+}
+
+/// Build the staging header bar with upload, album, and select-all buttons.
+fn build_staging_header() -> (libadwaita::HeaderBar, gtk::Button, gtk::Button, gtk::Button) {
+    let header = libadwaita::HeaderBar::builder()
+        .show_start_title_buttons(true)
+        .show_end_title_buttons(true)
+        .build();
+    let upload_btn = gtk::Button::builder()
+        .label("Upload")
+        .tooltip_text("Upload selected files to library")
+        .css_classes(["suggested-action", "mimick-pressable"])
+        .build();
+    let album_btn = gtk::Button::builder()
+        .label("Album")
+        .tooltip_text("Upload selected files to an album")
+        .css_classes(["mimick-pressable"])
+        .build();
+    let select_btn = gtk::Button::builder()
+        .icon_name("edit-select-all-symbolic")
+        .tooltip_text("Select all / Deselect all")
+        .css_classes(["mimick-pressable"])
+        .build();
+    header.pack_start(&upload_btn);
+    header.pack_start(&album_btn);
+    header.pack_end(&select_btn);
+    (header, upload_btn, album_btn, select_btn)
+}
+
+/// Install a 600sp breakpoint to toggle narrow grid layout.
+fn setup_narrow_breakpoint(
+    window: &libadwaita::ApplicationWindow,
+    grid: &crate::library::masonry::grid_view::GridViewParts,
+) {
+    let bp = libadwaita::Breakpoint::new(
+        libadwaita::BreakpointCondition::parse("max-width: 600sp")
+            .expect("valid breakpoint condition"),
+    );
+    let c1 = grid.canvas.clone();
+    bp.connect_apply(move |_| c1.set_narrow(true));
+    let c2 = grid.canvas.clone();
+    bp.connect_unapply(move |_| c2.set_narrow(false));
+    window.add_breakpoint(bp);
+}
+
+fn connect_select_all(
+    btn: &gtk::Button,
+    selection: &gtk::MultiSelection,
+    status_label: &gtk::Label,
+    file_count: u32,
+) {
+    let sel = selection.clone();
+    let lbl = status_label.clone();
+    let n = file_count;
+    let all_selected = Rc::new(Cell::new(false));
+    btn.connect_clicked(move |btn| {
+        if all_selected.get() {
+            sel.unselect_all();
+            btn.set_icon_name("edit-select-all-symbolic");
+            btn.set_tooltip_text(Some("Select all"));
+            all_selected.set(false);
+            lbl.set_text(&status_text(0, n));
+        } else {
+            sel.select_all();
+            btn.set_icon_name("edit-clear-all-symbolic");
+            btn.set_tooltip_text(Some("Deselect all"));
+            all_selected.set(true);
+            lbl.set_text(&status_text(n, n));
+        }
+    });
+}
+
+fn connect_selection_tracking(selection: &gtk::MultiSelection, status_label: &gtk::Label) {
+    let sel = selection.clone();
+    let lbl = status_label.clone();
+    sel.connect_selection_changed(move |sel, _, _| {
+        let total = sel.n_items();
+        let selected = count_selected(sel);
+        lbl.set_text(&status_text(selected, total));
+    });
+}
+
+/// Format the status bar text for selected/total counts.
+fn status_text(selected: u32, total: u32) -> String {
+    if selected == 0 {
+        format!("{} file(s) staged", total)
+    } else {
+        format!("{} of {} selected", selected, total)
+    }
+}
+
+/// Wire both upload buttons; they share identical clone setup, differing only in action.
+fn connect_upload_buttons(
+    upload_btn: &gtk::Button,
+    album_btn: &gtk::Button,
+    ctx: &Arc<AppContext>,
+    selection: &gtk::MultiSelection,
+    files_rc: &Rc<Vec<PathBuf>>,
+    window: &libadwaita::ApplicationWindow,
+) {
+    let (sel1, files1, ctx1, win1) = (
+        selection.clone(),
+        files_rc.clone(),
+        ctx.clone(),
+        window.clone(),
+    );
+    upload_btn.connect_clicked(move |_| {
+        let paths = selected_paths(&sel1, &files1);
+        if paths.is_empty() {
+            return;
+        }
+        let w = win1.clone();
+        upload_picker::spawn_enqueue_with_callback(
+            ctx1.clone(),
+            None,
+            paths,
+            move |queued, skipped| show_upload_result(&w, queued, skipped),
+        );
+    });
+
+    let (sel2, files2, ctx2, win2) = (
+        selection.clone(),
+        files_rc.clone(),
+        ctx.clone(),
+        window.clone(),
+    );
+    album_btn.connect_clicked(move |_| {
+        let paths = selected_paths(&sel2, &files2);
+        if paths.is_empty() {
+            return;
+        }
+        show_album_picker(win2.clone(), ctx2.clone(), paths);
+    });
 }
 
 /// Build `AssetObject` entries from local file paths for the staging grid.
@@ -320,14 +359,9 @@ fn show_album_picker(
     ctx: Arc<AppContext>,
     paths: Vec<PathBuf>,
 ) {
-    let dialog = libadwaita::AlertDialog::builder()
-        .heading("Upload to Album")
-        .body("Loading albums...")
-        .build();
-    dialog.add_response("cancel", "Cancel");
+    let dialog = simple_alert("Upload to Album", "Loading albums...", "cancel", "Cancel");
     dialog.present(Some(&parent));
 
-    // Fetch albums asynchronously and present the list.
     let ctx_c = ctx.clone();
     let parent_c = parent.clone();
     glib::MainContext::default().spawn_local(async move {
@@ -335,12 +369,7 @@ fn show_album_picker(
             Ok(a) => a,
             Err(err) => {
                 dialog.force_close();
-                let err_dialog = libadwaita::AlertDialog::builder()
-                    .heading("Failed to Load Albums")
-                    .body(&err)
-                    .build();
-                err_dialog.add_response("ok", "OK");
-                err_dialog.present(Some(&parent_c));
+                simple_alert("Failed to Load Albums", &err, "ok", "OK").present(Some(&parent_c));
                 return;
             }
         };
@@ -363,12 +392,56 @@ fn present_album_list(
         .build();
     dialog.add_response("cancel", "Cancel");
 
+    let (scroll, listbox) = build_album_listbox(&albums);
+    dialog.set_extra_child(Some(&scroll));
+
+    let albums_rc = Rc::new(albums);
+    let paths_rc = Rc::new(paths);
+    let ctx_c = ctx.clone();
+    dialog.connect_response(None, move |_dialog, response| {
+        if response == "cancel" {
+            return;
+        }
+        handle_album_upload(&listbox, &albums_rc, &ctx_c, &paths_rc, &parent_for_result);
+    });
+
+    dialog.add_response("upload", "Upload");
+    dialog.set_response_appearance("upload", libadwaita::ResponseAppearance::Suggested);
+    dialog.set_default_response(Some("upload"));
+    dialog.present(Some(&parent));
+}
+
+/// Handle the album upload response: look up selected row and enqueue.
+fn handle_album_upload(
+    listbox: &gtk::ListBox,
+    albums: &[LibraryAlbum],
+    ctx: &Arc<AppContext>,
+    paths: &Rc<Vec<PathBuf>>,
+    parent: &libadwaita::ApplicationWindow,
+) {
+    let Some(row) = listbox.selected_row() else {
+        return;
+    };
+    let idx = row.index() as usize;
+    if let Some(album) = albums.get(idx) {
+        let album_arg = Some((album.id.clone(), album.album_name.clone()));
+        let parent_c = parent.clone();
+        upload_picker::spawn_enqueue_with_callback(
+            ctx.clone(),
+            album_arg,
+            paths.to_vec(),
+            move |queued, skipped| show_upload_result(&parent_c, queued, skipped),
+        );
+    }
+}
+
+/// Build the scrollable album list for the picker dialog.
+fn build_album_listbox(albums: &[LibraryAlbum]) -> (gtk::ScrolledWindow, gtk::ListBox) {
     let listbox = gtk::ListBox::builder()
         .selection_mode(gtk::SelectionMode::Single)
         .css_classes(["boxed-list"])
         .build();
-
-    for album in &albums {
+    for album in albums {
         let row = libadwaita::ActionRow::builder()
             .title(&album.album_name)
             .subtitle(format!("{} assets", album.asset_count))
@@ -376,59 +449,13 @@ fn present_album_list(
             .build();
         listbox.append(&row);
     }
-
     let scroll = gtk::ScrolledWindow::builder()
         .child(&listbox)
         .min_content_height(200)
         .max_content_height(400)
         .hscrollbar_policy(gtk::PolicyType::Never)
         .build();
-    dialog.set_extra_child(Some(&scroll));
-
-    let albums_rc = Rc::new(albums);
-    let paths_rc = Rc::new(paths);
-    let ctx_c = ctx.clone();
-    let listbox_ref = listbox.clone();
-
-    dialog.connect_response(
-        None,
-        clone!(
-            #[strong]
-            albums_rc,
-            #[strong]
-            paths_rc,
-            #[strong]
-            ctx_c,
-            #[strong]
-            listbox_ref,
-            move |_dialog, response| {
-                if response == "cancel" {
-                    return;
-                }
-                let Some(row) = listbox_ref.selected_row() else {
-                    return;
-                };
-                let idx = row.index() as usize;
-                if let Some(album) = albums_rc.get(idx) {
-                    let album_arg = Some((album.id.clone(), album.album_name.clone()));
-                    let parent_c = parent_for_result.clone();
-                    upload_picker::spawn_enqueue_with_callback(
-                        ctx_c.clone(),
-                        album_arg,
-                        paths_rc.to_vec(),
-                        move |queued, skipped| show_upload_result(&parent_c, queued, skipped),
-                    );
-                }
-            }
-        ),
-    );
-
-    // Add an "Upload" response that the user clicks after selecting a row.
-    dialog.add_response("upload", "Upload");
-    dialog.set_response_appearance("upload", libadwaita::ResponseAppearance::Suggested);
-    dialog.set_default_response(Some("upload"));
-
-    dialog.present(Some(&parent));
+    (scroll, listbox)
 }
 
 /// Show a result dialog after upload enqueue completes.
@@ -459,12 +486,22 @@ fn show_upload_result(parent: &libadwaita::ApplicationWindow, queued: usize, ski
         )
     };
 
+    simple_alert(heading, &body, "ok", "OK").present(Some(parent));
+}
+
+/// Create a one-button `AlertDialog` (shared pattern used by multiple dialogs).
+fn simple_alert(
+    heading: &str,
+    body: &str,
+    response_id: &str,
+    response_label: &str,
+) -> libadwaita::AlertDialog {
     let dialog = libadwaita::AlertDialog::builder()
         .heading(heading)
-        .body(&body)
+        .body(body)
         .build();
-    dialog.add_response("ok", "OK");
-    dialog.present(Some(parent));
+    dialog.add_response(response_id, response_label);
+    dialog
 }
 
 #[cfg(test)]

--- a/src/library/staging_view.rs
+++ b/src/library/staging_view.rs
@@ -82,7 +82,6 @@ pub fn build_staging_window(
 }
 
 /// Build header, grid, toolbar, status bar and return the interactive widgets.
-#[allow(clippy::type_complexity)]
 fn build_staging_ui(
     window: &libadwaita::ApplicationWindow,
     ctx: &Arc<AppContext>,

--- a/src/library/staging_view.rs
+++ b/src/library/staging_view.rs
@@ -1,0 +1,573 @@
+//! Staging view for files opened via "Open With" or the `--upload` CLI flag.
+//!
+//! Presents externally-provided file paths in a masonry grid with selection
+//! checkboxes, a right-side preview pane, and Upload / Upload to Album
+//! actions. Reuses the existing `MasonryCanvas`, `LibraryAssetModel`,
+//! `AssetObject`, `ThumbnailCache`, and `spawn_enqueue` infrastructure.
+
+use std::cell::Cell;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use glib::clone;
+use gtk::prelude::*;
+use libadwaita::prelude::*;
+
+use crate::api_client::LibraryAlbum;
+use crate::app_context::AppContext;
+use crate::library::asset_object::AssetObject;
+use crate::library::masonry::build_grid_view;
+use crate::library::style;
+use crate::library::upload_picker;
+use crate::media_kinds;
+
+/// Build and present the staging window populated with the given file paths.
+///
+/// When `auto_upload` is true (the `--upload` Desktop Action), an album
+/// picker dialog is presented immediately after the window opens.
+pub fn build_staging_window(
+    app: &libadwaita::Application,
+    ctx: Arc<AppContext>,
+    files: Vec<PathBuf>,
+    auto_upload: bool,
+) {
+    style::ensure_registered();
+    crate::library::register_app_icons();
+
+    let window = libadwaita::ApplicationWindow::builder()
+        .application(app)
+        .title("Mimick - Upload")
+        .name("mimick-staging-window")
+        .default_width(960)
+        .default_height(640)
+        .width_request(360)
+        .height_request(400)
+        .build();
+
+    // --- Header bar ---
+    // Use icon+tooltip buttons so the header fits at 360px without overflow.
+    let header = libadwaita::HeaderBar::builder()
+        .show_start_title_buttons(true)
+        .show_end_title_buttons(true)
+        .build();
+
+    let upload_btn = gtk::Button::builder()
+        .icon_name("document-send-symbolic")
+        .tooltip_text("Upload selected files to library")
+        .css_classes(["suggested-action", "mimick-pressable"])
+        .build();
+    let upload_album_btn = gtk::Button::builder()
+        .icon_name("folder-pictures-symbolic")
+        .tooltip_text("Upload selected files to an album")
+        .css_classes(["mimick-pressable"])
+        .build();
+    let select_all_btn = gtk::Button::builder()
+        .icon_name("edit-select-all-symbolic")
+        .tooltip_text("Select all / Deselect all")
+        .css_classes(["mimick-pressable"])
+        .build();
+
+    header.pack_start(&upload_btn);
+    header.pack_start(&upload_album_btn);
+    header.pack_end(&select_all_btn);
+
+    let toolbar = libadwaita::ToolbarView::builder().build();
+    toolbar.add_top_bar(&header);
+
+    // --- Grid ---
+    let select_toggle = gtk::ToggleButton::builder()
+        .active(true) // staging view starts in select mode
+        .build();
+    let narrow = Rc::new(Cell::new(false));
+    let grid = build_grid_view(ctx.clone(), select_toggle.clone(), narrow.clone());
+    // Always show select checkboxes in staging view.
+    grid.canvas.set_select_mode(true);
+
+    // Populate model from file paths.
+    let assets = build_staging_assets(&files);
+    grid.model.reset_with_objects(assets);
+
+    // --- Preview split pane ---
+    let preview_picture = gtk::Picture::builder()
+        .content_fit(gtk::ContentFit::Contain)
+        .vexpand(true)
+        .hexpand(true)
+        .build();
+    let preview_filename = gtk::Label::builder()
+        .halign(gtk::Align::Start)
+        .ellipsize(gtk::pango::EllipsizeMode::Middle)
+        .css_classes(["title-4"])
+        .build();
+    let preview_info = gtk::Label::builder()
+        .halign(gtk::Align::Start)
+        .css_classes(["dim-label"])
+        .build();
+    let preview_box = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(8)
+        .margin_top(12)
+        .margin_bottom(12)
+        .margin_start(12)
+        .margin_end(12)
+        .build();
+    preview_box.append(&preview_picture);
+    preview_box.append(&preview_filename);
+    preview_box.append(&preview_info);
+
+    let preview_scroll = gtk::ScrolledWindow::builder()
+        .child(&preview_box)
+        .hscrollbar_policy(gtk::PolicyType::Never)
+        .vexpand(true)
+        .build();
+
+    let split = libadwaita::OverlaySplitView::builder()
+        .sidebar_position(gtk::PackType::End)
+        .show_sidebar(false)
+        .collapsed(true) // overlay mode at narrow widths
+        .enable_show_gesture(true)
+        .enable_hide_gesture(true)
+        .min_sidebar_width(200.0)
+        .max_sidebar_width(400.0)
+        .sidebar_width_fraction(0.40)
+        .build();
+    split.set_content(Some(&grid.scrolled));
+    split.set_sidebar(Some(&preview_scroll));
+
+    // Track narrow state and collapse the split pane when the window is small.
+    {
+        let split_ref = split.clone();
+        window.connect_default_width_notify(move |win| {
+            let is_narrow = win.default_width() < 600;
+            split_ref.set_collapsed(is_narrow);
+        });
+    }
+
+    // --- Status bar ---
+    let status_label = gtk::Label::builder()
+        .halign(gtk::Align::Start)
+        .hexpand(true)
+        .margin_start(12)
+        .margin_end(12)
+        .margin_top(4)
+        .margin_bottom(4)
+        .build();
+    let file_count = grid.model.n_items();
+    status_label.set_text(&format!("{} file(s) staged", file_count));
+
+    toolbar.set_content(Some(&split));
+    toolbar.add_bottom_bar(&status_label);
+    window.set_content(Some(&toolbar));
+
+    // --- Clone captures for closures ---
+    let files_rc = Rc::new(files);
+    let selection = grid.selection.clone();
+    let model_for_click = grid.model.clone();
+    let split_ref = split.clone();
+    let preview_picture_ref = preview_picture.clone();
+    let preview_filename_ref = preview_filename.clone();
+    let preview_info_ref = preview_info.clone();
+
+    // --- Tile click -> preview ---
+    grid.canvas.set_activate_handler(move |position| {
+        let Some(item) = model_for_click.item(position).and_downcast::<AssetObject>() else {
+            return;
+        };
+        let filename = item.property::<String>("filename");
+        let local_path = item.property::<String>("local-path");
+        let asset_type = item.property::<String>("asset-type");
+        let is_video = asset_type.eq_ignore_ascii_case("VIDEO");
+
+        preview_filename_ref.set_text(&filename);
+        split_ref.set_show_sidebar(true);
+
+        if is_video {
+            preview_picture_ref.set_paintable(None::<&gdk4::Paintable>);
+            preview_info_ref.set_text("Video file - upload to view on server");
+        } else {
+            let picture = preview_picture_ref.clone();
+            let info = preview_info_ref.clone();
+            let path = PathBuf::from(&local_path);
+            glib::MainContext::default().spawn_local(async move {
+                if let Some(texture) = crate::library::load_texture_oriented(&path).await {
+                    let dims = format!("{} x {} px", texture.width(), texture.height());
+                    info.set_text(&dims);
+                    picture.set_paintable(Some(&texture));
+                } else {
+                    info.set_text("Could not decode image");
+                    picture.set_paintable(None::<&gdk4::Paintable>);
+                }
+            });
+        }
+    });
+
+    // --- Select All / Deselect All ---
+    {
+        let sel = selection.clone();
+        let lbl = status_label.clone();
+        let n = file_count;
+        let all_selected = Rc::new(Cell::new(false));
+        select_all_btn.connect_clicked(move |btn| {
+            if all_selected.get() {
+                sel.unselect_all();
+                btn.set_icon_name("edit-select-all-symbolic");
+                btn.set_tooltip_text(Some("Select all"));
+                all_selected.set(false);
+                lbl.set_text(&format!("{} file(s) staged", n));
+            } else {
+                sel.select_all();
+                btn.set_icon_name("edit-clear-all-symbolic");
+                btn.set_tooltip_text(Some("Deselect all"));
+                all_selected.set(true);
+                lbl.set_text(&format!("{} of {} selected", n, n));
+            }
+        });
+    }
+
+    // --- Track selection count ---
+    {
+        let sel = selection.clone();
+        let lbl = status_label.clone();
+        sel.connect_selection_changed(move |sel, _, _| {
+            let total = sel.n_items();
+            let selected = count_selected(sel);
+            if selected == 0 {
+                lbl.set_text(&format!("{} file(s) staged", total));
+            } else {
+                lbl.set_text(&format!("{} of {} selected", selected, total));
+            }
+        });
+    }
+
+    // --- Upload (library, no album) ---
+    {
+        let ctx_c = ctx.clone();
+        let sel = selection.clone();
+        let files_c = files_rc.clone();
+        let win = window.clone();
+        upload_btn.connect_clicked(move |_| {
+            let paths = selected_paths(&sel, &files_c);
+            if paths.is_empty() {
+                return;
+            }
+            let win_c = win.clone();
+            upload_picker::spawn_enqueue_with_callback(
+                ctx_c.clone(),
+                None,
+                paths,
+                move |queued, skipped| show_upload_result(&win_c, queued, skipped),
+            );
+        });
+    }
+
+    // --- Upload to Album ---
+    {
+        let ctx_c = ctx.clone();
+        let sel = selection.clone();
+        let files_c = files_rc.clone();
+        let win = window.clone();
+        upload_album_btn.connect_clicked(move |_| {
+            let paths = selected_paths(&sel, &files_c);
+            if paths.is_empty() {
+                return;
+            }
+            show_album_picker(win.clone(), ctx_c.clone(), paths);
+        });
+    }
+
+    window.present();
+
+    // Auto-upload mode: immediately trigger album picker.
+    if auto_upload {
+        let all_paths = files_rc.to_vec();
+        // Select all items first.
+        selection.select_all();
+        glib::idle_add_local_once(clone!(
+            #[strong]
+            window,
+            #[strong]
+            ctx,
+            move || {
+                show_album_picker(window, ctx, all_paths);
+            }
+        ));
+    }
+}
+
+/// Build `AssetObject` entries from local file paths for the staging grid.
+fn build_staging_assets(files: &[PathBuf]) -> Vec<AssetObject> {
+    files
+        .iter()
+        .filter(|path| media_kinds::is_supported_path(path))
+        .filter_map(|path| {
+            let filename = path.file_name()?.to_string_lossy().to_string();
+            let mime = media_kinds::mime_for_path(path);
+            let kind = media_kinds::asset_kind(mime);
+            let asset_type = match kind {
+                media_kinds::AssetKind::Image => "IMAGE",
+                media_kinds::AssetKind::Video => "VIDEO",
+            };
+            let id = format!("local::{}", path.display());
+            let mtime_str = std::fs::metadata(path)
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .map(systemtime_to_iso)
+                .unwrap_or_default();
+
+            Some(AssetObject::new_local(
+                &id,
+                &filename,
+                mime,
+                &mtime_str,
+                asset_type,
+                &path.to_string_lossy(),
+            ))
+        })
+        .collect()
+}
+
+/// Format a `SystemTime` as an ISO 8601 string in the local timezone.
+fn systemtime_to_iso(t: std::time::SystemTime) -> String {
+    use chrono::{DateTime, Local};
+    let dt: DateTime<Local> = t.into();
+    dt.to_rfc3339()
+}
+
+/// Count the number of selected items in a `MultiSelection`.
+fn count_selected(sel: &gtk::MultiSelection) -> u32 {
+    let bs = sel.selection();
+    let mut count = 0u32;
+    let n = bs.size();
+    for i in 0..n {
+        if bs.nth(i as u32) != gtk::INVALID_LIST_POSITION {
+            count += 1;
+        }
+    }
+    // Fallback: iterate all items
+    if count == 0 && n > 0 {
+        count = n as u32;
+    }
+    count
+}
+
+/// Collect file paths for the selected items, or all items if none selected.
+fn selected_paths(sel: &gtk::MultiSelection, files: &[PathBuf]) -> Vec<PathBuf> {
+    let bs = sel.selection();
+    let total = sel.n_items();
+    let mut paths = Vec::new();
+
+    // Collect indices of selected items.
+    let mut selected_indices = Vec::new();
+    let n_ranges = bs.size();
+    if n_ranges > 0 {
+        for i in 0..total {
+            if sel.is_selected(i) {
+                selected_indices.push(i as usize);
+            }
+        }
+    }
+
+    if selected_indices.is_empty() {
+        // Nothing explicitly selected -- upload all.
+        return files
+            .iter()
+            .filter(|p| media_kinds::is_supported_path(p))
+            .cloned()
+            .collect();
+    }
+
+    for idx in selected_indices {
+        if let Some(item) = sel.item(idx as u32).and_downcast::<AssetObject>() {
+            let local_path = item.property::<String>("local-path");
+            if !local_path.is_empty() {
+                paths.push(PathBuf::from(local_path));
+            }
+        }
+    }
+    paths
+}
+
+/// Present an album picker dialog and upload files to the chosen album.
+fn show_album_picker(
+    parent: libadwaita::ApplicationWindow,
+    ctx: Arc<AppContext>,
+    paths: Vec<PathBuf>,
+) {
+    let dialog = libadwaita::AlertDialog::builder()
+        .heading("Upload to Album")
+        .body("Loading albums...")
+        .build();
+    dialog.add_response("cancel", "Cancel");
+    dialog.present(Some(&parent));
+
+    // Fetch albums asynchronously and present the list.
+    let ctx_c = ctx.clone();
+    let parent_c = parent.clone();
+    glib::MainContext::default().spawn_local(async move {
+        let albums = match ctx_c.api_client.fetch_library_albums().await {
+            Ok(a) => a,
+            Err(err) => {
+                dialog.force_close();
+                let err_dialog = libadwaita::AlertDialog::builder()
+                    .heading("Failed to Load Albums")
+                    .body(&err)
+                    .build();
+                err_dialog.add_response("ok", "OK");
+                err_dialog.present(Some(&parent_c));
+                return;
+            }
+        };
+        dialog.force_close();
+        present_album_list(parent_c, ctx_c, albums, paths);
+    });
+}
+
+/// Build and show the album selection list dialog.
+fn present_album_list(
+    parent: libadwaita::ApplicationWindow,
+    ctx: Arc<AppContext>,
+    albums: Vec<LibraryAlbum>,
+    paths: Vec<PathBuf>,
+) {
+    let parent_for_result = parent.clone();
+    let dialog = libadwaita::AlertDialog::builder()
+        .heading("Select Album")
+        .body("Choose an album for the upload:")
+        .build();
+    dialog.add_response("cancel", "Cancel");
+
+    let listbox = gtk::ListBox::builder()
+        .selection_mode(gtk::SelectionMode::Single)
+        .css_classes(["boxed-list"])
+        .build();
+
+    for album in &albums {
+        let row = libadwaita::ActionRow::builder()
+            .title(&album.album_name)
+            .subtitle(format!("{} assets", album.asset_count))
+            .activatable(true)
+            .build();
+        listbox.append(&row);
+    }
+
+    let scroll = gtk::ScrolledWindow::builder()
+        .child(&listbox)
+        .min_content_height(200)
+        .max_content_height(400)
+        .hscrollbar_policy(gtk::PolicyType::Never)
+        .build();
+    dialog.set_extra_child(Some(&scroll));
+
+    let albums_rc = Rc::new(albums);
+    let paths_rc = Rc::new(paths);
+    let ctx_c = ctx.clone();
+    let listbox_ref = listbox.clone();
+
+    dialog.connect_response(
+        None,
+        clone!(
+            #[strong]
+            albums_rc,
+            #[strong]
+            paths_rc,
+            #[strong]
+            ctx_c,
+            #[strong]
+            listbox_ref,
+            move |_dialog, response| {
+                if response == "cancel" {
+                    return;
+                }
+                let Some(row) = listbox_ref.selected_row() else {
+                    return;
+                };
+                let idx = row.index() as usize;
+                if let Some(album) = albums_rc.get(idx) {
+                    let album_arg = Some((album.id.clone(), album.album_name.clone()));
+                    let parent_c = parent_for_result.clone();
+                    upload_picker::spawn_enqueue_with_callback(
+                        ctx_c.clone(),
+                        album_arg,
+                        paths_rc.to_vec(),
+                        move |queued, skipped| show_upload_result(&parent_c, queued, skipped),
+                    );
+                }
+            }
+        ),
+    );
+
+    // Add an "Upload" response that the user clicks after selecting a row.
+    dialog.add_response("upload", "Upload");
+    dialog.set_response_appearance("upload", libadwaita::ResponseAppearance::Suggested);
+    dialog.set_default_response(Some("upload"));
+
+    dialog.present(Some(&parent));
+}
+
+/// Show a result dialog after upload enqueue completes.
+fn show_upload_result(parent: &libadwaita::ApplicationWindow, queued: usize, skipped: usize) {
+    let (heading, body) = if skipped == 0 {
+        (
+            "Upload Queued",
+            format!(
+                "{} file(s) queued for upload. Progress is visible in the queue inspector.",
+                queued
+            ),
+        )
+    } else if queued == 0 {
+        (
+            "Upload Failed",
+            format!(
+                "All {} file(s) failed to enqueue. Check the logs for details.",
+                skipped
+            ),
+        )
+    } else {
+        (
+            "Upload Partially Queued",
+            format!(
+                "{} file(s) queued, {} skipped (hash or path errors).",
+                queued, skipped
+            ),
+        )
+    };
+
+    let dialog = libadwaita::AlertDialog::builder()
+        .heading(heading)
+        .body(&body)
+        .build();
+    dialog.add_response("ok", "OK");
+    dialog.present(Some(parent));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_staging_assets_filters_unsupported() {
+        let files = vec![
+            PathBuf::from("/tmp/photo.jpg"),
+            PathBuf::from("/tmp/document.pdf"),
+            PathBuf::from("/tmp/video.mp4"),
+            PathBuf::from("/tmp/readme.txt"),
+        ];
+        let assets = build_staging_assets(&files);
+        // .jpg and .mp4 are supported; .pdf and .txt are not.
+        assert_eq!(assets.len(), 2);
+        assert_eq!(assets[0].property::<String>("filename"), "photo.jpg");
+        assert_eq!(assets[1].property::<String>("filename"), "video.mp4");
+    }
+
+    #[test]
+    fn build_staging_assets_sets_asset_type() {
+        let files = vec![
+            PathBuf::from("/tmp/photo.png"),
+            PathBuf::from("/tmp/clip.mkv"),
+        ];
+        let assets = build_staging_assets(&files);
+        assert_eq!(assets.len(), 2);
+        assert_eq!(assets[0].property::<String>("asset-type"), "IMAGE");
+        assert_eq!(assets[1].property::<String>("asset-type"), "VIDEO");
+    }
+}

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -387,34 +387,7 @@ impl ThumbnailCache {
         let log_path = path.clone();
         let cache_dir = self.cache_dir.clone();
         let texture = tokio::task::spawn_blocking(move || -> Result<Texture, String> {
-            let is_video = crate::media_kinds::is_video_path(&path);
-            let is_raw = crate::media_kinds::is_raw_path(&path);
-
-            let pixbuf = if is_video {
-                ffmpeg_extract_thumbnail(&path)?
-            } else if is_raw {
-                // Try custom RAW decoder first (skips the pixbuf attempt that
-                // always fails for most camera RAW formats).
-                custom_decode_to_thumbnail(&path).or_else(|_| {
-                    // Some simple TIFF-based RAW files (DNG) can still be
-                    // decoded by glycin/pixbuf, so fall back to it.
-                    gtk::gdk_pixbuf::Pixbuf::from_file_at_scale(&path, 256, 256, true)
-                        .map(|raw| raw.apply_embedded_orientation().unwrap_or(raw))
-                        .map_err(|e| e.to_string())
-                })?
-            } else {
-                match gtk::gdk_pixbuf::Pixbuf::from_file_at_scale(&path, 256, 256, true) {
-                    Ok(raw) => raw.apply_embedded_orientation().unwrap_or(raw),
-                    Err(err) => {
-                        log::debug!(
-                            "gdk_pixbuf direct load failed for {}: {}; attempting custom decoder",
-                            path.display(),
-                            err
-                        );
-                        custom_decode_to_thumbnail(&path)?
-                    }
-                }
-            };
+            let pixbuf = decode_local_pixbuf(&path)?;
             std::fs::create_dir_all(&cache_dir).map_err(|err| err.to_string())?;
             let encoded = pixbuf_png_bytes(&pixbuf)?;
             std::fs::write(&cache_file, encoded).map_err(|err| err.to_string())?;
@@ -536,62 +509,44 @@ fn read_meminfo_total_bytes() -> Option<usize> {
     None
 }
 
-/// Extract a thumbnail frame from a video file using `ffmpeg`.
-///
-/// Runs `ffmpeg -ss 1 -i <path> -frames:v 1 -vf scale=256:-1 <tmp.png>` and
-/// loads the resulting PNG as a pixbuf. The temporary file is removed
-/// immediately after loading. Falls back to a 0-second seek if the 1-second
-/// seek fails (very short clips).
-fn ffmpeg_extract_thumbnail(path: &std::path::Path) -> Result<gtk::gdk_pixbuf::Pixbuf, String> {
-    use std::process::Command;
-
-    let tmp_dir = std::env::temp_dir();
-    let tmp_name = format!(
-        "mimick_vthumb_{}.png",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    );
-    let tmp_path = tmp_dir.join(&tmp_name);
-
-    // Try to extract a frame at 1 second (avoids black intro frames).
-    let result = Command::new("ffmpeg")
-        .args(["-y", "-ss", "1", "-i"])
-        .arg(path)
-        .args([
-            "-frames:v",
-            "1",
-            "-vf",
-            "scale=256:-1",
-            "-loglevel",
-            "error",
-        ])
-        .arg(&tmp_path)
-        .output();
-
-    let output = match result {
-        Ok(o) => o,
+/// Decode a local file to a 256x256 thumbnail pixbuf, routing through video,
+/// RAW, or standard image pipelines as appropriate.
+fn decode_local_pixbuf(path: &std::path::Path) -> Result<gtk::gdk_pixbuf::Pixbuf, String> {
+    if crate::media_kinds::is_video_path(path) {
+        return ffmpeg_extract_thumbnail(path);
+    }
+    if crate::media_kinds::is_raw_path(path) {
+        return custom_decode_to_thumbnail(path).or_else(|_| {
+            gtk::gdk_pixbuf::Pixbuf::from_file_at_scale(path, 256, 256, true)
+                .map(|raw| raw.apply_embedded_orientation().unwrap_or(raw))
+                .map_err(|e| e.to_string())
+        });
+    }
+    match gtk::gdk_pixbuf::Pixbuf::from_file_at_scale(path, 256, 256, true) {
+        Ok(raw) => Ok(raw.apply_embedded_orientation().unwrap_or(raw)),
         Err(err) => {
-            return Err(format!("ffmpeg not available: {}", err));
+            log::debug!(
+                "gdk_pixbuf direct load failed for {}: {}; attempting custom decoder",
+                path.display(),
+                err
+            );
+            custom_decode_to_thumbnail(path)
         }
-    };
+    }
+}
 
-    // If the 1s seek failed (video < 1s), retry at 0s.
-    if !output.status.success() || !tmp_path.exists() {
-        let _ = Command::new("ffmpeg")
-            .args(["-y", "-ss", "0", "-i"])
-            .arg(path)
-            .args([
-                "-frames:v",
-                "1",
-                "-vf",
-                "scale=256:-1",
-                "-loglevel",
-                "error",
-            ])
-            .arg(&tmp_path)
-            .output();
+/// Extract a thumbnail frame from a video file using `ffmpeg`.
+fn ffmpeg_extract_thumbnail(path: &std::path::Path) -> Result<gtk::gdk_pixbuf::Pixbuf, String> {
+    let tmp_file = tempfile::Builder::new()
+        .prefix("mimick_vthumb_")
+        .suffix(".png")
+        .tempfile()
+        .map_err(|e| format!("failed to create temp file: {}", e))?;
+    let tmp_path = tmp_file.path().to_path_buf();
+
+    // Try 1s seek first (avoids black intro), fall back to 0s.
+    if !run_ffmpeg_frame(path, "1", &tmp_path) {
+        run_ffmpeg_frame(path, "0", &tmp_path);
     }
 
     if !tmp_path.exists() {
@@ -600,26 +555,44 @@ fn ffmpeg_extract_thumbnail(path: &std::path::Path) -> Result<gtk::gdk_pixbuf::P
             path.display()
         ));
     }
+    let pixbuf = gtk::gdk_pixbuf::Pixbuf::from_file(&tmp_path).map_err(|e| e.to_string())?;
+    scale_pixbuf_to_thumbnail(pixbuf)
+}
 
-    let pixbuf = gtk::gdk_pixbuf::Pixbuf::from_file(&tmp_path).map_err(|e| {
-        let _ = std::fs::remove_file(&tmp_path);
-        e.to_string()
-    })?;
-    let _ = std::fs::remove_file(&tmp_path);
+/// Run ffmpeg to extract a single frame at the given seek position.
+fn run_ffmpeg_frame(input: &std::path::Path, seek_sec: &str, output: &std::path::Path) -> bool {
+    use std::process::Command;
+    Command::new("ffmpeg")
+        .args(["-y", "-ss", seek_sec, "-i"])
+        .arg(input)
+        .args([
+            "-frames:v",
+            "1",
+            "-vf",
+            "scale=256:-1",
+            "-loglevel",
+            "error",
+        ])
+        .arg(output)
+        .output()
+        .map(|o| o.status.success() && output.exists())
+        .unwrap_or(false)
+}
 
-    // Scale down if larger than 256x256 (ffmpeg -vf scale only constrains width).
-    let w = pixbuf.width();
-    let h = pixbuf.height();
-    if w > 256 || h > 256 {
-        let scale = (256.0 / w as f64).min(256.0 / h as f64);
-        let tw = ((w as f64 * scale).round() as i32).max(1);
-        let th = ((h as f64 * scale).round() as i32).max(1);
-        pixbuf
-            .scale_simple(tw, th, gtk::gdk_pixbuf::InterpType::Bilinear)
-            .ok_or_else(|| "Failed to scale video thumbnail".to_string())
-    } else {
-        Ok(pixbuf)
+/// Scale a pixbuf down to fit within 256x256 if needed.
+fn scale_pixbuf_to_thumbnail(
+    pixbuf: gtk::gdk_pixbuf::Pixbuf,
+) -> Result<gtk::gdk_pixbuf::Pixbuf, String> {
+    let (w, h) = (pixbuf.width(), pixbuf.height());
+    if w <= 256 && h <= 256 {
+        return Ok(pixbuf);
     }
+    let scale = (256.0 / w as f64).min(256.0 / h as f64);
+    let tw = ((w as f64 * scale).round() as i32).max(1);
+    let th = ((h as f64 * scale).round() as i32).max(1);
+    pixbuf
+        .scale_simple(tw, th, gtk::gdk_pixbuf::InterpType::Bilinear)
+        .ok_or_else(|| "Failed to scale video thumbnail".to_string())
 }
 
 /// Decodes an image file through the application's custom texture pipeline and

--- a/src/library/thumbnail_cache.rs
+++ b/src/library/thumbnail_cache.rs
@@ -387,10 +387,12 @@ impl ThumbnailCache {
         let log_path = path.clone();
         let cache_dir = self.cache_dir.clone();
         let texture = tokio::task::spawn_blocking(move || -> Result<Texture, String> {
+            let is_video = crate::media_kinds::is_video_path(&path);
             let is_raw = crate::media_kinds::is_raw_path(&path);
-            // For RAW files, gdk_pixbuf never recognises the format, so skip
-            // straight to the custom decoder to avoid a wasted attempt + log noise.
-            let pixbuf = if is_raw {
+
+            let pixbuf = if is_video {
+                ffmpeg_extract_thumbnail(&path)?
+            } else if is_raw {
                 // Try custom RAW decoder first (skips the pixbuf attempt that
                 // always fails for most camera RAW formats).
                 custom_decode_to_thumbnail(&path).or_else(|_| {
@@ -534,12 +536,98 @@ fn read_meminfo_total_bytes() -> Option<usize> {
     None
 }
 
-/// Decode a file through the custom pipeline (RAW / non-pixbuf formats) and
+/// Extract a thumbnail frame from a video file using `ffmpeg`.
+///
+/// Runs `ffmpeg -ss 1 -i <path> -frames:v 1 -vf scale=256:-1 <tmp.png>` and
+/// loads the resulting PNG as a pixbuf. The temporary file is removed
+/// immediately after loading. Falls back to a 0-second seek if the 1-second
+/// seek fails (very short clips).
+fn ffmpeg_extract_thumbnail(path: &std::path::Path) -> Result<gtk::gdk_pixbuf::Pixbuf, String> {
+    use std::process::Command;
+
+    let tmp_dir = std::env::temp_dir();
+    let tmp_name = format!(
+        "mimick_vthumb_{}.png",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    let tmp_path = tmp_dir.join(&tmp_name);
+
+    // Try to extract a frame at 1 second (avoids black intro frames).
+    let result = Command::new("ffmpeg")
+        .args(["-y", "-ss", "1", "-i"])
+        .arg(path)
+        .args([
+            "-frames:v",
+            "1",
+            "-vf",
+            "scale=256:-1",
+            "-loglevel",
+            "error",
+        ])
+        .arg(&tmp_path)
+        .output();
+
+    let output = match result {
+        Ok(o) => o,
+        Err(err) => {
+            return Err(format!("ffmpeg not available: {}", err));
+        }
+    };
+
+    // If the 1s seek failed (video < 1s), retry at 0s.
+    if !output.status.success() || !tmp_path.exists() {
+        let _ = Command::new("ffmpeg")
+            .args(["-y", "-ss", "0", "-i"])
+            .arg(path)
+            .args([
+                "-frames:v",
+                "1",
+                "-vf",
+                "scale=256:-1",
+                "-loglevel",
+                "error",
+            ])
+            .arg(&tmp_path)
+            .output();
+    }
+
+    if !tmp_path.exists() {
+        return Err(format!(
+            "ffmpeg failed to extract frame from {}",
+            path.display()
+        ));
+    }
+
+    let pixbuf = gtk::gdk_pixbuf::Pixbuf::from_file(&tmp_path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp_path);
+        e.to_string()
+    })?;
+    let _ = std::fs::remove_file(&tmp_path);
+
+    // Scale down if larger than 256x256 (ffmpeg -vf scale only constrains width).
+    let w = pixbuf.width();
+    let h = pixbuf.height();
+    if w > 256 || h > 256 {
+        let scale = (256.0 / w as f64).min(256.0 / h as f64);
+        let tw = ((w as f64 * scale).round() as i32).max(1);
+        let th = ((h as f64 * scale).round() as i32).max(1);
+        pixbuf
+            .scale_simple(tw, th, gtk::gdk_pixbuf::InterpType::Bilinear)
+            .ok_or_else(|| "Failed to scale video thumbnail".to_string())
+    } else {
+        Ok(pixbuf)
+    }
+}
+
+/// Decodes an image file through the application's custom texture pipeline and
 /// scale the result down to a 256x256 thumbnail pixbuf.
 ///
 /// RAW paths use the thumbnail-specific decoder (embedded JPEG first, full
 /// demosaic only as last resort) so the global "Full RAW Decoding" toggle
-/// — which is meant for lightbox quality — never penalises grid loading.
+/// -- which is meant for lightbox quality -- never penalises grid loading.
 fn custom_decode_to_thumbnail(path: &std::path::Path) -> Result<gtk::gdk_pixbuf::Pixbuf, String> {
     let full_texture = if crate::media_kinds::is_raw_path(path) {
         super::decode_raw_thumbnail_texture(path)

--- a/src/library/upload_picker.rs
+++ b/src/library/upload_picker.rs
@@ -78,49 +78,9 @@ pub(super) fn spawn_enqueue_with_callback<F>(
         let total = paths.len();
         let mut queued = 0usize;
         for path in paths {
-            let Some(path_str) = path.to_str().map(str::to_owned) else {
-                log::warn!("Skipping non-UTF8 upload path: {}", path.display());
-                continue;
-            };
-            let watch_path = path
-                .parent()
-                .and_then(|p| p.to_str())
-                .map(str::to_owned)
-                .unwrap_or_default();
-            let hash_target = path_str.clone();
-            let checksum =
-                match tokio::task::spawn_blocking(move || compute_sha1_chunked(&hash_target)).await
-                {
-                    Ok(Ok(c)) => c,
-                    Ok(Err(err)) => {
-                        log::warn!("Could not checksum upload '{}': {}", path_str, err);
-                        continue;
-                    }
-                    Err(err) => {
-                        log::warn!("Checksum task failed for '{}': {}", path_str, err);
-                        continue;
-                    }
-                };
-            let sidecar_path = if ctx.config.read().data.upload_xmp_sidecars {
-                crate::sidecar::find_sidecar(&path).map(|p| p.to_string_lossy().into_owned())
-            } else {
-                None
-            };
-            let task = FileTask {
-                path: path_str,
-                watch_path,
-                checksum,
-                album_id: album.as_ref().map(|(id, _)| id.clone()),
-                album_name: album.as_ref().map(|(_, name)| name.clone()),
-                reassociate_only: false,
-                // When the user uploads from the library / albums / explore
-                // view (album=None) the asset must land album-less; the
-                // queue's parent-dir-as-album fallback would otherwise create
-                // a junk album named after the user's file system layout.
-                skip_album: album.is_none(),
-                sidecar_path,
-            };
-            if ctx.queue_manager.add_to_queue(task).await {
+            if let Some(task) = build_file_task(&ctx, &album, &path).await
+                && ctx.queue_manager.add_to_queue(task).await
+            {
                 queued += 1;
             }
         }
@@ -132,4 +92,46 @@ pub(super) fn spawn_enqueue_with_callback<F>(
         );
         on_complete(queued, skipped);
     });
+}
+
+/// Build a `FileTask` for a single path, computing checksum and resolving sidecar.
+async fn build_file_task(
+    ctx: &AppContext,
+    album: &Option<(String, String)>,
+    path: &std::path::Path,
+) -> Option<FileTask> {
+    let path_str = path.to_str().map(str::to_owned)?;
+    let watch_path = path
+        .parent()
+        .and_then(|p| p.to_str())
+        .map(str::to_owned)
+        .unwrap_or_default();
+    let hash_target = path_str.clone();
+    let checksum =
+        match tokio::task::spawn_blocking(move || compute_sha1_chunked(&hash_target)).await {
+            Ok(Ok(c)) => c,
+            Ok(Err(err)) => {
+                log::warn!("Could not checksum upload '{}': {}", path_str, err);
+                return None;
+            }
+            Err(err) => {
+                log::warn!("Checksum task failed for '{}': {}", path_str, err);
+                return None;
+            }
+        };
+    let sidecar_path = if ctx.config.read().data.upload_xmp_sidecars {
+        crate::sidecar::find_sidecar(path).map(|p| p.to_string_lossy().into_owned())
+    } else {
+        None
+    };
+    Some(FileTask {
+        path: path_str,
+        watch_path,
+        checksum,
+        album_id: album.as_ref().map(|(id, _)| id.clone()),
+        album_name: album.as_ref().map(|(_, name)| name.clone()),
+        reassociate_only: false,
+        skip_album: album.is_none(),
+        sidecar_path,
+    })
 }

--- a/src/library/upload_picker.rs
+++ b/src/library/upload_picker.rs
@@ -56,8 +56,26 @@ pub fn pick_and_upload(
     });
 }
 
-fn spawn_enqueue(ctx: Arc<AppContext>, album: Option<(String, String)>, paths: Vec<PathBuf>) {
+pub(super) fn spawn_enqueue(
+    ctx: Arc<AppContext>,
+    album: Option<(String, String)>,
+    paths: Vec<PathBuf>,
+) {
+    spawn_enqueue_with_callback(ctx, album, paths, |_, _| {});
+}
+
+/// Enqueue files for upload and invoke `on_complete(queued, skipped)` on the
+/// main context when all files have been hashed and enqueued.
+pub(super) fn spawn_enqueue_with_callback<F>(
+    ctx: Arc<AppContext>,
+    album: Option<(String, String)>,
+    paths: Vec<PathBuf>,
+    on_complete: F,
+) where
+    F: FnOnce(usize, usize) + 'static,
+{
     glib::MainContext::default().spawn_local(async move {
+        let total = paths.len();
         let mut queued = 0usize;
         for path in paths {
             let Some(path_str) = path.to_str().map(str::to_owned) else {
@@ -106,6 +124,12 @@ fn spawn_enqueue(ctx: Arc<AppContext>, album: Option<(String, String)>, paths: V
                 queued += 1;
             }
         }
-        log::info!("Manual upload: queued {} file(s)", queued);
+        let skipped = total - queued;
+        log::info!(
+            "Manual upload: queued {} file(s), skipped {}",
+            queued,
+            skipped
+        );
+        on_complete(queued, skipped);
     });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -603,6 +603,7 @@ async fn main() {
         let ctx_early = APP_CONTEXT.get().cloned();
         let want_settings = argv.contains(&"--settings".to_string());
         let want_library = argv.contains(&"--library".to_string());
+        let want_upload = argv.contains(&"--upload".to_string());
         let setup_required = ctx_early
             .as_ref()
             .map(|c| c.config.read().get_api_key().unwrap_or_default().is_empty())
@@ -616,7 +617,24 @@ async fn main() {
                 .expect("App context should be initialized before command-line activation")
         };
 
-        if want_settings || setup_required {
+        // Collect file path arguments (positional args that are not flags).
+        let file_args: Vec<std::path::PathBuf> = argv
+            .iter()
+            .skip(1) // skip binary name
+            .filter(|a| !a.starts_with("--"))
+            .map(std::path::PathBuf::from)
+            .filter(|p| crate::media_kinds::is_supported_path(p))
+            .collect();
+
+        if !file_args.is_empty() && !setup_required {
+            // Files were passed -- open the staging view.
+            crate::library::staging_view::build_staging_window(
+                app,
+                ctx_lookup(),
+                file_args,
+                want_upload,
+            );
+        } else if want_settings || setup_required {
             open_settings_window_now(app, ctx_lookup());
         } else if want_library {
             open_library_window_now(app, ctx_lookup());

--- a/src/media_kinds.rs
+++ b/src/media_kinds.rs
@@ -206,4 +206,25 @@ mod tests {
         assert!(!is_raw_path(Path::new("video.mp4")));
         assert!(!is_raw_path(Path::new("noext")));
     }
+
+    #[test]
+    fn desktop_file_mime_types_match() {
+        use std::collections::BTreeSet;
+        let desktop = include_str!("../setup/dev.nicx.mimick.desktop");
+        let mime_line = desktop
+            .lines()
+            .find(|l| l.starts_with("MimeType="))
+            .expect("No MimeType= line in .desktop file");
+        let declared: BTreeSet<&str> = mime_line
+            .strip_prefix("MimeType=")
+            .unwrap()
+            .split(';')
+            .filter(|s| !s.is_empty())
+            .collect();
+        let source: BTreeSet<&str> = MIME_BY_EXT.values().copied().collect();
+        assert_eq!(
+            declared, source,
+            "MimeType= in .desktop file does not match MIME_BY_EXT in media_kinds.rs"
+        );
+    }
 }

--- a/src/media_kinds.rs
+++ b/src/media_kinds.rs
@@ -155,6 +155,14 @@ pub fn asset_kind(mime: &str) -> AssetKind {
     }
 }
 
+/// Whether the path's extension maps to a video MIME type.
+pub fn is_video_path(path: &Path) -> bool {
+    matches!(
+        extension_lower(path).and_then(|ext| mime_for(&ext)),
+        Some(mime) if mime.starts_with("video/")
+    )
+}
+
 /// Extract the extension from a path and return it lowercased.
 fn extension_lower(path: &Path) -> Option<String> {
     path.extension()

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -368,11 +368,18 @@ pub fn build_settings_window_with_parent(
         download_clear_btn,
     } = library::build_library_group(&settings_page);
 
+    let ctx_for_library = ctx.clone();
     library_view_row.connect_active_notify(glib::clone!(
         #[weak]
         library_group,
         move |row| {
-            library_group.set_visible(row.is_active());
+            let active = row.is_active();
+            library_group.set_visible(active);
+            let mut cfg = ctx_for_library.config.write();
+            if cfg.data.library_view_enabled != active {
+                cfg.data.library_view_enabled = active;
+                cfg.save();
+            }
         }
     ));
 


### PR DESCRIPTION
## Summary

Register Mimick as a handler for all supported media MIME types so it appears in file manager "Open With" menus. Adds a staging view for reviewing and uploading files, plus an "Upload with Mimick" desktop action.

## Changes

### Staging View (`staging_view.rs` - new)
- Masonry grid with selection checkboxes for files opened via "Open With" or `--upload`
- Upload to library or Upload to Album actions with album picker dialog
- Upload result feedback dialog (queued/skipped/failed counts)
- Responsive layout with narrow breakpoint at 600sp for mobile widths

### File Associations (`dev.nicx.mimick.desktop`)
- Registered all supported MIME types from `media_kinds.rs`
- Added `Upload` desktop action (`--upload %F`) for direct album upload

### Video Thumbnails (`thumbnail_cache.rs`)
- Local video files now get real thumbnails via `ffmpeg` frame extraction (available in GNOME Platform runtime)
- Seeks to 1s (falls back to 0s for short clips), scales to 256px

### Checkbox Badges (`canvas.rs`)
- Select mode now shows checkbox indicators on tile corners (both library and staging views)
- Unchecked: bordered square outline; Checked: accent-colour filled square with checkmark
- Uses `libadwaita::AccentColor` API for proper theme accent colour

### Supporting Changes
- `upload_picker.rs`: Added `spawn_enqueue_with_callback` for upload result reporting
- `asset_model.rs`: Added `reset_with_objects` for bulk model replacement
- `media_kinds.rs`: Added `is_video_path` helper, MIME consistency test
- `main.rs`: CLI routing for file path arguments and `--upload` flag

## Testing
- 176/176 tests pass, clippy clean, cargo audit clean
- Verified via Flatpak dev profile with portal file forwarding