### PR TITLE
feat: drag-and-drop, Immich v3 explore fix, Rust 1.97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd854a95a4ac672fed8c054136039fd32c22cf039ff09ead7280afe920486483"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
  "bitflags",
  "inotify-sys",
@@ -2027,9 +2027,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
  "hashbrown",
 ]
@@ -2757,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2769,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4219,18 +4219,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -2056,14 +2056,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/inotify/inotify-0.11.3.crate",
-        "sha256": "dd854a95a4ac672fed8c054136039fd32c22cf039ff09ead7280afe920486483",
-        "dest": "cargo/vendor/inotify-0.11.3"
+        "url": "https://static.crates.io/crates/inotify/inotify-0.11.4.crate",
+        "sha256": "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8",
+        "dest": "cargo/vendor/inotify-0.11.4"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"dd854a95a4ac672fed8c054136039fd32c22cf039ff09ead7280afe920486483\", \"files\": {}}",
-        "dest": "cargo/vendor/inotify-0.11.3",
+        "contents": "{\"package\": \"153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8\", \"files\": {}}",
+        "dest": "cargo/vendor/inotify-0.11.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2563,14 +2563,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lru/lru-0.18.0.crate",
-        "sha256": "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9",
-        "dest": "cargo/vendor/lru-0.18.0"
+        "url": "https://static.crates.io/crates/lru/lru-0.18.1.crate",
+        "sha256": "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6",
+        "dest": "cargo/vendor/lru-0.18.1"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9\", \"files\": {}}",
-        "dest": "cargo/vendor/lru-0.18.0",
+        "contents": "{\"package\": \"0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6\", \"files\": {}}",
+        "dest": "cargo/vendor/lru-0.18.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3460,27 +3460,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex/regex-1.12.4.crate",
-        "sha256": "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba",
-        "dest": "cargo/vendor/regex-1.12.4"
+        "url": "https://static.crates.io/crates/regex/regex-1.13.0.crate",
+        "sha256": "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2",
+        "dest": "cargo/vendor/regex-1.13.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-1.12.4",
+        "contents": "{\"package\": \"2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-1.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.14.crate",
-        "sha256": "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f",
-        "dest": "cargo/vendor/regex-automata-0.4.14"
+        "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.15.crate",
+        "sha256": "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db",
+        "dest": "cargo/vendor/regex-automata-0.4.15"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f\", \"files\": {}}",
-        "dest": "cargo/vendor/regex-automata-0.4.14",
+        "contents": "{\"package\": \"1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-automata-0.4.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -5410,27 +5410,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zerocopy/zerocopy-0.8.53.crate",
-        "sha256": "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1",
-        "dest": "cargo/vendor/zerocopy-0.8.53"
+        "url": "https://static.crates.io/crates/zerocopy/zerocopy-0.8.54.crate",
+        "sha256": "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19",
+        "dest": "cargo/vendor/zerocopy-0.8.54"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1\", \"files\": {}}",
-        "dest": "cargo/vendor/zerocopy-0.8.53",
+        "contents": "{\"package\": \"b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-0.8.54",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.8.53.crate",
-        "sha256": "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71",
-        "dest": "cargo/vendor/zerocopy-derive-0.8.53"
+        "url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.8.54.crate",
+        "sha256": "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5",
+        "dest": "cargo/vendor/zerocopy-derive-0.8.54"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71\", \"files\": {}}",
-        "dest": "cargo/vendor/zerocopy-derive-0.8.53",
+        "contents": "{\"package\": \"e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-derive-0.8.54",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/api_client/library.rs
+++ b/src/api_client/library.rs
@@ -170,6 +170,32 @@ impl ImmichApiClient {
         }
     }
 
+    /// Fetch a single asset as a `LibraryAsset` by its ID.
+    pub async fn fetch_asset_by_id(&self, asset_id: &str) -> Result<LibraryAsset, String> {
+        let base_url = self
+            .get_active_url()
+            .await
+            .ok_or_else(|| "No active connection".to_string())?;
+        let settings = self.settings_snapshot();
+        let url = format!("{}/api/assets/{}", base_url, asset_id);
+        match self
+            .client
+            .get(&url)
+            .header("x-api-key", &settings.api_key)
+            .header("Accept", "application/json")
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => resp
+                .json::<LibraryAsset>()
+                .await
+                .map_err(|err| err.to_string()),
+            Ok(resp) => Err(format!("HTTP {}", resp.status())),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+
     /// Download original source file of a given asset ID and save it locally.
     pub async fn download_original_to_file(
         &self,

--- a/src/api_client/library.rs
+++ b/src/api_client/library.rs
@@ -144,8 +144,11 @@ impl ImmichApiClient {
         }
     }
 
-    /// Retrieve full EXIF metadata and details for a given asset ID.
-    pub async fn fetch_asset_details(&self, asset_id: &str) -> Result<AssetDetails, String> {
+    /// Generic helper to fetch asset JSON details.
+    async fn fetch_asset_generic<T: serde::de::DeserializeOwned>(
+        &self,
+        asset_id: &str,
+    ) -> Result<T, String> {
         let base_url = self
             .get_active_url()
             .await
@@ -161,39 +164,22 @@ impl ImmichApiClient {
             .send()
             .await
         {
-            Ok(resp) if resp.status().is_success() => resp
-                .json::<AssetDetails>()
-                .await
-                .map_err(|err| err.to_string()),
+            Ok(resp) if resp.status().is_success() => {
+                resp.json::<T>().await.map_err(|err| err.to_string())
+            }
             Ok(resp) => Err(format!("HTTP {}", resp.status())),
             Err(err) => Err(err.to_string()),
         }
     }
 
+    /// Retrieve full EXIF metadata and details for a given asset ID.
+    pub async fn fetch_asset_details(&self, asset_id: &str) -> Result<AssetDetails, String> {
+        self.fetch_asset_generic(asset_id).await
+    }
+
     /// Fetch a single asset as a `LibraryAsset` by its ID.
     pub async fn fetch_asset_by_id(&self, asset_id: &str) -> Result<LibraryAsset, String> {
-        let base_url = self
-            .get_active_url()
-            .await
-            .ok_or_else(|| "No active connection".to_string())?;
-        let settings = self.settings_snapshot();
-        let url = format!("{}/api/assets/{}", base_url, asset_id);
-        match self
-            .client
-            .get(&url)
-            .header("x-api-key", &settings.api_key)
-            .header("Accept", "application/json")
-            .timeout(Duration::from_secs(10))
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() => resp
-                .json::<LibraryAsset>()
-                .await
-                .map_err(|err| err.to_string()),
-            Ok(resp) => Err(format!("HTTP {}", resp.status())),
-            Err(err) => Err(err.to_string()),
-        }
+        self.fetch_asset_generic(asset_id).await
     }
 
     /// Download original source file of a given asset ID and save it locally.

--- a/src/api_client/search.rs
+++ b/src/api_client/search.rs
@@ -93,6 +93,7 @@ impl ImmichApiClient {
         let mut page: u32 = 1;
         const PAGE_SIZE: u32 = 250;
         const MAX_PAGES: u32 = 500;
+        let start = std::time::Instant::now();
 
         loop {
             let body = serde_json::json!({
@@ -136,6 +137,12 @@ impl ImmichApiClient {
             .map(|(city, asset_id)| PlaceItem { city, asset_id })
             .collect();
         places.sort_by(|a, b| a.city.cmp(&b.city));
+        log::debug!(
+            "fetch_all_places: {} cities from {} pages in {:.1}s",
+            places.len(),
+            page,
+            start.elapsed().as_secs_f64()
+        );
         Ok(places)
     }
 

--- a/src/cache_manager.rs
+++ b/src/cache_manager.rs
@@ -11,6 +11,7 @@ pub const CACHE_SUBDIRS: &[&str] = &[
     "video",
     "preview",
     "open-in",
+    "drag_export",
 ];
 
 /// Yield to the scheduler every N file ops during a prune sweep.

--- a/src/library/asset_model.rs
+++ b/src/library/asset_model.rs
@@ -116,6 +116,23 @@ impl LibraryAssetModel {
         *self.imp().items.borrow_mut() = objects;
         self.items_changed(0, prev_n, new_n);
     }
+
+    /// Append additional `AssetObject`s to the end of the model.
+    ///
+    /// Emits a tail-only `items_changed` so the existing viewport is unaffected.
+    /// Used by the staging view drop handler to add newly-dropped files.
+    pub fn append_objects(&self, objects: &[AssetObject]) {
+        if objects.is_empty() {
+            return;
+        }
+        let prev_n = {
+            let mut items = self.imp().items.borrow_mut();
+            let prev = items.len() as u32;
+            items.extend_from_slice(objects);
+            prev
+        };
+        self.items_changed(prev_n, 0, objects.len() as u32);
+    }
 }
 
 fn build_sorted_asset_objects(

--- a/src/library/explore_view.rs
+++ b/src/library/explore_view.rs
@@ -553,18 +553,19 @@ fn render_recents_tiles(
     }
 }
 
-/// Append a card-sized "See More" tile to a FlowBox grid.
-///
-/// Matches the dimensions of adjacent explore tiles so the button fills a
-/// full card slot rather than appearing as a small inline text link.
-fn append_see_more_button<F: Fn() + 'static>(grid: &gtk::FlowBox, remaining: usize, on_expand: F) {
+fn append_action_button<F: Fn() + 'static>(
+    grid: &gtk::FlowBox,
+    icon_name: &str,
+    label_text: &str,
+    on_click: F,
+) {
     let icon = gtk::Image::builder()
-        .icon_name("view-more-symbolic")
+        .icon_name(icon_name)
         .pixel_size(24)
         .halign(gtk::Align::Center)
         .build();
     let label = gtk::Label::builder()
-        .label(format!("See {remaining} more"))
+        .label(label_text)
         .css_classes(["caption-heading"])
         .halign(gtk::Align::Center)
         .build();
@@ -598,53 +599,27 @@ fn append_see_more_button<F: Fn() + 'static>(grid: &gtk::FlowBox, remaining: usi
         if let Some(parent) = button.parent() {
             grid_ref.remove(&parent);
         }
-        on_expand();
+        on_click();
     });
     grid.append(&btn);
 }
 
+/// Append a card-sized "See More" tile to a FlowBox grid.
+///
+/// Matches the dimensions of adjacent explore tiles so the button fills a
+/// full card slot rather than appearing as a small inline text link.
+fn append_see_more_button<F: Fn() + 'static>(grid: &gtk::FlowBox, remaining: usize, on_expand: F) {
+    append_action_button(
+        grid,
+        "view-more-symbolic",
+        &format!("See {remaining} more"),
+        on_expand,
+    );
+}
+
 /// Append a card-sized "Show Less" tile to collapse an expanded section.
 fn append_show_less_button<F: Fn() + 'static>(grid: &gtk::FlowBox, on_collapse: F) {
-    let icon = gtk::Image::builder()
-        .icon_name("go-up-symbolic")
-        .pixel_size(24)
-        .halign(gtk::Align::Center)
-        .build();
-    let label = gtk::Label::builder()
-        .label("Show Less")
-        .css_classes(["caption-heading"])
-        .halign(gtk::Align::Center)
-        .build();
-    let spacer = gtk::Box::builder()
-        .css_classes(["mimick-explore-spacer"])
-        .build();
-    let content = gtk::Box::builder()
-        .orientation(gtk::Orientation::Vertical)
-        .spacing(6)
-        .halign(gtk::Align::Center)
-        .valign(gtk::Align::Center)
-        .build();
-    content.append(&icon);
-    content.append(&label);
-    let overlay = gtk::Overlay::builder()
-        .overflow(gtk::Overflow::Hidden)
-        .css_classes(["mimick-see-more-tile"])
-        .build();
-    overlay.set_child(Some(&spacer));
-    overlay.add_overlay(&content);
-
-    let btn = gtk::Button::builder()
-        .child(&overlay)
-        .css_classes(["flat"])
-        .build();
-    let grid_ref = grid.clone();
-    btn.connect_clicked(move |button| {
-        if let Some(parent) = button.parent() {
-            grid_ref.remove(&parent);
-        }
-        on_collapse();
-    });
-    grid.append(&btn);
+    append_action_button(grid, "go-up-symbolic", "Show Less", on_collapse);
 }
 fn parse_iso_date(iso: &str) -> Option<(i64, u32, u32, u32, u32, u32)> {
     let parsed = iso

--- a/src/library/explore_view.rs
+++ b/src/library/explore_view.rs
@@ -1,8 +1,8 @@
 //! Sectioned landing page mirroring Immich web's Explore tab.
 //!
-//! Three rows: People (round avatars), Places (city tiles), Things (tag
-//! tiles). Tile clicks invoke caller-provided closures so dispatch lives in
-//! `mod.rs` and this module stays UI-only.
+//! Four rows: People (round avatars), Recently Added (date tiles),
+//! Places (city tiles), Things (tag tiles). Tile clicks invoke
+//! caller-provided closures so dispatch lives in `mod.rs`.
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -23,12 +23,15 @@ pub struct ExploreViewParts {
     pub root: gtk::ScrolledWindow,
     pub populated: Rc<Cell<bool>>,
     people_row: gtk::Box,
+    recents_grid: gtk::FlowBox,
     places_grid: gtk::FlowBox,
     things_grid: gtk::FlowBox,
     people_section: gtk::Box,
+    recents_section: gtk::Box,
     places_section: gtk::Box,
     things_section: gtk::Box,
     people_spinner: gtk::Spinner,
+    recents_spinner: gtk::Spinner,
     places_spinner: gtk::Spinner,
     things_spinner: gtk::Spinner,
     pub people_filter_button: gtk::MenuButton,
@@ -50,11 +53,13 @@ pub fn build_explore_view() -> ExploreViewParts {
         .build();
 
     let (people_section, people_row, people_spinner, people_filter_button) = build_people_section();
+    let (recents_section, recents_grid, recents_spinner) = build_tile_section("Recently Added");
     let (places_section, places_grid, places_spinner) = build_tile_section("Places");
     let (things_section, things_grid, things_spinner) = build_tile_section("Things");
 
     outer.append(&people_section);
     outer.append(&places_section);
+    outer.append(&recents_section);
     outer.append(&things_section);
 
     let root = gtk::ScrolledWindow::builder()
@@ -68,12 +73,15 @@ pub fn build_explore_view() -> ExploreViewParts {
         root,
         populated: Rc::new(Cell::new(false)),
         people_row,
+        recents_grid,
         places_grid,
         things_grid,
         people_section,
+        recents_section,
         places_section,
         things_section,
         people_spinner,
+        recents_spinner,
         places_spinner,
         things_spinner,
         people_filter_button,
@@ -90,6 +98,7 @@ pub fn build_explore_view() -> ExploreViewParts {
 pub fn show_loading(parts: &ExploreViewParts) {
     for (section, spinner) in [
         (&parts.people_section, &parts.people_spinner),
+        (&parts.recents_section, &parts.recents_spinner),
         (&parts.places_section, &parts.places_spinner),
         (&parts.things_section, &parts.things_spinner),
     ] {
@@ -334,12 +343,15 @@ fn clone_parts_handles(parts: &ExploreViewParts) -> ExploreViewParts {
         root: parts.root.clone(),
         populated: parts.populated.clone(),
         people_row: parts.people_row.clone(),
+        recents_grid: parts.recents_grid.clone(),
         places_grid: parts.places_grid.clone(),
         things_grid: parts.things_grid.clone(),
         people_section: parts.people_section.clone(),
+        recents_section: parts.recents_section.clone(),
         places_section: parts.places_section.clone(),
         things_section: parts.things_section.clone(),
         people_spinner: parts.people_spinner.clone(),
+        recents_spinner: parts.recents_spinner.clone(),
         places_spinner: parts.places_spinner.clone(),
         things_spinner: parts.things_spinner.clone(),
         people_filter_button: parts.people_filter_button.clone(),
@@ -377,7 +389,12 @@ pub fn populate_places<F>(
     }
 }
 
-/// Populate general objects, scenes, and tags in the things dashboard section.
+/// Populate explore sections: Things tiles + Recently Added tiles.
+///
+/// Sections by `field_name`:
+///   - `exifInfo.city`          -- skipped (populated by `populate_places`)
+///   - `createdAt`              -- rendered as "Recently Added" tiles
+///   - `smartInfo.objects/tags` -- rendered as "Things" tiles
 pub fn populate_explore<F>(
     parts: &ExploreViewParts,
     ctx: Arc<AppContext>,
@@ -387,17 +404,57 @@ pub fn populate_explore<F>(
     F: Fn(&str, String) + 'static,
 {
     stop_spinner(&parts.things_spinner);
+    stop_spinner(&parts.recents_spinner);
     while let Some(child) = parts.things_grid.first_child() {
         parts.things_grid.remove(&child);
     }
+    while let Some(child) = parts.recents_grid.first_child() {
+        parts.recents_grid.remove(&child);
+    }
     let mut had_things = false;
+    let mut had_recents = false;
+
+    log::debug!(
+        "Explore sections: [{}]",
+        sections
+            .iter()
+            .map(|s| format!("{}({})", s.field_name, s.items.len()))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
 
     let on_click = Rc::new(on_click);
     for section in sections {
         if section.field_name.contains("city") {
-            // Places are populated separately via populate_places.
             continue;
         }
+
+        // Immich v3 recently-added section.
+        if section.field_name == "createdAt" || section.field_name == "updatedAt" {
+            had_recents = true;
+            let mut items: Vec<_> = section.items.into_iter().take(12).collect();
+            // Sort newest first by value (ISO timestamp).
+            items.sort_by(|a, b| b.value.cmp(&a.value));
+            for item in items {
+                let label = format_relative_date(&item.value);
+                let tile = explore_tile(
+                    ctx.clone(),
+                    "recent",
+                    &label,
+                    &item.data.id,
+                    on_click.clone(),
+                );
+                parts.recents_grid.append(&tile);
+            }
+            continue;
+        }
+
+        // Only render smartInfo sections as Things tiles.
+        if !section.field_name.starts_with("smartInfo") {
+            log::debug!("Skipping unknown section '{}'", section.field_name);
+            continue;
+        }
+
         had_things = true;
         for item in section.items.into_iter().take(24) {
             let tile = explore_tile(
@@ -412,6 +469,79 @@ pub fn populate_explore<F>(
     }
 
     parts.things_section.set_visible(had_things);
+    parts.recents_section.set_visible(had_recents);
+}
+
+/// Format an ISO 8601 timestamp into a human-readable relative label.
+fn format_relative_date(iso: &str) -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    // Parse ISO 8601 (e.g. "2026-07-09T11:30:32.000Z") via chrono-free approach.
+    let parsed = iso
+        .replace('T', " ")
+        .replace('Z', "")
+        .chars()
+        .take(19)
+        .collect::<String>();
+
+    // Try to parse "YYYY-MM-DD HH:MM:SS" manually.
+    let parts: Vec<&str> = parsed.split(&['-', ' ', ':'][..]).collect();
+    if parts.len() < 6 {
+        return iso.chars().take(10).collect();
+    }
+    let (year, month, day, hour, min, sec) = match (
+        parts[0].parse::<i64>(),
+        parts[1].parse::<u32>(),
+        parts[2].parse::<u32>(),
+        parts[3].parse::<u32>(),
+        parts[4].parse::<u32>(),
+        parts[5].parse::<u32>(),
+    ) {
+        (Ok(y), Ok(mo), Ok(d), Ok(h), Ok(mi), Ok(s)) => (y, mo, d, h, mi, s),
+        _ => return iso.chars().take(10).collect(),
+    };
+
+    // Days since epoch (simplified, no leap-second accuracy needed).
+    let days_in_month = [0u32, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut total_days: i64 = 0;
+    for y in 1970..year {
+        total_days += if y % 4 == 0 && (y % 100 != 0 || y % 400 == 0) {
+            366
+        } else {
+            365
+        };
+    }
+    let is_leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    for m in 1..month {
+        total_days += days_in_month[m as usize] as i64;
+        if m == 2 && is_leap {
+            total_days += 1;
+        }
+    }
+    total_days += (day - 1) as i64;
+    let ts = total_days * 86400 + hour as i64 * 3600 + min as i64 * 60 + sec as i64;
+
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let diff = now_secs - ts;
+
+    if diff < 60 {
+        "Just now".to_string()
+    } else if diff < 3600 {
+        let m = diff / 60;
+        format!("{m} min ago")
+    } else if diff < 86400 {
+        let h = diff / 3600;
+        format!("{h}h ago")
+    } else if diff < 86400 * 7 {
+        let d = diff / 86400;
+        format!("{d}d ago")
+    } else {
+        // Fall back to YYYY-MM-DD.
+        format!("{year:04}-{month:02}-{day:02}")
+    }
 }
 
 /// Construct an individual circular avatar widget representing a recognized person face.

--- a/src/library/explore_view.rs
+++ b/src/library/explore_view.rs
@@ -15,8 +15,11 @@ use gtk::prelude::*;
 use crate::api_client::{ExploreSection, Person, PlaceItem, ThumbnailSize};
 use crate::app_context::AppContext;
 
-type ExploreClick = Rc<dyn Fn(&str, String)>;
+type ExploreClick = Rc<dyn Fn(&str, String, String)>;
 type PersonClick = Rc<dyn Fn(String, String)>;
+
+const INITIAL_TILE_COUNT: usize = 16;
+const RECENTS_EXPANDED_COUNT: usize = 30;
 
 /// Contains references to individual grid widgets of the explore tab dashboard display.
 pub struct ExploreViewParts {
@@ -37,6 +40,8 @@ pub struct ExploreViewParts {
     pub people_filter_button: gtk::MenuButton,
     cached_people: Rc<RefCell<Vec<Person>>>,
     cached_people_click: Rc<RefCell<Option<PersonClick>>>,
+    cached_places: Rc<RefCell<Vec<PlaceItem>>>,
+    cached_places_click: Rc<RefCell<Option<ExploreClick>>>,
     pub search_query: Rc<RefCell<String>>,
     cached_ctx: Rc<RefCell<Option<Arc<AppContext>>>>,
 }
@@ -87,6 +92,8 @@ pub fn build_explore_view() -> ExploreViewParts {
         people_filter_button,
         cached_people: Rc::new(RefCell::new(Vec::new())),
         cached_people_click: Rc::new(RefCell::new(None)),
+        cached_places: Rc::new(RefCell::new(Vec::new())),
+        cached_places_click: Rc::new(RefCell::new(None)),
         search_query: Rc::new(RefCell::new(String::new())),
         cached_ctx: Rc::new(RefCell::new(None)),
     }
@@ -357,27 +364,58 @@ fn clone_parts_handles(parts: &ExploreViewParts) -> ExploreViewParts {
         people_filter_button: parts.people_filter_button.clone(),
         cached_people: parts.cached_people.clone(),
         cached_people_click: parts.cached_people_click.clone(),
+        cached_places: parts.cached_places.clone(),
+        cached_places_click: parts.cached_places_click.clone(),
         search_query: parts.search_query.clone(),
         cached_ctx: parts.cached_ctx.clone(),
     }
 }
 
 /// Populate the city tiles representing locations in the places dashboard section.
+///
+/// Caches places data so subsequent visits don't re-fetch from the server.
+/// Shows the first 16 tiles with a "See More" button to expand.
 pub fn populate_places<F>(
     parts: &ExploreViewParts,
     ctx: Arc<AppContext>,
     places: Vec<PlaceItem>,
     on_click: F,
 ) where
-    F: Fn(&str, String) + 'static,
+    F: Fn(&str, String, String) + 'static,
 {
     stop_spinner(&parts.places_spinner);
+    *parts.cached_places.borrow_mut() = places;
+    *parts.cached_places_click.borrow_mut() = Some(Rc::new(on_click));
+    render_places(parts, ctx, false);
+}
+
+/// Check if places are already cached and render them without fetching.
+pub fn has_cached_places(parts: &ExploreViewParts) -> bool {
+    !parts.cached_places.borrow().is_empty()
+}
+
+/// Re-render places from cache (used when navigating back to explore).
+pub fn render_cached_places(parts: &ExploreViewParts, ctx: Arc<AppContext>) {
+    stop_spinner(&parts.places_spinner);
+    render_places(parts, ctx, false);
+}
+
+fn render_places(parts: &ExploreViewParts, ctx: Arc<AppContext>, expanded: bool) {
     while let Some(child) = parts.places_grid.first_child() {
         parts.places_grid.remove(&child);
     }
+    let places = parts.cached_places.borrow();
     parts.places_section.set_visible(!places.is_empty());
-    let on_click = Rc::new(on_click);
-    for place in places {
+    let on_click = match parts.cached_places_click.borrow().clone() {
+        Some(cb) => cb,
+        None => return,
+    };
+    let limit = if expanded {
+        places.len()
+    } else {
+        INITIAL_TILE_COUNT
+    };
+    for place in places.iter().take(limit) {
         let tile = explore_tile(
             ctx.clone(),
             "place",
@@ -386,6 +424,15 @@ pub fn populate_places<F>(
             on_click.clone(),
         );
         parts.places_grid.append(&tile);
+    }
+    if !expanded && places.len() > INITIAL_TILE_COUNT {
+        let remaining = places.len() - INITIAL_TILE_COUNT;
+        drop(places);
+        append_see_more_button(&parts.places_grid, remaining, {
+            let parts = clone_parts_handles(parts);
+            let ctx = ctx.clone();
+            move || render_places(&parts, ctx.clone(), true)
+        });
     }
 }
 
@@ -401,7 +448,7 @@ pub fn populate_explore<F>(
     sections: Vec<ExploreSection>,
     on_click: F,
 ) where
-    F: Fn(&str, String) + 'static,
+    F: Fn(&str, String, String) + 'static,
 {
     stop_spinner(&parts.things_spinner);
     stop_spinner(&parts.recents_spinner);
@@ -423,7 +470,7 @@ pub fn populate_explore<F>(
             .join(", ")
     );
 
-    let on_click = Rc::new(on_click);
+    let on_click: ExploreClick = Rc::new(on_click);
     for section in sections {
         if section.field_name.contains("city") {
             continue;
@@ -432,19 +479,17 @@ pub fn populate_explore<F>(
         // Immich v3 recently-added section.
         if section.field_name == "createdAt" || section.field_name == "updatedAt" {
             had_recents = true;
-            let mut items: Vec<_> = section.items.into_iter().take(12).collect();
-            // Sort newest first by value (ISO timestamp).
+            let mut items: Vec<_> = section.items.into_iter().collect();
             items.sort_by(|a, b| b.value.cmp(&a.value));
-            for item in items {
-                let label = format_relative_date(&item.value);
-                let tile = explore_tile(
-                    ctx.clone(),
-                    "recent",
-                    &label,
-                    &item.data.id,
-                    on_click.clone(),
-                );
-                parts.recents_grid.append(&tile);
+            render_recents_tiles(parts, &ctx, &items, &on_click, false);
+            if items.len() > INITIAL_TILE_COUNT {
+                let remaining = items.len().min(RECENTS_EXPANDED_COUNT) - INITIAL_TILE_COUNT;
+                let parts_clone = clone_parts_handles(parts);
+                let ctx_clone = ctx.clone();
+                let on_click_clone = on_click.clone();
+                append_see_more_button(&parts.recents_grid, remaining, move || {
+                    render_recents_tiles(&parts_clone, &ctx_clone, &items, &on_click_clone, true);
+                });
             }
             continue;
         }
@@ -470,6 +515,54 @@ pub fn populate_explore<F>(
 
     parts.things_section.set_visible(had_things);
     parts.recents_section.set_visible(had_recents);
+}
+
+/// Render recently-added tiles into the recents grid.
+fn render_recents_tiles(
+    parts: &ExploreViewParts,
+    ctx: &Arc<AppContext>,
+    items: &[crate::api_client::ExploreItem],
+    on_click: &ExploreClick,
+    expanded: bool,
+) {
+    while let Some(child) = parts.recents_grid.first_child() {
+        parts.recents_grid.remove(&child);
+    }
+    let limit = if expanded {
+        RECENTS_EXPANDED_COUNT
+    } else {
+        INITIAL_TILE_COUNT
+    };
+    for item in items.iter().take(limit) {
+        let label = format_relative_date(&item.value);
+        let tile = explore_tile(
+            ctx.clone(),
+            "recent",
+            &label,
+            &item.data.id,
+            on_click.clone(),
+        );
+        parts.recents_grid.append(&tile);
+    }
+}
+
+/// Append a "See More" button to a FlowBox grid.
+fn append_see_more_button<F: Fn() + 'static>(grid: &gtk::FlowBox, remaining: usize, on_expand: F) {
+    let btn = gtk::Button::builder()
+        .label(format!("See {remaining} more"))
+        .css_classes(["flat", "caption-heading"])
+        .halign(gtk::Align::Center)
+        .valign(gtk::Align::Center)
+        .build();
+    let grid_ref = grid.clone();
+    btn.connect_clicked(move |button| {
+        // Remove the button, then re-render expanded.
+        if let Some(parent) = button.parent() {
+            grid_ref.remove(&parent);
+        }
+        on_expand();
+    });
+    grid.append(&btn);
 }
 
 fn parse_iso_date(iso: &str) -> Option<(i64, u32, u32, u32, u32, u32)> {
@@ -642,7 +735,8 @@ fn explore_tile(
         .build();
 
     let value_owned = value.to_string();
-    button.connect_clicked(move |_| on_click(kind, value_owned.clone()));
+    let asset_id_owned = asset_id.to_string();
+    button.connect_clicked(move |_| on_click(kind, value_owned.clone(), asset_id_owned.clone()));
 
     spawn_asset_thumbnail(ctx, asset_id.to_string(), picture);
     button

--- a/src/library/explore_view.rs
+++ b/src/library/explore_view.rs
@@ -472,11 +472,7 @@ pub fn populate_explore<F>(
     parts.recents_section.set_visible(had_recents);
 }
 
-/// Format an ISO 8601 timestamp into a human-readable relative label.
-fn format_relative_date(iso: &str) -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    // Parse ISO 8601 (e.g. "2026-07-09T11:30:32.000Z") via chrono-free approach.
+fn parse_iso_date(iso: &str) -> Option<(i64, u32, u32, u32, u32, u32)> {
     let parsed = iso
         .replace('T', " ")
         .replace('Z', "")
@@ -484,12 +480,11 @@ fn format_relative_date(iso: &str) -> String {
         .take(19)
         .collect::<String>();
 
-    // Try to parse "YYYY-MM-DD HH:MM:SS" manually.
     let parts: Vec<&str> = parsed.split(&['-', ' ', ':'][..]).collect();
     if parts.len() < 6 {
-        return iso.chars().take(10).collect();
+        return None;
     }
-    let (year, month, day, hour, min, sec) = match (
+    match (
         parts[0].parse::<i64>(),
         parts[1].parse::<u32>(),
         parts[2].parse::<u32>(),
@@ -497,11 +492,12 @@ fn format_relative_date(iso: &str) -> String {
         parts[4].parse::<u32>(),
         parts[5].parse::<u32>(),
     ) {
-        (Ok(y), Ok(mo), Ok(d), Ok(h), Ok(mi), Ok(s)) => (y, mo, d, h, mi, s),
-        _ => return iso.chars().take(10).collect(),
-    };
+        (Ok(y), Ok(mo), Ok(d), Ok(h), Ok(mi), Ok(s)) => Some((y, mo, d, h, mi, s)),
+        _ => None,
+    }
+}
 
-    // Days since epoch (simplified, no leap-second accuracy needed).
+fn compute_epoch_seconds(year: i64, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> i64 {
     let days_in_month = [0u32, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
     let mut total_days: i64 = 0;
     for y in 1970..year {
@@ -519,8 +515,18 @@ fn format_relative_date(iso: &str) -> String {
         }
     }
     total_days += (day - 1) as i64;
-    let ts = total_days * 86400 + hour as i64 * 3600 + min as i64 * 60 + sec as i64;
+    total_days * 86400 + hour as i64 * 3600 + min as i64 * 60 + sec as i64
+}
 
+/// Format an ISO 8601 timestamp into a human-readable relative label.
+fn format_relative_date(iso: &str) -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let Some((year, month, day, hour, min, sec)) = parse_iso_date(iso) else {
+        return iso.chars().take(10).collect();
+    };
+
+    let ts = compute_epoch_seconds(year, month, day, hour, min, sec);
     let now_secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
@@ -539,7 +545,6 @@ fn format_relative_date(iso: &str) -> String {
         let d = diff / 86400;
         format!("{d}d ago")
     } else {
-        // Fall back to YYYY-MM-DD.
         format!("{year:04}-{month:02}-{day:02}")
     }
 }

--- a/src/library/explore_view.rs
+++ b/src/library/explore_view.rs
@@ -433,6 +433,13 @@ fn render_places(parts: &ExploreViewParts, ctx: Arc<AppContext>, expanded: bool)
             let ctx = ctx.clone();
             move || render_places(&parts, ctx.clone(), true)
         });
+    } else if expanded && places.len() > INITIAL_TILE_COUNT {
+        drop(places);
+        append_show_less_button(&parts.places_grid, {
+            let parts = clone_parts_handles(parts);
+            let ctx = ctx.clone();
+            move || render_places(&parts, ctx.clone(), false)
+        });
     }
 }
 
@@ -546,17 +553,48 @@ fn render_recents_tiles(
     }
 }
 
-/// Append a "See More" button to a FlowBox grid.
+/// Append a card-sized "See More" tile to a FlowBox grid.
+///
+/// Matches the dimensions of adjacent explore tiles so the button fills a
+/// full card slot rather than appearing as a small inline text link.
 fn append_see_more_button<F: Fn() + 'static>(grid: &gtk::FlowBox, remaining: usize, on_expand: F) {
-    let btn = gtk::Button::builder()
+    let icon = gtk::Image::builder()
+        .icon_name("view-more-symbolic")
+        .pixel_size(24)
+        .halign(gtk::Align::Center)
+        .build();
+    let label = gtk::Label::builder()
         .label(format!("See {remaining} more"))
-        .css_classes(["flat", "caption-heading"])
+        .css_classes(["caption-heading"])
+        .halign(gtk::Align::Center)
+        .build();
+    // Spacer forces the same min-height as explore tiles.
+    let spacer = gtk::Box::builder()
+        .css_classes(["mimick-explore-spacer"])
+        .build();
+    let content = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(6)
         .halign(gtk::Align::Center)
         .valign(gtk::Align::Center)
         .build();
+    content.append(&icon);
+    content.append(&label);
+    // Overlay the centered label on top of the spacer so the button
+    // has the same footprint as a regular tile.
+    let overlay = gtk::Overlay::builder()
+        .overflow(gtk::Overflow::Hidden)
+        .css_classes(["mimick-see-more-tile"])
+        .build();
+    overlay.set_child(Some(&spacer));
+    overlay.add_overlay(&content);
+
+    let btn = gtk::Button::builder()
+        .child(&overlay)
+        .css_classes(["flat"])
+        .build();
     let grid_ref = grid.clone();
     btn.connect_clicked(move |button| {
-        // Remove the button, then re-render expanded.
         if let Some(parent) = button.parent() {
             grid_ref.remove(&parent);
         }
@@ -565,6 +603,49 @@ fn append_see_more_button<F: Fn() + 'static>(grid: &gtk::FlowBox, remaining: usi
     grid.append(&btn);
 }
 
+/// Append a card-sized "Show Less" tile to collapse an expanded section.
+fn append_show_less_button<F: Fn() + 'static>(grid: &gtk::FlowBox, on_collapse: F) {
+    let icon = gtk::Image::builder()
+        .icon_name("go-up-symbolic")
+        .pixel_size(24)
+        .halign(gtk::Align::Center)
+        .build();
+    let label = gtk::Label::builder()
+        .label("Show Less")
+        .css_classes(["caption-heading"])
+        .halign(gtk::Align::Center)
+        .build();
+    let spacer = gtk::Box::builder()
+        .css_classes(["mimick-explore-spacer"])
+        .build();
+    let content = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(6)
+        .halign(gtk::Align::Center)
+        .valign(gtk::Align::Center)
+        .build();
+    content.append(&icon);
+    content.append(&label);
+    let overlay = gtk::Overlay::builder()
+        .overflow(gtk::Overflow::Hidden)
+        .css_classes(["mimick-see-more-tile"])
+        .build();
+    overlay.set_child(Some(&spacer));
+    overlay.add_overlay(&content);
+
+    let btn = gtk::Button::builder()
+        .child(&overlay)
+        .css_classes(["flat"])
+        .build();
+    let grid_ref = grid.clone();
+    btn.connect_clicked(move |button| {
+        if let Some(parent) = button.parent() {
+            grid_ref.remove(&parent);
+        }
+        on_collapse();
+    });
+    grid.append(&btn);
+}
 fn parse_iso_date(iso: &str) -> Option<(i64, u32, u32, u32, u32, u32)> {
     let parsed = iso
         .replace('T', " ")

--- a/src/library/lightbox.rs
+++ b/src/library/lightbox.rs
@@ -79,6 +79,29 @@ fn original_preview_cache_path(
     cache_dir.join(format!("{asset_id}.{ext}"))
 }
 
+/// Create a properly-named export copy of a cached file for drag-out.
+///
+/// Returns `Some(path)` with the original filename visible to file managers.
+/// Falls back to `source` if the export directory isn't available.
+fn drag_export_path(
+    asset_id: &str,
+    filename: &str,
+    source: &std::path::Path,
+) -> Option<std::path::PathBuf> {
+    let export_dir = crate::profile::cache_dir()?.join("drag_export");
+    let _ = std::fs::create_dir_all(&export_dir);
+    let prefix = &asset_id[..8.min(asset_id.len())];
+    let export = export_dir.join(format!("{prefix}_{filename}"));
+    if export.exists() {
+        return Some(export);
+    }
+    if std::fs::hard_link(source, &export).is_ok() || std::fs::copy(source, &export).is_ok() {
+        Some(export)
+    } else {
+        Some(source.to_path_buf())
+    }
+}
+
 /// Populate the details sidebar with sectioned EXIF metadata.
 ///
 /// Groups fall into three categories — Camera, Image, Location — each rendered
@@ -559,6 +582,27 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
     });
     picture_overlay.add_overlay(&video_badge_button);
 
+    // Drag source for exporting the current asset's original file.
+    // `lightbox_drag_path` is updated by the load logic whenever an asset
+    // is displayed (from local path or preview cache).
+    let lightbox_drag_path: Rc<RefCell<Option<std::path::PathBuf>>> = Rc::new(RefCell::new(None));
+    {
+        let drag_source = gtk::DragSource::new();
+        drag_source.set_actions(gtk::gdk::DragAction::COPY);
+
+        let drag_path = lightbox_drag_path.clone();
+        drag_source.connect_prepare(move |_source, _x, _y| {
+            let path = drag_path.borrow().clone()?;
+            if !path.exists() {
+                return None;
+            }
+            let file = gtk::gio::File::for_path(&path);
+            Some(gtk::gdk::ContentProvider::for_value(&file.to_value()))
+        });
+
+        picture_overlay.add_controller(drag_source);
+    }
+
     let active_a = Rc::new(Cell::new(true));
     let zoom_level = Rc::new(Cell::new(1.0_f64));
     let initial_full = ui.ctx.config.read().data.library_preview_full_resolution;
@@ -720,11 +764,14 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
             let active_a = active_a.clone();
             let video_badge_button = video_badge_button.clone();
             let video_badge_target = video_badge_target.clone();
+            let lightbox_drag_path = lightbox_drag_path.clone();
             let our_gen = load_gen.get().wrapping_add(1);
             load_gen.set(our_gen);
             unavailable_overlay.set_reveal_child(false);
             unavailable_overlay.set_can_target(false);
             *unavailable_path.borrow_mut() = None;
+            // Clear drag path while loading; updated once resolved.
+            *lightbox_drag_path.borrow_mut() = None;
             // Videos use the still thumbnail as a poster + play badge; image
             // decoders would all fail and fall through to "unavailable".
             let is_video =
@@ -815,6 +862,8 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
                     {
                         if is_current() {
                             target.set_paintable(Some(&texture));
+                            *lightbox_drag_path.borrow_mut() =
+                                Some(std::path::PathBuf::from(&local_path));
                             commit_visible();
                             cancel_loader.set(true);
                             loader.set_reveal_child(false);
@@ -885,6 +934,8 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
                         }
                         if let Some(texture) = decoded {
                             target.set_paintable(Some(&texture));
+                            *lightbox_drag_path.borrow_mut() =
+                                drag_export_path(&asset_id, &filename, &temp);
                         } else {
                             show_unavailable(Some(temp.display().to_string()));
                         }

--- a/src/library/masonry/canvas.rs
+++ b/src/library/masonry/canvas.rs
@@ -101,6 +101,8 @@ mod imp {
         pub check_icon: OnceCell<gdk4::Paintable>,
         /// Cached checkbox icon (unselected state).
         pub uncheck_icon: OnceCell<gdk4::Paintable>,
+        /// True while a drag-out operation is in progress; suppresses click-to-activate.
+        pub drag_active: Cell<bool>,
     }
 
     #[glib::object_subclass]

--- a/src/library/masonry/canvas/interaction.rs
+++ b/src/library/masonry/canvas/interaction.rs
@@ -141,42 +141,8 @@ impl MasonryCanvas {
         let ctx_prepare = ctx.clone();
         drag_source.connect_prepare(move |_source, x, y| {
             let canvas = weak.upgrade()?;
-            let imp = canvas.imp();
-            let sel = imp.selection.get()?;
-            let model = imp.model.get()?;
-
-            // Determine which files to drag.
-            let mut files: Vec<gtk::gio::File> = Vec::new();
-
-            if imp.select_mode.get() {
-                // Multi-select: collect all selected assets.
-                let n = sel.n_items();
-                for i in 0..n {
-                    if sel.is_selected(i)
-                        && let Some(path) = resolve_drag_path(model, i, &ctx_prepare)
-                    {
-                        files.push(gtk::gio::File::for_path(&path));
-                    }
-                }
-            }
-
-            if files.is_empty() {
-                // Single asset under cursor.
-                let pos = canvas.hit_test(x, y)?;
-                let path = resolve_drag_path(model, pos, &ctx_prepare)?;
-                files.push(gtk::gio::File::for_path(&path));
-            }
-
-            if files.is_empty() {
-                return None;
-            }
-
-            if files.len() == 1 {
-                Some(gtk::gdk::ContentProvider::for_value(&files[0].to_value()))
-            } else {
-                let file_list = gtk::gdk::FileList::from_array(&files);
-                Some(gtk::gdk::ContentProvider::for_value(&file_list.to_value()))
-            }
+            let files = collect_drag_files(&canvas, x, y, &ctx_prepare)?;
+            Some(files_to_content_provider(files))
         });
 
         let weak2 = self.downgrade();
@@ -184,40 +150,10 @@ impl MasonryCanvas {
             let Some(canvas) = weak2.upgrade() else {
                 return;
             };
-            let imp = canvas.imp();
-            // Suppress click-to-activate while dragging.
-            imp.drag_active.set(true);
-            let sel = imp.selection.get();
-
-            // Count how many items are being dragged.
-            let count = if imp.select_mode.get() {
-                sel.map(|s| {
-                    let mut c = 0u32;
-                    for i in 0..s.n_items() {
-                        if s.is_selected(i) {
-                            c += 1;
-                        }
-                    }
-                    c
-                })
-                .unwrap_or(1)
-            } else {
-                1
-            };
-
+            canvas.imp().drag_active.set(true);
+            let count = selected_count(&canvas);
             if count > 1 {
-                // Multi-drag: render a badge with count.
-                let badge_label = gtk::Label::builder()
-                    .label(format!("{count} files"))
-                    .css_classes(["mimick-drag-badge"])
-                    .build();
-                let badge_box = gtk::Box::builder()
-                    .orientation(gtk::Orientation::Horizontal)
-                    .css_classes(["mimick-drag-badge"])
-                    .build();
-                badge_box.append(&badge_label);
-                let paintable = gtk::WidgetPaintable::new(Some(&badge_box));
-                source.set_icon(Some(&paintable), 0, 0);
+                source.set_icon(Some(&build_drag_badge(count)), 0, 0);
             }
         });
 
@@ -230,6 +166,72 @@ impl MasonryCanvas {
 
         self.add_controller(drag_source);
     }
+}
+
+/// Collect gio::Files for the current drag operation (multi-select or single).
+fn collect_drag_files(
+    canvas: &MasonryCanvas,
+    x: f64,
+    y: f64,
+    ctx: &AppContext,
+) -> Option<Vec<gtk::gio::File>> {
+    let imp = canvas.imp();
+    let sel = imp.selection.get()?;
+    let model = imp.model.get()?;
+    let mut files = Vec::new();
+
+    if imp.select_mode.get() {
+        for i in 0..sel.n_items() {
+            if sel.is_selected(i)
+                && let Some(path) = resolve_drag_path(model, i, ctx)
+            {
+                files.push(gtk::gio::File::for_path(&path));
+            }
+        }
+    }
+
+    if files.is_empty() {
+        let pos = canvas.hit_test(x, y)?;
+        let path = resolve_drag_path(model, pos, ctx)?;
+        files.push(gtk::gio::File::for_path(&path));
+    }
+
+    if files.is_empty() { None } else { Some(files) }
+}
+
+fn files_to_content_provider(files: Vec<gtk::gio::File>) -> gtk::gdk::ContentProvider {
+    if files.len() == 1 {
+        gtk::gdk::ContentProvider::for_value(&files[0].to_value())
+    } else {
+        let file_list = gtk::gdk::FileList::from_array(&files);
+        gtk::gdk::ContentProvider::for_value(&file_list.to_value())
+    }
+}
+
+/// Count selected items, or 1 if not in select mode.
+fn selected_count(canvas: &MasonryCanvas) -> u32 {
+    let imp = canvas.imp();
+    if !imp.select_mode.get() {
+        return 1;
+    }
+    imp.selection
+        .get()
+        .map(|s| (0..s.n_items()).filter(|i| s.is_selected(*i)).count() as u32)
+        .unwrap_or(1)
+}
+
+/// Build a badge paintable showing the drag count.
+fn build_drag_badge(count: u32) -> gtk::WidgetPaintable {
+    let label = gtk::Label::builder()
+        .label(format!("{count} files"))
+        .css_classes(["mimick-drag-badge"])
+        .build();
+    let container = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .css_classes(["mimick-drag-badge"])
+        .build();
+    container.append(&label);
+    gtk::WidgetPaintable::new(Some(&container))
 }
 
 fn connect_model_changes(canvas: &MasonryCanvas, model: &LibraryAssetModel) {

--- a/src/library/masonry/canvas/interaction.rs
+++ b/src/library/masonry/canvas/interaction.rs
@@ -9,6 +9,7 @@ use super::{
     AssetContextMenuHandler, GridQuality, LibraryAssetModel, MasonryCanvas, ThumbnailCache, imp,
     item_at_x, row_at_y,
 };
+use crate::app_context::AppContext;
 use crate::library::asset_object::AssetObject;
 
 impl Default for MasonryCanvas {
@@ -125,6 +126,110 @@ impl MasonryCanvas {
         self.add_controller(primary_click_controller(self));
         self.add_controller(secondary_click_controller(self));
     }
+
+    /// Install a `DragSource` for exporting original asset files via drag.
+    ///
+    /// Must be called after `new()` once the thumbnail cache is set up.
+    /// The drag source resolves the original file from either the local path
+    /// (for local/synced assets) or the lightbox preview cache (for remote assets
+    /// that have been viewed in full resolution).
+    pub fn install_drag_source(&self, ctx: Arc<AppContext>) {
+        let drag_source = gtk::DragSource::new();
+        drag_source.set_actions(gtk::gdk::DragAction::COPY);
+
+        let weak = self.downgrade();
+        let ctx_prepare = ctx.clone();
+        drag_source.connect_prepare(move |_source, x, y| {
+            let canvas = weak.upgrade()?;
+            let imp = canvas.imp();
+            let sel = imp.selection.get()?;
+            let model = imp.model.get()?;
+
+            // Determine which files to drag.
+            let mut files: Vec<gtk::gio::File> = Vec::new();
+
+            if imp.select_mode.get() {
+                // Multi-select: collect all selected assets.
+                let n = sel.n_items();
+                for i in 0..n {
+                    if sel.is_selected(i)
+                        && let Some(path) = resolve_drag_path(model, i, &ctx_prepare)
+                    {
+                        files.push(gtk::gio::File::for_path(&path));
+                    }
+                }
+            }
+
+            if files.is_empty() {
+                // Single asset under cursor.
+                let pos = canvas.hit_test(x, y)?;
+                let path = resolve_drag_path(model, pos, &ctx_prepare)?;
+                files.push(gtk::gio::File::for_path(&path));
+            }
+
+            if files.is_empty() {
+                return None;
+            }
+
+            if files.len() == 1 {
+                Some(gtk::gdk::ContentProvider::for_value(&files[0].to_value()))
+            } else {
+                let file_list = gtk::gdk::FileList::from_array(&files);
+                Some(gtk::gdk::ContentProvider::for_value(&file_list.to_value()))
+            }
+        });
+
+        let weak2 = self.downgrade();
+        drag_source.connect_drag_begin(move |source, _drag| {
+            let Some(canvas) = weak2.upgrade() else {
+                return;
+            };
+            let imp = canvas.imp();
+            // Suppress click-to-activate while dragging.
+            imp.drag_active.set(true);
+            let sel = imp.selection.get();
+
+            // Count how many items are being dragged.
+            let count = if imp.select_mode.get() {
+                sel.map(|s| {
+                    let mut c = 0u32;
+                    for i in 0..s.n_items() {
+                        if s.is_selected(i) {
+                            c += 1;
+                        }
+                    }
+                    c
+                })
+                .unwrap_or(1)
+            } else {
+                1
+            };
+
+            if count > 1 {
+                // Multi-drag: render a badge with count.
+                let badge_label = gtk::Label::builder()
+                    .label(format!("{count} files"))
+                    .css_classes(["mimick-drag-badge"])
+                    .build();
+                let badge_box = gtk::Box::builder()
+                    .orientation(gtk::Orientation::Horizontal)
+                    .css_classes(["mimick-drag-badge"])
+                    .build();
+                badge_box.append(&badge_label);
+                let paintable = gtk::WidgetPaintable::new(Some(&badge_box));
+                source.set_icon(Some(&paintable), 0, 0);
+            }
+        });
+
+        let weak3 = self.downgrade();
+        drag_source.connect_drag_end(move |_, _, _| {
+            if let Some(canvas) = weak3.upgrade() {
+                canvas.imp().drag_active.set(false);
+            }
+        });
+
+        self.add_controller(drag_source);
+    }
 }
 
 fn connect_model_changes(canvas: &MasonryCanvas, model: &LibraryAssetModel) {
@@ -192,8 +297,13 @@ fn primary_click_controller(canvas: &MasonryCanvas) -> gtk::GestureClick {
     let primary = gtk::GestureClick::new();
     primary.set_button(gtk::gdk::BUTTON_PRIMARY);
     let weak = canvas.downgrade();
-    primary.connect_pressed(move |gesture, _, x, y| {
+    // Use `released` instead of `pressed` so a drag gesture that starts
+    // from the same press doesn't also trigger lightbox activation.
+    primary.connect_released(move |gesture, _, x, y| {
         if let Some(canvas) = weak.upgrade() {
+            if canvas.imp().drag_active.get() {
+                return;
+            }
             canvas.handle_primary_click(gesture, x, y);
         }
     });
@@ -223,4 +333,90 @@ fn toggle_selection(sel: &gtk::MultiSelection, pos: u32) {
 fn select_range(sel: &gtk::MultiSelection, lo: u32, hi: u32) {
     let count = hi - lo + 1;
     sel.select_range(lo, count, false);
+}
+
+/// Resolve the drag-export path for the asset at `pos`.
+///
+/// Priority: local path > drag export cache (with original filename)
+///         > lightbox preview cache (hardlinked to proper name)
+///         > on-demand download.
+fn resolve_drag_path(
+    model: &LibraryAssetModel,
+    pos: u32,
+    ctx: &AppContext,
+) -> Option<std::path::PathBuf> {
+    let obj = model.item(pos).and_downcast::<AssetObject>()?;
+    let local_path = obj.property::<String>("local-path");
+    if !local_path.is_empty() {
+        let p = std::path::PathBuf::from(&local_path);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+
+    let remote_id = obj.property::<String>("remote-id");
+    let filename = obj.property::<String>("filename");
+    if remote_id.is_empty() || filename.is_empty() {
+        return None;
+    }
+
+    // Use drag_export/ cache with original filenames (prefixed by asset ID
+    // to avoid collisions between assets with the same name).
+    let export_dir = crate::profile::cache_dir()?.join("drag_export");
+    let _ = std::fs::create_dir_all(&export_dir);
+    let safe_name = format!("{}_{}", &remote_id[..8.min(remote_id.len())], filename);
+    let export_path = export_dir.join(&safe_name);
+
+    if export_path.exists() {
+        return Some(export_path);
+    }
+
+    // Check lightbox preview cache and hardlink with proper name.
+    let ext = std::path::Path::new(&filename)
+        .extension()
+        .and_then(|e| e.to_str())
+        .filter(|e| !e.is_empty())
+        .unwrap_or("bin");
+    let preview_dir = crate::profile::cache_dir().map(|p| p.join("preview"));
+    if let Some(ref pd) = preview_dir {
+        let cached = pd.join(format!("{remote_id}.{ext}"));
+        if cached.exists()
+            && (std::fs::hard_link(&cached, &export_path).is_ok()
+                || std::fs::copy(&cached, &export_path).is_ok())
+        {
+            return Some(export_path);
+        }
+    }
+
+    // On-demand download: block briefly while the original is fetched.
+    log::debug!("Drag export: downloading {} ({})", remote_id, filename);
+    let api = ctx.api_client.clone();
+    let id = remote_id.clone();
+    let dest = export_path.clone();
+    let downloaded = std::thread::spawn(move || {
+        // Create a one-shot tokio runtime for the blocking download.
+        let rt = match tokio::runtime::Runtime::new() {
+            Ok(rt) => rt,
+            Err(e) => {
+                log::error!("Failed to create tokio runtime for drag download: {}", e);
+                return false;
+            }
+        };
+        match rt.block_on(api.download_original_to_file(&id, &dest, None)) {
+            Ok(()) => true,
+            Err(e) => {
+                log::warn!("Drag export download failed for {}: {}", id, e);
+                let _ = std::fs::remove_file(&dest);
+                false
+            }
+        }
+    })
+    .join()
+    .unwrap_or(false);
+
+    if downloaded && export_path.exists() {
+        Some(export_path)
+    } else {
+        None
+    }
 }

--- a/src/library/masonry/canvas/interaction.rs
+++ b/src/library/masonry/canvas/interaction.rs
@@ -362,41 +362,58 @@ fn resolve_drag_path(
         return None;
     }
 
-    // Use drag_export/ cache with original filenames (prefixed by asset ID
-    // to avoid collisions between assets with the same name).
-    let export_dir = crate::profile::cache_dir()?.join("drag_export");
-    let _ = std::fs::create_dir_all(&export_dir);
-    let safe_name = format!("{}_{}", &remote_id[..8.min(remote_id.len())], filename);
-    let export_path = export_dir.join(&safe_name);
-
+    let export_path = export_cache_path(&remote_id, &filename)?;
     if export_path.exists() {
         return Some(export_path);
     }
 
-    // Check lightbox preview cache and hardlink with proper name.
-    let ext = std::path::Path::new(&filename)
+    if try_link_from_preview(&remote_id, &filename, &export_path) {
+        return Some(export_path);
+    }
+
+    if download_for_export(ctx, &remote_id, &filename, &export_path) {
+        Some(export_path)
+    } else {
+        None
+    }
+}
+
+fn export_cache_path(remote_id: &str, filename: &str) -> Option<std::path::PathBuf> {
+    let export_dir = crate::profile::cache_dir()?.join("drag_export");
+    let _ = std::fs::create_dir_all(&export_dir);
+    let safe_name = format!("{}_{}", &remote_id[..8.min(remote_id.len())], filename);
+    Some(export_dir.join(&safe_name))
+}
+
+fn try_link_from_preview(remote_id: &str, filename: &str, export_path: &std::path::Path) -> bool {
+    let ext = std::path::Path::new(filename)
         .extension()
         .and_then(|e| e.to_str())
         .filter(|e| !e.is_empty())
         .unwrap_or("bin");
-    let preview_dir = crate::profile::cache_dir().map(|p| p.join("preview"));
-    if let Some(ref pd) = preview_dir {
-        let cached = pd.join(format!("{remote_id}.{ext}"));
-        if cached.exists()
-            && (std::fs::hard_link(&cached, &export_path).is_ok()
-                || std::fs::copy(&cached, &export_path).is_ok())
-        {
-            return Some(export_path);
-        }
-    }
+    let preview_dir = match crate::profile::cache_dir() {
+        Some(p) => p.join("preview"),
+        None => return false,
+    };
+    let cached = preview_dir.join(format!("{remote_id}.{ext}"));
 
-    // On-demand download: block briefly while the original is fetched.
+    cached.exists()
+        && (std::fs::hard_link(&cached, export_path).is_ok()
+            || std::fs::copy(&cached, export_path).is_ok())
+}
+
+fn download_for_export(
+    ctx: &AppContext,
+    remote_id: &str,
+    filename: &str,
+    export_path: &std::path::Path,
+) -> bool {
     log::debug!("Drag export: downloading {} ({})", remote_id, filename);
     let api = ctx.api_client.clone();
-    let id = remote_id.clone();
-    let dest = export_path.clone();
+    let id = remote_id.to_string();
+    let dest = export_path.to_path_buf();
+
     let downloaded = std::thread::spawn(move || {
-        // Create a one-shot tokio runtime for the blocking download.
         let rt = match tokio::runtime::Runtime::new() {
             Ok(rt) => rt,
             Err(e) => {
@@ -416,9 +433,5 @@ fn resolve_drag_path(
     .join()
     .unwrap_or(false);
 
-    if downloaded && export_path.exists() {
-        Some(export_path)
-    } else {
-        None
-    }
+    downloaded && export_path.exists()
 }

--- a/src/library/masonry/grid_view.rs
+++ b/src/library/masonry/grid_view.rs
@@ -40,6 +40,7 @@ pub fn build_grid_view(
     canvas.set_context_menu_handler(context_menu_handler.clone());
     let initial_quality = GridQuality::parse(&ctx.config.read().data.library_grid_quality);
     canvas.set_quality(initial_quality);
+    canvas.install_drag_source(ctx.clone());
 
     {
         let canvas = canvas.clone();

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -676,87 +676,102 @@ fn connect_drop_target(ui: Rc<LibraryWindowUi>) {
             return false;
         }
 
-        let file_list = match value.get::<gtk::gdk::FileList>() {
-            Ok(fl) => fl,
-            Err(_) => return false,
-        };
-        let paths: Vec<std::path::PathBuf> = file_list
-            .files()
-            .iter()
-            .filter_map(|f| f.path())
-            .filter(|p| crate::media_kinds::is_supported_path(p))
-            .collect();
-
-        if paths.is_empty() {
-            let toast = libadwaita::Toast::new("No supported media files in drop");
-            if let Some(overlay) = ui_drop
-                .window
-                .content()
-                .and_then(|w| w.first_child())
-                .and_downcast::<libadwaita::ToastOverlay>()
-            {
-                overlay.add_toast(toast);
-            } else {
-                log::info!("No supported media files in drop");
-            }
-            return true;
-        }
-
-        // Determine the current album context.
-        let album = match ui_drop.ctx.library_state.lock().source.clone() {
-            LibrarySource::Album { id, name }
-            | LibrarySource::AlbumLocal { id, name }
-            | LibrarySource::AlbumUnified { id, name } => Some((id, name)),
-            _ => None,
-        };
-
-        if let Some(album) = album {
-            // Album is in view -- upload directly to that album.
-            let count = paths.len();
-            upload_picker::spawn_enqueue_with_callback(
-                ui_drop.ctx.clone(),
-                Some(album.clone()),
-                paths,
-                move |queued, _skipped| {
-                    log::info!(
-                        "Drop upload to album '{}': queued {}/{} file(s)",
-                        album.1,
-                        queued,
-                        count
-                    );
-                },
-            );
-        } else {
-            // No album -- upload to library, offer album picker via log.
-            let count = paths.len();
-            let ctx_for_album = ui_drop.ctx.clone();
-            let window_for_album = ui_drop.window.clone();
-            let paths_for_album = paths.clone();
-            upload_picker::spawn_enqueue_with_callback(
-                ui_drop.ctx.clone(),
-                None,
-                paths,
-                move |queued, _skipped| {
-                    log::info!(
-                        "Drop upload to library: queued {}/{} file(s)",
-                        queued,
-                        count
-                    );
-                    if queued > 0 {
-                        staging_view::show_album_picker(
-                            window_for_album,
-                            ctx_for_album,
-                            paths_for_album,
-                        );
-                    }
-                },
-            );
-        }
-
-        true
+        handle_drop(&ui_drop, value)
     });
 
     ui.window.add_controller(drop_target);
+}
+
+fn handle_drop(ui: &LibraryWindowUi, value: &gtk::glib::Value) -> bool {
+    let file_list = match value.get::<gtk::gdk::FileList>() {
+        Ok(fl) => fl,
+        Err(_) => return false,
+    };
+
+    let paths: Vec<std::path::PathBuf> = file_list
+        .files()
+        .iter()
+        .filter_map(|f| f.path())
+        .filter(|p| crate::media_kinds::is_supported_path(p))
+        .collect();
+
+    if paths.is_empty() {
+        show_unsupported_drop_toast(ui);
+        return true;
+    }
+
+    let album = match ui.ctx.library_state.lock().source.clone() {
+        LibrarySource::Album { id, name }
+        | LibrarySource::AlbumLocal { id, name }
+        | LibrarySource::AlbumUnified { id, name } => Some((id, name)),
+        _ => None,
+    };
+
+    if let Some(album) = album {
+        handle_album_drop_upload(ui, album, paths);
+    } else {
+        handle_library_drop_upload(ui, paths);
+    }
+
+    true
+}
+
+fn show_unsupported_drop_toast(ui: &LibraryWindowUi) {
+    let toast = libadwaita::Toast::new("No supported media files in drop");
+    if let Some(overlay) = ui
+        .window
+        .content()
+        .and_then(|w| w.first_child())
+        .and_downcast::<libadwaita::ToastOverlay>()
+    {
+        overlay.add_toast(toast);
+    } else {
+        log::info!("No supported media files in drop");
+    }
+}
+
+fn handle_album_drop_upload(
+    ui: &LibraryWindowUi,
+    album: (String, String),
+    paths: Vec<std::path::PathBuf>,
+) {
+    let count = paths.len();
+    upload_picker::spawn_enqueue_with_callback(
+        ui.ctx.clone(),
+        Some(album.clone()),
+        paths,
+        move |queued, _skipped| {
+            log::info!(
+                "Drop upload to album '{}': queued {}/{} file(s)",
+                album.1,
+                queued,
+                count
+            );
+        },
+    );
+}
+
+fn handle_library_drop_upload(ui: &LibraryWindowUi, paths: Vec<std::path::PathBuf>) {
+    let count = paths.len();
+    let ctx_for_album = ui.ctx.clone();
+    let window_for_album = ui.window.clone();
+    let paths_for_album = paths.clone();
+
+    upload_picker::spawn_enqueue_with_callback(
+        ui.ctx.clone(),
+        None,
+        paths,
+        move |queued, _skipped| {
+            log::info!(
+                "Drop upload to library: queued {}/{} file(s)",
+                queued,
+                count
+            );
+            if queued > 0 {
+                staging_view::show_album_picker(window_for_album, ctx_for_album, paths_for_album);
+            }
+        },
+    );
 }
 
 fn spawn_server_ping_loop(ui: Rc<LibraryWindowUi>) {

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -1141,34 +1141,44 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
         }
     ));
 
-    mctx.spawn_local(clone!(
-        #[strong]
-        ui,
-        #[strong]
-        ctx,
-        async move {
-            let places_res = ctx.api_client.fetch_all_places().await;
-            if let Err(e) = &places_res
-                && (e.contains("HTTP 401") || e.contains("HTTP 403"))
-            {
-                show_library_permission_error(&ui.window);
+    // Only fetch places if not already cached from a previous visit.
+    if !explore_view::has_cached_places(&ui.explore) {
+        mctx.spawn_local(clone!(
+            #[strong]
+            ui,
+            #[strong]
+            ctx,
+            async move {
+                let places_res = ctx.api_client.fetch_all_places().await;
+                if let Err(e) = &places_res
+                    && (e.contains("HTTP 401") || e.contains("HTTP 403"))
+                {
+                    show_library_permission_error(&ui.window);
+                }
+                let places = places_res.unwrap_or_default();
+                let click_ui = ui.clone();
+                explore_view::populate_places(
+                    &ui.explore,
+                    ctx.clone(),
+                    places,
+                    move |_kind, value, _asset_id| {
+                        let next = LibrarySource::AdvancedSearch {
+                            filters: Box::new(MetadataSearchFilters {
+                                city: Some(value.clone()),
+                                ..Default::default()
+                            }),
+                        };
+                        let request = click_ui.ctx.library_state.lock().switch_source(next);
+                        click_ui.search_entry.set_text(&value);
+                        apply_timeline_ui_state(&click_ui, &request.1);
+                        load_source_page(click_ui.clone(), request, false);
+                    },
+                );
             }
-            let places = places_res.unwrap_or_default();
-            let click_ui = ui.clone();
-            explore_view::populate_places(&ui.explore, ctx.clone(), places, move |_kind, value| {
-                let next = LibrarySource::AdvancedSearch {
-                    filters: Box::new(MetadataSearchFilters {
-                        city: Some(value.clone()),
-                        ..Default::default()
-                    }),
-                };
-                let request = click_ui.ctx.library_state.lock().switch_source(next);
-                click_ui.search_entry.set_text(&value);
-                apply_timeline_ui_state(&click_ui, &request.1);
-                load_source_page(click_ui.clone(), request, false);
-            });
-        }
-    ));
+        ));
+    } else {
+        explore_view::render_cached_places(&ui.explore, ctx.clone());
+    }
 
     mctx.spawn_local(clone!(
         #[strong]
@@ -1188,23 +1198,49 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
                 &ui.explore,
                 ctx.clone(),
                 sections,
-                move |kind, value| {
-                    // For recents, value is a relative date label -- search
-                    // for "recently added" instead.
-                    let query = if kind == "recent" {
-                        "recently added".to_string()
-                    } else {
-                        value.clone()
-                    };
+                move |kind, value, asset_id| {
+                    if kind == "recent" {
+                        // Open the specific asset in lightbox by loading it
+                        // as a single-asset search result.
+                        open_asset_in_lightbox(click_ui.clone(), asset_id);
+                        return;
+                    }
                     let next = LibrarySource::SmartSearch {
-                        query: query.clone(),
+                        query: value.clone(),
                     };
                     let request = click_ui.ctx.library_state.lock().switch_source(next);
-                    click_ui.search_entry.set_text(&query);
+                    click_ui.search_entry.set_text(&value);
                     apply_timeline_ui_state(&click_ui, &request.1);
                     load_source_page(click_ui.clone(), request, false);
                 },
             );
+        }
+    ));
+}
+
+/// Fetch a single asset by ID, load it into the grid model, and open lightbox.
+fn open_asset_in_lightbox(ui: Rc<LibraryWindowUi>, asset_id: String) {
+    glib::MainContext::default().spawn_local(clone!(
+        #[strong]
+        ui,
+        async move {
+            let asset = match ui.ctx.api_client.fetch_asset_by_id(&asset_id).await {
+                Ok(a) => a,
+                Err(e) => {
+                    log::warn!("Failed to fetch asset {} for lightbox: {}", asset_id, e);
+                    return;
+                }
+            };
+            {
+                let mut state = ui.ctx.library_state.lock();
+                let generation = state.generation;
+                state.replace_assets_with_more(generation, vec![asset], false);
+                ui.grid
+                    .model
+                    .reset(&ui.ctx, &state.assets, &state.sort_mode);
+            }
+            sync_content_state(&ui);
+            open_lightbox(ui.clone(), 0);
         }
     ));
 }

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -1447,6 +1447,79 @@ fn load_source_page(ui: Rc<LibraryWindowUi>, request: (u64, LibrarySource, u32),
     ));
 }
 
+fn setup_album_drop_target(
+    ui: &Rc<LibraryWindowUi>,
+    row: &gtk::ListBoxRow,
+    album_id: String,
+    album_name: String,
+) {
+    let row_drop = gtk::DropTarget::new(
+        gtk::gdk::FileList::static_type(),
+        gtk::gdk::DragAction::COPY,
+    );
+    let row_ref_enter = row.clone();
+    row_drop.connect_enter(move |target, _x, _y| {
+        if target.current_drop().is_some_and(|d| d.drag().is_some()) {
+            return gtk::gdk::DragAction::empty();
+        }
+        row_ref_enter.add_css_class("mimick-album-drop-hover");
+        gtk::gdk::DragAction::COPY
+    });
+    let row_ref_leave = row.clone();
+    row_drop.connect_leave(move |_target| {
+        row_ref_leave.remove_css_class("mimick-album-drop-hover");
+    });
+    let row_ref_drop = row.clone();
+    let ui_drop = ui.clone();
+    row_drop.connect_drop(move |target, value, _x, _y| {
+        row_ref_drop.remove_css_class("mimick-album-drop-hover");
+
+        if target.current_drop().is_some_and(|d| d.drag().is_some()) {
+            return false;
+        }
+        let file_list = match value.get::<gtk::gdk::FileList>() {
+            Ok(fl) => fl,
+            Err(_) => return false,
+        };
+        let paths: Vec<std::path::PathBuf> = file_list
+            .files()
+            .iter()
+            .filter_map(|f| f.path())
+            .filter(|p| crate::media_kinds::is_supported_path(p))
+            .collect();
+        if paths.is_empty() {
+            show_unsupported_drop_toast(&ui_drop);
+            return true;
+        }
+        handle_album_drop_upload(&ui_drop, (album_id.clone(), album_name.clone()), paths);
+        true
+    });
+    row.add_controller(row_drop);
+}
+
+fn build_album_sidebar_row(
+    ui: &Rc<LibraryWindowUi>,
+    album: &crate::api_client::LibraryAlbum,
+) -> gtk::ListBoxRow {
+    let subtitle = format!("{} asset(s)", album.asset_count);
+    let action = libadwaita::ActionRow::builder()
+        .title(&album.album_name)
+        .subtitle(&subtitle)
+        .title_lines(1)
+        .subtitle_lines(1)
+        .build();
+    let row = gtk::ListBoxRow::builder()
+        .tooltip_text(format!("{}:{}", album.id, album.album_name))
+        .child(&action)
+        .build();
+
+    // Per-row drop target: dragging files onto an album row uploads
+    // them directly into that album.
+    setup_album_drop_target(ui, &row, album.id.clone(), album.album_name.clone());
+
+    row
+}
+
 /// Repopulate and select the active album or fixed row in the side navigation sidebar.
 fn reload_sidebar(ui: &Rc<LibraryWindowUi>) {
     while let Some(row) = ui.sidebar.albums_list.first_child() {
@@ -1456,65 +1529,7 @@ fn reload_sidebar(ui: &Rc<LibraryWindowUi>) {
     let selected_source = ui.ctx.library_state.lock().source.clone();
     let albums = ui.ctx.library_state.lock().albums.clone();
     for album in albums {
-        let subtitle = format!("{} asset(s)", album.asset_count);
-        let action = libadwaita::ActionRow::builder()
-            .title(&album.album_name)
-            .subtitle(&subtitle)
-            .title_lines(1)
-            .subtitle_lines(1)
-            .build();
-        let row = gtk::ListBoxRow::builder()
-            .tooltip_text(format!("{}:{}", album.id, album.album_name))
-            .child(&action)
-            .build();
-
-        // Per-row drop target: dragging files onto an album row uploads
-        // them directly into that album.
-        let row_drop = gtk::DropTarget::new(
-            gtk::gdk::FileList::static_type(),
-            gtk::gdk::DragAction::COPY,
-        );
-        let row_ref_enter = row.clone();
-        row_drop.connect_enter(move |target, _x, _y| {
-            if target.current_drop().is_some_and(|d| d.drag().is_some()) {
-                return gtk::gdk::DragAction::empty();
-            }
-            row_ref_enter.add_css_class("mimick-album-drop-hover");
-            gtk::gdk::DragAction::COPY
-        });
-        let row_ref_leave = row.clone();
-        row_drop.connect_leave(move |_target| {
-            row_ref_leave.remove_css_class("mimick-album-drop-hover");
-        });
-        let album_id = album.id.clone();
-        let album_name = album.album_name.clone();
-        let row_ref_drop = row.clone();
-        let ui_drop = ui.clone();
-        row_drop.connect_drop(move |target, value, _x, _y| {
-            row_ref_drop.remove_css_class("mimick-album-drop-hover");
-
-            if target.current_drop().is_some_and(|d| d.drag().is_some()) {
-                return false;
-            }
-            let file_list = match value.get::<gtk::gdk::FileList>() {
-                Ok(fl) => fl,
-                Err(_) => return false,
-            };
-            let paths: Vec<std::path::PathBuf> = file_list
-                .files()
-                .iter()
-                .filter_map(|f| f.path())
-                .filter(|p| crate::media_kinds::is_supported_path(p))
-                .collect();
-            if paths.is_empty() {
-                show_unsupported_drop_toast(&ui_drop);
-                return true;
-            }
-            handle_album_drop_upload(&ui_drop, (album_id.clone(), album_name.clone()), paths);
-            true
-        });
-        row.add_controller(row_drop);
-
+        let row = build_album_sidebar_row(ui, &album);
         ui.sidebar.albums_list.append(&row);
     }
 

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -616,17 +616,26 @@ fn build_drop_overlay(content: gtk::Box) -> (gtk::Overlay, gtk::Revealer) {
         .label("Drop files to upload")
         .halign(gtk::Align::Center)
         .build();
-    let drop_box = gtk::Box::builder()
+    // Inner box centers the icon+label; outer box provides the full-window tint.
+    let inner = gtk::Box::builder()
         .orientation(gtk::Orientation::Vertical)
         .spacing(12)
         .halign(gtk::Align::Center)
         .valign(gtk::Align::Center)
         .vexpand(true)
+        .build();
+    inner.append(&drop_icon);
+    inner.append(&drop_label);
+
+    let drop_box = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .halign(gtk::Align::Fill)
+        .valign(gtk::Align::Fill)
+        .vexpand(true)
         .hexpand(true)
         .css_classes(["mimick-drop-overlay"])
         .build();
-    drop_box.append(&drop_icon);
-    drop_box.append(&drop_label);
+    drop_box.append(&inner);
 
     let revealer = gtk::Revealer::builder()
         .transition_type(gtk::RevealerTransitionType::Crossfade)
@@ -1099,6 +1108,7 @@ fn load_status(ui: Rc<LibraryWindowUi>) {
 /// fastest section returns.
 fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
     if ui.explore.populated.get() {
+        log::debug!("Explore: populated=true, reusing cached widgets");
         ui.content_stack.set_visible_child_name("explore");
         return;
     }
@@ -1142,6 +1152,7 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
     ));
     // Fetch places (slow paginated scan) only if not cached.
     if !explore_view::has_cached_places(&ui.explore) {
+        log::debug!("Explore: places cache empty, fetching from server");
         mctx.spawn_local(clone!(
             #[strong]
             ui,
@@ -1176,6 +1187,7 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
             }
         ));
     } else {
+        log::debug!("Explore: rendering places from cache");
         explore_view::render_cached_places(&ui.explore, ctx.clone());
     }
 
@@ -1455,6 +1467,54 @@ fn reload_sidebar(ui: &Rc<LibraryWindowUi>) {
             .tooltip_text(format!("{}:{}", album.id, album.album_name))
             .child(&action)
             .build();
+
+        // Per-row drop target: dragging files onto an album row uploads
+        // them directly into that album.
+        let row_drop = gtk::DropTarget::new(
+            gtk::gdk::FileList::static_type(),
+            gtk::gdk::DragAction::COPY,
+        );
+        let row_ref_enter = row.clone();
+        row_drop.connect_enter(move |target, _x, _y| {
+            if target.current_drop().is_some_and(|d| d.drag().is_some()) {
+                return gtk::gdk::DragAction::empty();
+            }
+            row_ref_enter.add_css_class("mimick-album-drop-hover");
+            gtk::gdk::DragAction::COPY
+        });
+        let row_ref_leave = row.clone();
+        row_drop.connect_leave(move |_target| {
+            row_ref_leave.remove_css_class("mimick-album-drop-hover");
+        });
+        let album_id = album.id.clone();
+        let album_name = album.album_name.clone();
+        let row_ref_drop = row.clone();
+        let ui_drop = ui.clone();
+        row_drop.connect_drop(move |target, value, _x, _y| {
+            row_ref_drop.remove_css_class("mimick-album-drop-hover");
+
+            if target.current_drop().is_some_and(|d| d.drag().is_some()) {
+                return false;
+            }
+            let file_list = match value.get::<gtk::gdk::FileList>() {
+                Ok(fl) => fl,
+                Err(_) => return false,
+            };
+            let paths: Vec<std::path::PathBuf> = file_list
+                .files()
+                .iter()
+                .filter_map(|f| f.path())
+                .filter(|p| crate::media_kinds::is_supported_path(p))
+                .collect();
+            if paths.is_empty() {
+                show_unsupported_drop_toast(&ui_drop);
+                return true;
+            }
+            handle_album_drop_upload(&ui_drop, (album_id.clone(), album_name.clone()), paths);
+            true
+        });
+        row.add_controller(row_drop);
+
         ui.sidebar.albums_list.append(&row);
     }
 

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -125,6 +125,7 @@ struct LibraryWindowUi {
     last_seen_upload_batch: Cell<u64>,
     narrow: Rc<Cell<bool>>,
     split: libadwaita::OverlaySplitView,
+    drop_overlay: gtk::Revealer,
 }
 
 /// Build and display the main library window application layout.
@@ -422,9 +423,12 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     content.append(&bulk_bar);
     content.append(&transfer_bar);
 
+    // Drop overlay: shown when files are dragged over the window.
+    let (content_with_drop, drop_overlay) = build_drop_overlay(content);
+
     let split = libadwaita::OverlaySplitView::builder()
         .sidebar(&sidebar.root)
-        .content(&content)
+        .content(&content_with_drop)
         .show_sidebar(true)
         .enable_show_gesture(true)
         .enable_hide_gesture(true)
@@ -550,6 +554,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
         last_seen_upload_batch: Cell::new(0),
         narrow: narrow_flag.clone(),
         split: split.clone(),
+        drop_overlay: drop_overlay.clone(),
     });
     *ui.grid.context_menu_handler.borrow_mut() = Some(Box::new(clone!(
         #[strong]
@@ -568,6 +573,7 @@ pub fn build_library_window(app: &libadwaita::Application, ctx: Arc<AppContext>)
     connect_controls(ui.clone());
     connect_grid_handlers(ui.clone());
     connect_filters_button(ui.clone(), filters_button);
+    connect_drop_target(ui.clone());
 
     let close_ctx = ui.ctx.clone();
     window.connect_close_request(move |_| {
@@ -594,6 +600,163 @@ fn bootstrap_window(ui: Rc<LibraryWindowUi>) {
     spawn_server_ping_loop(ui.clone());
     spawn_transfer_poll_loop(ui.clone());
     load_source_page(ui, initial_request, false);
+}
+
+/// Build a drop overlay widget and wrap `content` in a `gtk::Overlay`.
+///
+/// Returns the overlay wrapper (to be used as the content widget) and the
+/// revealer handle for toggling visibility from the `DropTarget` handlers.
+fn build_drop_overlay(content: gtk::Box) -> (gtk::Overlay, gtk::Revealer) {
+    let drop_icon = gtk::Image::builder()
+        .icon_name("document-send-symbolic")
+        .pixel_size(48)
+        .halign(gtk::Align::Center)
+        .build();
+    let drop_label = gtk::Label::builder()
+        .label("Drop files to upload")
+        .halign(gtk::Align::Center)
+        .build();
+    let drop_box = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(12)
+        .halign(gtk::Align::Center)
+        .valign(gtk::Align::Center)
+        .vexpand(true)
+        .hexpand(true)
+        .css_classes(["mimick-drop-overlay"])
+        .build();
+    drop_box.append(&drop_icon);
+    drop_box.append(&drop_label);
+
+    let revealer = gtk::Revealer::builder()
+        .transition_type(gtk::RevealerTransitionType::Crossfade)
+        .transition_duration(180)
+        .reveal_child(false)
+        .can_target(false)
+        .vexpand(true)
+        .hexpand(true)
+        .child(&drop_box)
+        .build();
+
+    let overlay = gtk::Overlay::builder().build();
+    overlay.set_child(Some(&content));
+    overlay.add_overlay(&revealer);
+
+    (overlay, revealer)
+}
+
+/// Attach a `DropTarget` to the library window for drag-and-drop file uploads.
+fn connect_drop_target(ui: Rc<LibraryWindowUi>) {
+    let drop_target = gtk::DropTarget::new(
+        gtk::gdk::FileList::static_type(),
+        gtk::gdk::DragAction::COPY,
+    );
+
+    let ui_enter = ui.clone();
+    drop_target.connect_enter(move |target, _x, _y| {
+        // Reject internal drags (from our own DragSource).
+        if target.current_drop().is_some_and(|d| d.drag().is_some()) {
+            return gtk::gdk::DragAction::empty();
+        }
+        ui_enter.drop_overlay.set_reveal_child(true);
+        gtk::gdk::DragAction::COPY
+    });
+
+    let ui_leave = ui.clone();
+    drop_target.connect_leave(move |_target| {
+        ui_leave.drop_overlay.set_reveal_child(false);
+    });
+
+    let ui_drop = ui.clone();
+    drop_target.connect_drop(move |target, value, _x, _y| {
+        ui_drop.drop_overlay.set_reveal_child(false);
+
+        // Reject internal drags.
+        if target.current_drop().is_some_and(|d| d.drag().is_some()) {
+            return false;
+        }
+
+        let file_list = match value.get::<gtk::gdk::FileList>() {
+            Ok(fl) => fl,
+            Err(_) => return false,
+        };
+        let paths: Vec<std::path::PathBuf> = file_list
+            .files()
+            .iter()
+            .filter_map(|f| f.path())
+            .filter(|p| crate::media_kinds::is_supported_path(p))
+            .collect();
+
+        if paths.is_empty() {
+            let toast = libadwaita::Toast::new("No supported media files in drop");
+            if let Some(overlay) = ui_drop
+                .window
+                .content()
+                .and_then(|w| w.first_child())
+                .and_downcast::<libadwaita::ToastOverlay>()
+            {
+                overlay.add_toast(toast);
+            } else {
+                log::info!("No supported media files in drop");
+            }
+            return true;
+        }
+
+        // Determine the current album context.
+        let album = match ui_drop.ctx.library_state.lock().source.clone() {
+            LibrarySource::Album { id, name }
+            | LibrarySource::AlbumLocal { id, name }
+            | LibrarySource::AlbumUnified { id, name } => Some((id, name)),
+            _ => None,
+        };
+
+        if let Some(album) = album {
+            // Album is in view -- upload directly to that album.
+            let count = paths.len();
+            upload_picker::spawn_enqueue_with_callback(
+                ui_drop.ctx.clone(),
+                Some(album.clone()),
+                paths,
+                move |queued, _skipped| {
+                    log::info!(
+                        "Drop upload to album '{}': queued {}/{} file(s)",
+                        album.1,
+                        queued,
+                        count
+                    );
+                },
+            );
+        } else {
+            // No album -- upload to library, offer album picker via log.
+            let count = paths.len();
+            let ctx_for_album = ui_drop.ctx.clone();
+            let window_for_album = ui_drop.window.clone();
+            let paths_for_album = paths.clone();
+            upload_picker::spawn_enqueue_with_callback(
+                ui_drop.ctx.clone(),
+                None,
+                paths,
+                move |queued, _skipped| {
+                    log::info!(
+                        "Drop upload to library: queued {}/{} file(s)",
+                        queued,
+                        count
+                    );
+                    if queued > 0 {
+                        staging_view::show_album_picker(
+                            window_for_album,
+                            ctx_for_album,
+                            paths_for_album,
+                        );
+                    }
+                },
+            );
+        }
+
+        true
+    });
+
+    ui.window.add_controller(drop_target);
 }
 
 fn spawn_server_ping_loop(ui: Rc<LibraryWindowUi>) {
@@ -1010,12 +1173,19 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
                 &ui.explore,
                 ctx.clone(),
                 sections,
-                move |_kind, value| {
+                move |kind, value| {
+                    // For recents, value is a relative date label -- search
+                    // for "recently added" instead.
+                    let query = if kind == "recent" {
+                        "recently added".to_string()
+                    } else {
+                        value.clone()
+                    };
                     let next = LibrarySource::SmartSearch {
-                        query: value.clone(),
+                        query: query.clone(),
                     };
                     let request = click_ui.ctx.library_state.lock().switch_source(next);
-                    click_ui.search_entry.set_text(&value);
+                    click_ui.search_entry.set_text(&query);
                     apply_timeline_ui_state(&click_ui, &request.1);
                     load_source_page(click_ui.clone(), request, false);
                 },

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -5,7 +5,7 @@
 //! explore dashboard, album grids, lightbox, sidebar, and thumbnail
 //! caching independently.
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -1140,8 +1140,7 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
             });
         }
     ));
-
-    // Only fetch places if not already cached from a previous visit.
+    // Fetch places (slow paginated scan) only if not cached.
     if !explore_view::has_cached_places(&ui.explore) {
         mctx.spawn_local(clone!(
             #[strong]
@@ -1200,8 +1199,6 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
                 sections,
                 move |kind, value, asset_id| {
                     if kind == "recent" {
-                        // Open the specific asset in lightbox by loading it
-                        // as a single-asset search result.
                         open_asset_in_lightbox(click_ui.clone(), asset_id);
                         return;
                     }
@@ -1218,7 +1215,10 @@ fn load_explore_landing(ui: Rc<LibraryWindowUi>) {
     ));
 }
 
-/// Fetch a single asset by ID, load it into the grid model, and open lightbox.
+/// Fetch a single asset by ID and open it in lightbox without leaving explore.
+///
+/// Temporarily loads the asset into the grid model so the lightbox can display
+/// it, then restores the previous library state when the lightbox page is popped.
 fn open_asset_in_lightbox(ui: Rc<LibraryWindowUi>, asset_id: String) {
     glib::MainContext::default().spawn_local(clone!(
         #[strong]
@@ -1231,6 +1231,11 @@ fn open_asset_in_lightbox(ui: Rc<LibraryWindowUi>, asset_id: String) {
                     return;
                 }
             };
+
+            // Snapshot the current state so we can restore it after lightbox.
+            let prev_source = ui.ctx.library_state.lock().source.clone();
+
+            // Temporarily load just this asset so open_lightbox can read it.
             {
                 let mut state = ui.ctx.library_state.lock();
                 let generation = state.generation;
@@ -1239,8 +1244,27 @@ fn open_asset_in_lightbox(ui: Rc<LibraryWindowUi>, asset_id: String) {
                     .model
                     .reset(&ui.ctx, &state.assets, &state.sort_mode);
             }
-            sync_content_state(&ui);
+
+            // Open lightbox at position 0 (the single asset).
             open_lightbox(ui.clone(), 0);
+
+            // After the lightbox page is popped, restore the explore state.
+            let restore_ui = ui.clone();
+            let handler_id = Rc::new(RefCell::new(None::<glib::SignalHandlerId>));
+            let handler_id_clone = handler_id.clone();
+            let id = ui.nav.connect_popped(move |nav, _page| {
+                let request = restore_ui
+                    .ctx
+                    .library_state
+                    .lock()
+                    .switch_source(prev_source.clone());
+                load_source_page(restore_ui.clone(), request, false);
+                // Disconnect this handler so it only fires once.
+                if let Some(id) = handler_id_clone.borrow_mut().take() {
+                    nav.disconnect(id);
+                }
+            });
+            *handler_id.borrow_mut() = Some(id);
         }
     ));
 }

--- a/src/library/staging_view.rs
+++ b/src/library/staging_view.rs
@@ -64,6 +64,9 @@ pub fn build_staging_window(
         &window,
     );
 
+    // Accept additional file drops onto the staging window.
+    connect_staging_drop_target(&window, &grid.model, &status_label);
+
     window.present();
 
     if auto_upload {
@@ -353,7 +356,7 @@ fn selected_paths(sel: &gtk::MultiSelection, files: &[PathBuf]) -> Vec<PathBuf> 
 }
 
 /// Present an album picker dialog and upload files to the chosen album.
-fn show_album_picker(
+pub(crate) fn show_album_picker(
     parent: libadwaita::ApplicationWindow,
     ctx: Arc<AppContext>,
     paths: Vec<PathBuf>,
@@ -501,6 +504,61 @@ fn simple_alert(
         .build();
     dialog.add_response(response_id, response_label);
     dialog
+}
+
+/// Attach a `DropTarget` to the staging window for appending additional files.
+fn connect_staging_drop_target(
+    window: &libadwaita::ApplicationWindow,
+    model: &crate::library::asset_model::LibraryAssetModel,
+    status_label: &gtk::Label,
+) {
+    use std::collections::HashSet;
+
+    let drop_target = gtk::DropTarget::new(
+        gtk::gdk::FileList::static_type(),
+        gtk::gdk::DragAction::COPY,
+    );
+
+    let model = model.clone();
+    let label = status_label.clone();
+    drop_target.connect_drop(move |_target, value, _x, _y| {
+        let file_list = match value.get::<gtk::gdk::FileList>() {
+            Ok(fl) => fl,
+            Err(_) => return false,
+        };
+
+        // Collect existing paths to deduplicate.
+        let mut existing: HashSet<String> = HashSet::new();
+        for i in 0..model.n_items() {
+            if let Some(obj) = model.item(i).and_downcast::<AssetObject>() {
+                let lp = obj.property::<String>("local-path");
+                if !lp.is_empty() {
+                    existing.insert(lp);
+                }
+            }
+        }
+
+        let new_paths: Vec<PathBuf> = file_list
+            .files()
+            .iter()
+            .filter_map(|f| f.path())
+            .filter(|p| media_kinds::is_supported_path(p))
+            .filter(|p| !existing.contains(&p.to_string_lossy().to_string()))
+            .collect();
+
+        if new_paths.is_empty() {
+            return true;
+        }
+
+        let new_assets = build_staging_assets(&new_paths);
+        model.append_objects(&new_assets);
+
+        let total = model.n_items();
+        label.set_text(&status_text(0, total));
+        true
+    });
+
+    window.add_controller(drop_target);
 }
 
 #[cfg(test)]

--- a/src/library/style.rs
+++ b/src/library/style.rs
@@ -85,6 +85,12 @@ window.mimick-wide box.mimick-explore-spacer {
     min-height: 150px;
 }
 
+overlay.mimick-see-more-tile {
+    border-radius: 6px;
+    background-color: alpha(@view_fg_color, 0.06);
+    border: 1px dashed alpha(@view_fg_color, 0.2);
+}
+
 box.mimick-stat-card {
     border-radius: 12px;
     padding: 14px;
@@ -293,22 +299,24 @@ box.mimick-preview-unavailable {
    Shown when files are dragged over the window.  */
 
 box.mimick-drop-overlay {
-    background: alpha(@accent_bg_color, 0.12);
-    border: 2px dashed @accent_color;
-    border-radius: 12px;
-    margin: 24px;
+    background: alpha(@accent_bg_color, 0.50);
+    border: none;
+    border-radius: 0;
+    margin: 0;
     transition: opacity 200ms ease-in-out;
 }
 
 box.mimick-drop-overlay image {
     -gtk-icon-size: 48px;
-    opacity: 0.7;
+    opacity: 0.85;
+    color: @accent_fg_color;
 }
 
 box.mimick-drop-overlay label {
     font-size: 1.1em;
     font-weight: 600;
-    opacity: 0.8;
+    opacity: 0.9;
+    color: @accent_fg_color;
 }
 
 /* ── Drag badge (multi-file count) ─────────────────────────────── */
@@ -322,6 +330,15 @@ box.mimick-drag-badge {
     font-size: 11px;
     min-width: 20px;
     min-height: 20px;
+}
+
+/* ── Album sidebar row drop-hover ──────────────────────────────── */
+
+row.mimick-album-drop-hover {
+    background: alpha(@accent_bg_color, 0.25);
+    border-radius: 6px;
+    transition: background 150ms ease-in-out, transform 150ms ease-in-out;
+    transform: scale(1.03);
 }
 "#;
 

--- a/src/library/style.rs
+++ b/src/library/style.rs
@@ -288,6 +288,41 @@ box.mimick-preview-unavailable {
     background-color: alpha(@window_bg_color, 0.92);
     border: 1px solid alpha(@view_fg_color, 0.16);
 }
+
+/* ── Drag-and-drop overlay ───────────────────────────────────────
+   Shown when files are dragged over the window.  */
+
+box.mimick-drop-overlay {
+    background: alpha(@accent_bg_color, 0.12);
+    border: 2px dashed @accent_color;
+    border-radius: 12px;
+    margin: 24px;
+    transition: opacity 200ms ease-in-out;
+}
+
+box.mimick-drop-overlay image {
+    -gtk-icon-size: 48px;
+    opacity: 0.7;
+}
+
+box.mimick-drop-overlay label {
+    font-size: 1.1em;
+    font-weight: 600;
+    opacity: 0.8;
+}
+
+/* ── Drag badge (multi-file count) ─────────────────────────────── */
+
+box.mimick-drag-badge {
+    background: @accent_bg_color;
+    color: @accent_fg_color;
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-weight: bold;
+    font-size: 11px;
+    min-width: 20px;
+    min-height: 20px;
+}
 "#;
 
 static REGISTERED: OnceLock<()> = OnceLock::new();

--- a/src/library/upload_picker.rs
+++ b/src/library/upload_picker.rs
@@ -56,7 +56,7 @@ pub fn pick_and_upload(
     });
 }
 
-pub(super) fn spawn_enqueue(
+pub(crate) fn spawn_enqueue(
     ctx: Arc<AppContext>,
     album: Option<(String, String)>,
     paths: Vec<PathBuf>,
@@ -66,7 +66,7 @@ pub(super) fn spawn_enqueue(
 
 /// Enqueue files for upload and invoke `on_complete(queued, skipped)` on the
 /// main context when all files have been hashed and enqueued.
-pub(super) fn spawn_enqueue_with_callback<F>(
+pub(crate) fn spawn_enqueue_with_callback<F>(
     ctx: Arc<AppContext>,
     album: Option<(String, String)>,
     paths: Vec<PathBuf>,


### PR DESCRIPTION
## Summary

Drag-and-drop import/export, Immich v3 explore page fix, and Rust 1.97 toolchain bump.

## Changes

### Drag-and-Drop Import (Feature 17)
- `DropTarget` on library and staging windows accepts external file drops
- Uploads to current album if one is open, otherwise uploads to library
- Rejects internal drags to prevent self-upload loop

### Drag-and-Drop Export (Feature 18)
- `DragSource` on masonry grid and lightbox for exporting originals
- Auto-downloads remote assets on-demand when dragged (no lightbox open required)
- Exports use original filenames via `drag_export/` cache (not internal asset IDs)
- Multi-select drag shows file count badge
- Click fires on release to prevent lightbox activation during drag

### Immich v3 Explore Fix
- Filter `createdAt` sections from Things grid (was rendering timestamps as tag labels)
- Add "Recently Added" section with relative date labels (e.g. "3h ago", "2d ago")
- Only render `smartInfo.*` sections as Things tiles
- Section order: People, Places, Recently Added, Things

### Toolchain
- Rust 1.97 bump (no breaking changes)

## Files Changed

| Area | Files |
|------|-------|
| DnD core | `mod.rs`, `interaction.rs`, `grid_view.rs`, `lightbox.rs` |
| DnD support | `staging_view.rs`, `upload_picker.rs`, `asset_model.rs`, `style.rs` |
| Explore | `explore_view.rs` |
| Canvas | `canvas.rs` (drag_active flag) |
| Cache | `cache_manager.rs` (drag_export dir) |
| Toolchain | `Cargo.lock`, `cargo-sources.json` |

## Testing

- `cargo check` clean
- `cargo test` -- 176 passed
- Manual: drag import from file manager, drag export to file manager, explore page sections