### PR TITLE
Fix:Duplicate back icon in lightbox view

### DIFF
--- a/src/assets/mimick.gresource.xml
+++ b/src/assets/mimick.gresource.xml
@@ -19,5 +19,8 @@
     <file alias="scalable/actions/mimick-video-symbolic.svg"
           compressed="true"
           preprocess="xml-stripblanks">scalable/actions/mimick-video-symbolic.svg</file>
+    <file alias="scalable/actions/mimick-library-symbolic.svg"
+          compressed="true"
+          preprocess="xml-stripblanks">scalable/actions/mimick-library-symbolic.svg</file>
   </gresource>
 </gresources>

--- a/src/assets/scalable/actions/mimick-library-symbolic.svg
+++ b/src/assets/scalable/actions/mimick-library-symbolic.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect fill="currentColor" x="2" y="2" width="5" height="5" rx="1"/>
+  <rect fill="currentColor" x="9" y="2" width="5" height="5" rx="1"/>
+  <rect fill="currentColor" x="2" y="9" width="5" height="5" rx="1"/>
+  <rect fill="currentColor" x="9" y="9" width="5" height="5" rx="1"/>
+</svg>

--- a/src/config.rs
+++ b/src/config.rs
@@ -414,10 +414,13 @@ impl Config {
     /// Automatically selects the correct backend:
     /// - Flatpak sandbox: encrypted file via the Secret portal
     /// - Native: D-Bus Secret Service (GNOME Keyring, KWallet)
+    ///
+    /// When the portal is unavailable (common on Hyprland, Sway, XFCE),
+    /// falls back to the D-Bus Secret Service before giving up.
     pub fn get_api_key(&self) -> Option<String> {
         let result = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                let keyring = oo7::Keyring::new().await?;
+                let keyring = keyring_with_dbus_fallback().await?;
                 let account = crate::profile::keyring_account();
                 let attributes: Vec<(&str, &str)> =
                     vec![("service", "mimick"), ("account", account.as_str())];
@@ -441,18 +444,26 @@ impl Config {
                 key
             }
             Err(e) => {
-                log::debug!("oo7 keyring lookup failed: {:?}", e);
+                log::warn!(
+                    "Keyring lookup failed ({}): {:?}",
+                    keyring_error_hint(&e),
+                    e
+                );
                 None
             }
         }
     }
 
     /// Store the API key in the desktop keyring via oo7.
-    pub fn set_api_key(&self, key: &str) -> bool {
+    ///
+    /// Returns `Ok(())` on success. On failure, returns an error string
+    /// with user-facing guidance tailored to the specific keyring backend
+    /// that failed (portal misconfiguration, missing D-Bus service, etc.).
+    pub fn set_api_key(&self, key: &str) -> Result<(), String> {
         let secret = key.to_string();
         let result = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                let keyring = oo7::Keyring::new().await?;
+                let keyring = keyring_with_dbus_fallback().await?;
                 let account = crate::profile::keyring_account();
                 let attributes: Vec<(&str, &str)> =
                     vec![("service", "mimick"), ("account", account.as_str())];
@@ -470,11 +481,15 @@ impl Config {
         match result {
             Ok(()) => {
                 log::info!("API key saved via oo7 keyring.");
-                true
+                Ok(())
             }
             Err(e) => {
                 log::error!("Failed to save API key via oo7 keyring: {:?}", e);
-                false
+                Err(format!(
+                    "{}\n\nTechnical detail: {}",
+                    keyring_error_message(&e),
+                    e
+                ))
             }
         }
     }
@@ -486,6 +501,58 @@ impl Config {
             .iter()
             .map(|e| e.path().to_string())
             .collect()
+    }
+}
+
+/// Try `oo7::Keyring::new()`, which auto-selects portal (Flatpak) or
+/// D-Bus (native). If the portal backend fails -- common on Hyprland,
+/// Sway, XFCE, and other non-GNOME/KDE desktops -- explicitly attempt
+/// the D-Bus Secret Service as a fallback before returning an error.
+async fn keyring_with_dbus_fallback() -> Result<oo7::Keyring, oo7::Error> {
+    match oo7::Keyring::new().await {
+        Ok(keyring) => Ok(keyring),
+        Err(oo7::Error::File(ref file_err)) => {
+            // Portal errors surface when xdg-desktop-portal doesn't
+            // expose org.freedesktop.portal.Secret -- try D-Bus.
+            log::info!(
+                "oo7 portal backend unavailable ({}), trying D-Bus Secret Service fallback",
+                file_err
+            );
+            let service = oo7::dbus::Service::new().await?;
+            let collection = service.default_collection().await?;
+            Ok(oo7::Keyring::DBus(collection))
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Return a user-facing error message for a keyring failure, tailored
+/// to the specific backend that failed.
+fn keyring_error_message(e: &oo7::Error) -> &'static str {
+    match e {
+        oo7::Error::File(_) => {
+            "Your desktop's Secret portal is not configured.\n\
+             This typically happens on Hyprland, Sway, XFCE, and other \
+             non-GNOME/KDE desktops.\n\n\
+             To fix this, ensure gnome-keyring (or kwallet) is installed \
+             and add an entry for org.freedesktop.impl.portal.Secret in \
+             your portal configuration.\n\n\
+             See: https://github.com/nicx17/mimick/wiki/Keyring-Setup"
+        }
+        oo7::Error::DBus(_) => {
+            "The D-Bus Secret Service is not available.\n\
+             Ensure gnome-keyring-daemon or KWallet is installed \
+             and running.\n\n\
+             See: https://github.com/nicx17/mimick/wiki/Keyring-Setup"
+        }
+    }
+}
+
+/// Short diagnostic label for log messages.
+fn keyring_error_hint(e: &oo7::Error) -> &'static str {
+    match e {
+        oo7::Error::File(_) => "portal backend error",
+        oo7::Error::DBus(_) => "D-Bus Secret Service error",
     }
 }
 

--- a/src/library/lightbox.rs
+++ b/src/library/lightbox.rs
@@ -411,8 +411,19 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         .build();
     let toolbar = libadwaita::ToolbarView::builder().build();
     let header = libadwaita::HeaderBar::builder()
-        .show_back_button(true)
+        .show_back_button(false)
         .build();
+    let back_btn = gtk::Button::builder()
+        .icon_name("mimick-library-symbolic")
+        .tooltip_text("Back to library")
+        .build();
+    back_btn.connect_clicked(clone!(
+        #[strong]
+        ui,
+        move |_| {
+            ui.nav.pop();
+        }
+    ));
     let prev_btn = gtk::Button::builder()
         .icon_name("go-previous-symbolic")
         .tooltip_text("Previous (Left)")
@@ -426,6 +437,7 @@ pub(super) fn open_lightbox(ui: Rc<LibraryWindowUi>, position: u32) {
         .tooltip_text("Toggle details (I)")
         .active(false)
         .build();
+    header.pack_start(&back_btn);
     header.pack_start(&prev_btn);
     header.pack_start(&next_btn);
     header.pack_end(&details_btn);

--- a/src/settings_window/mod.rs
+++ b/src/settings_window/mod.rs
@@ -783,15 +783,11 @@ pub fn build_settings_window_with_parent(
 
                         if include_connectivity
                             && !api_key.is_empty()
-                            && !new_config.set_api_key(&api_key)
+                            && let Err(detail) = new_config.set_api_key(&api_key)
                         {
                             apply_in_flight.set(false);
 
-                            show_alert(
-                                &window,
-                                "Could Not Save API Key",
-                                "Mimick could not store the API key in your desktop keyring.",
-                            );
+                            show_alert(&window, "Could Not Save API Key", &detail);
                             return;
                         }
 

--- a/wiki/Configuration-and-First-Run.md
+++ b/wiki/Configuration-and-First-Run.md
@@ -56,7 +56,7 @@ The window follows your desktop appearance preference, so it can render in eithe
     * Click **New API Key**, give it a name (like "Linux Desktop"), and click Create.
     * Make sure the key includes **Asset (Read, View, Download, Upload, Update, Delete)**, **Album (Read, Create, Update)**, **User (Read)**, and **Person (Read)** permissions.
     * Copy the key and paste it into the API Key field in Mimick.
-    * *The key is stored securely using the `oo7` crate (encrypted portal file in Flatpak, or D-Bus Secret Service native).*
+    * *The key is stored securely using the `oo7` crate (encrypted portal file in Flatpak, or D-Bus Secret Service native). On non-GNOME/KDE desktops you may need to configure the Secret portal first -- see [Keyring Setup](Keyring-Setup).*
 
 **Test Connection**: Verifies connectivity by pinging the Immich `/api/server/ping` endpoint, confirming a valid `{"res": "pong"}` JSON response to ensure you are talking to an actual Immich server rather than a captive portal.
 

--- a/wiki/Flatpak-and-Permissions.md
+++ b/wiki/Flatpak-and-Permissions.md
@@ -19,6 +19,8 @@ Mimick uses the [oo7](https://github.com/linux-credentials/oo7) crate for secure
 - **Inside Flatpak**: Credentials are stored in an encrypted file within the sandbox (`~/.var/app/dev.nicx.mimick/data/keyrings/`). The encryption key is retrieved from the `org.freedesktop.portal.Secret` portal. This avoids exposing secrets to other sandboxed applications.
 - **Outside Flatpak (native)**: Credentials are stored in the desktop's Secret Service (GNOME Keyring, KWallet) via the `org.freedesktop.secrets` D-Bus interface.
 
+> **Note:** On desktops other than GNOME and KDE (Hyprland, Sway, XFCE, i3, etc.), the Secret portal may not be configured out of the box. If saving your API key fails, see the [Keyring Setup](Keyring-Setup) guide.
+
 ### D-Bus Permissions
 
 The Flatpak manifest grants the following D-Bus talk permissions:

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -25,6 +25,7 @@ Mimick is a Linux background app that watches selected folders and syncs photos 
 [![Performance](https://img.shields.io/badge/Performance-Tuning-0E7490?style=for-the-badge&labelColor=0E7490)](Performance-Tuning)
 [![Screenshots](https://img.shields.io/badge/Screenshots-Gallery-E05D44?style=for-the-badge&labelColor=E05D44)](Screenshots)
 [![Flatpak](https://img.shields.io/badge/Flatpak-Permissions-6366F1?style=for-the-badge&labelColor=6366F1)](Flatpak-and-Permissions)
+[![Keyring](https://img.shields.io/badge/Keyring-Setup-8B5CF6?style=for-the-badge&labelColor=8B5CF6)](Keyring-Setup)
 [![Troubleshooting](https://img.shields.io/badge/Troubleshooting-Help-CB4B16?style=for-the-badge&labelColor=CB4B16)](Troubleshooting)
 
 </div>

--- a/wiki/Keyring-Setup.md
+++ b/wiki/Keyring-Setup.md
@@ -1,0 +1,155 @@
+# Keyring Setup
+
+Mimick stores your Immich API key securely in your desktop's keyring.
+On **GNOME** and **KDE** this works out of the box.
+On other desktops -- **Hyprland**, **Sway**, **XFCE**, **i3**, **Cosmic**,
+and similar compositors -- the keyring portal may not be wired up by
+default, causing the error:
+
+> Could Not Save API Key
+
+This page explains how to fix it.
+
+---
+
+## Background
+
+Mimick uses the [oo7](https://crates.io/crates/oo7) keyring library,
+which stores credentials through one of two backends:
+
+1. **Portal backend** (Flatpak sandbox) --
+   uses `org.freedesktop.portal.Secret`, exposed by
+   `gnome-keyring` or `kwallet`.
+2. **D-Bus Secret Service** (native installs) --
+   uses `org.freedesktop.secrets`, the standard Linux Secret
+   Service API.
+
+Both backends need a keyring daemon *and* correct portal wiring.
+GNOME and KDE ship `.portal` files that register their keyring
+daemons automatically (`UseIn=gnome` / `UseIn=kde`).
+On other compositors, `xdg-desktop-portal` skips those files, so
+the Secret portal is never exposed.
+
+---
+
+## Prerequisites
+
+Regardless of your desktop, ensure these are installed:
+
+- **gnome-keyring** (or **kwallet** if you prefer the KDE stack)
+- **libsecret**
+- **xdg-desktop-portal**
+- Your compositor's portal backend (e.g., `xdg-desktop-portal-hyprland`,
+  `xdg-desktop-portal-wlr`, `xdg-desktop-portal-gtk`)
+
+Confirm the keyring daemon is running:
+
+```bash
+systemctl --user status gnome-keyring-daemon
+```
+
+---
+
+## Fix by Desktop
+
+### Hyprland / Sway / wlroots compositors
+
+Create (or edit) `~/.config/xdg-desktop-portal/portals.conf`:
+
+```ini
+[preferred]
+default=hyprland;gtk
+org.freedesktop.impl.portal.Secret=gnome-keyring
+```
+
+> Replace `hyprland` with `wlr` or your compositor's portal name.
+
+Then restart the portal:
+
+```bash
+systemctl --user restart xdg-desktop-portal
+```
+
+### XFCE
+
+1. Install `xdg-desktop-portal-xapp` (in addition to
+   `xdg-desktop-portal-gtk`).
+2. Edit `/usr/share/xdg-desktop-portal/xfce-portals.conf`:
+
+```ini
+[preferred]
+default=xapp;gtk;
+```
+
+3. **Remove** any overriding files that may conflict:
+   - `~/.config/xdg-desktop-portal/portals.conf`
+   - `/etc/xdg-desktop-portal/portals.conf`
+
+4. Restart the portal:
+
+```bash
+systemctl --user restart xdg-desktop-portal
+```
+
+### i3 / other X11 window managers
+
+Create `~/.config/xdg-desktop-portal/portals.conf`:
+
+```ini
+[preferred]
+default=gtk
+org.freedesktop.impl.portal.Secret=gnome-keyring
+```
+
+Then restart:
+
+```bash
+systemctl --user restart xdg-desktop-portal
+```
+
+### Cosmic
+
+If you are using the COSMIC desktop, install the COSMIC portal
+backend and configure:
+
+```ini
+[preferred]
+default=cosmic;gtk
+org.freedesktop.impl.portal.Secret=gnome-keyring
+```
+
+---
+
+## Verifying the Fix
+
+After restarting the portal, test that the Secret portal is exposed:
+
+```bash
+busctl --user call org.freedesktop.portal.Desktop \
+  /org/freedesktop/portal/desktop \
+  org.freedesktop.DBus.Properties Get \
+  ss org.freedesktop.portal.Secret version
+```
+
+A successful result returns the portal version.
+If it errors with "Unknown interface", the portal is still not configured.
+
+Then relaunch Mimick and try saving your API key again.
+
+---
+
+## Still Not Working?
+
+If you have configured the portal but the error persists:
+
+1. Check logs: run Mimick from a terminal to see detailed keyring errors.
+2. Ensure gnome-keyring has an unlocked "default" collection:
+
+```bash
+secret-tool store --label='test' test-key test-value
+secret-tool lookup test-key test-value
+```
+
+3. File an issue at
+   [github.com/nicx17/mimick/issues](https://github.com/nicx17/mimick/issues)
+   with the error output from step 1.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -18,6 +18,7 @@ If you see this error:
 
 1. Make sure your desktop keyring daemon is running (GNOME Keyring, KWallet, etc.)
 2. If running inside Flatpak, check that the keyring file is not corrupted (see below)
+3. **On Hyprland, Sway, XFCE, i3, and other non-GNOME/KDE desktops**, the Secret portal is often not configured by default. See the [Keyring Setup](Keyring-Setup) guide for step-by-step instructions.
 
 ### "IncorrectSecret" or "PartiallyCorruptedKeyring"
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -8,6 +8,7 @@
 - [Sync Behavior](Sync-Behavior)
 - [Performance Tuning](Performance-Tuning)
 - [Flatpak and Permissions](Flatpak-and-Permissions)
+- [Keyring Setup](Keyring-Setup)
 - [Troubleshooting](Troubleshooting)
 - [Screenshots](Screenshots)
 


### PR DESCRIPTION
### Changes

**Issue #188 - Duplicate back arrow**
- Replace the duplicate back arrow in the lightbox header with a custom 2x2 grid icon (`mimick-library-symbolic.svg`) to differentiate "Back to library" from "Previous image"

**Issue #185 - Keyring fails on non-GNOME/KDE desktops**
- Add D-Bus Secret Service fallback when the portal backend is unavailable (Hyprland, Sway, XFCE, i3, etc.)
- Change `set_api_key` to return actionable error messages tailored to the specific failure (portal misconfiguration vs. missing D-Bus service)
- Enrich `get_api_key` error logging with portal-specific diagnostics
- Add wiki [Keyring Setup](https://github.com/nicx17/mimick/wiki/Keyring-Setup) guide with per-desktop instructions
- Cross-reference Keyring Setup from Sidebar, Home, Troubleshooting, Flatpak, and Configuration wiki pages

Closes #185, closes #188