### PR TITLE
fix: autostart/window issues on KDE (Flatpak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed duplicate back icon displaying in the lightbox view (#199).
+- Fixed disabling autostart in Flatpak environments not removing the background portal entry (#201).
+
 ## [9.9.0] - 2026-08-08
 
 ### Added

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -55,7 +55,7 @@ async fn request_background_portal(
     if enable {
         Ok(response.auto_start() && response.run_in_background())
     } else {
-        Ok(!response.auto_start())
+        Ok(response.auto_start())
     }
 }
 

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -17,12 +17,10 @@ const AUTOSTART_REASON: &str = "Reason for requesting background access: Mimick 
 
 /// Configure or request autostart registration depending on container and integration style.
 pub async fn apply(window: &impl IsA<gtk::Window>, enable: bool) -> Result<bool, String> {
-    if enable {
-        if is_flatpak_sandbox() {
-            request_background_portal(window).await
-        } else {
-            install_desktop_entry().map(|_| true)
-        }
+    if is_flatpak_sandbox() {
+        request_background_portal(window, enable).await
+    } else if enable {
+        install_desktop_entry().map(|_| true)
     } else {
         remove_desktop_entry().map(|_| false)
     }
@@ -33,8 +31,11 @@ fn is_flatpak_sandbox() -> bool {
     Path::new("/.flatpak-info").exists()
 }
 
-/// Direct autostart portal request on supported Flatpak desktop backgrounds.
-async fn request_background_portal(window: &impl IsA<gtk::Window>) -> Result<bool, String> {
+/// Request autostart state change through the XDG Background portal.
+async fn request_background_portal(
+    window: &impl IsA<gtk::Window>,
+    enable: bool,
+) -> Result<bool, String> {
     let identifier = match window.as_ref().native() {
         Some(native) => WindowIdentifier::from_native(&native).await,
         None => None,
@@ -43,7 +44,7 @@ async fn request_background_portal(window: &impl IsA<gtk::Window>) -> Result<boo
     let response = Background::request()
         .identifier(identifier)
         .reason(AUTOSTART_REASON)
-        .auto_start(true)
+        .auto_start(enable)
         .dbus_activatable(false)
         .send()
         .await
@@ -51,7 +52,11 @@ async fn request_background_portal(window: &impl IsA<gtk::Window>) -> Result<boo
         .response()
         .map_err(|err| format!("The desktop rejected the autostart request: {err}"))?;
 
-    Ok(response.auto_start() && response.run_in_background())
+    if enable {
+        Ok(response.auto_start() && response.run_in_background())
+    } else {
+        Ok(!response.auto_start())
+    }
 }
 
 /// Install autostart desktop shortcut entry in standard non-flatpak configurations.

--- a/src/main.rs
+++ b/src/main.rs
@@ -610,6 +610,20 @@ async fn main() {
             .unwrap_or(true);
         let secondary_activation = cmdline.is_remote();
 
+        let bg_sync = ctx_early
+            .as_ref()
+            .map(|c| c.config.read().data.background_sync_enabled)
+            .unwrap_or(false);
+
+        log::info!(
+            "command-line handler: argv={:?} remote={} setup_required={} bg_sync={} ctx_present={}",
+            argv,
+            secondary_activation,
+            setup_required,
+            bg_sync,
+            ctx_early.is_some(),
+        );
+
         let ctx_lookup = || {
             APP_CONTEXT
                 .get()
@@ -627,6 +641,10 @@ async fn main() {
             .collect();
 
         if !file_args.is_empty() && !setup_required {
+            log::info!(
+                "command-line: opening staging view for {} file(s)",
+                file_args.len()
+            );
             // Files were passed -- open the staging view.
             crate::library::staging_view::build_staging_window(
                 app,
@@ -635,8 +653,14 @@ async fn main() {
                 want_upload,
             );
         } else if want_settings || setup_required {
+            log::info!(
+                "command-line: opening settings (want_settings={} setup_required={})",
+                want_settings,
+                setup_required
+            );
             open_settings_window_now(app, ctx_lookup());
         } else if want_library {
+            log::info!("command-line: opening library (explicit --library flag)");
             open_library_window_now(app, ctx_lookup());
         } else if secondary_activation
             || !ctx_early
@@ -644,7 +668,14 @@ async fn main() {
                 .map(|c| c.config.read().data.background_sync_enabled)
                 .unwrap_or(false)
         {
+            log::info!(
+                "command-line: opening default window (secondary={} bg_sync={})",
+                secondary_activation,
+                bg_sync
+            );
             open_default_window(app, ctx_lookup());
+        } else {
+            log::info!("command-line: background mode, no window opened");
         }
 
         app.activate();

--- a/src/main.rs
+++ b/src/main.rs
@@ -610,20 +610,6 @@ async fn main() {
             .unwrap_or(true);
         let secondary_activation = cmdline.is_remote();
 
-        let bg_sync = ctx_early
-            .as_ref()
-            .map(|c| c.config.read().data.background_sync_enabled)
-            .unwrap_or(false);
-
-        log::info!(
-            "command-line handler: argv={:?} remote={} setup_required={} bg_sync={} ctx_present={}",
-            argv,
-            secondary_activation,
-            setup_required,
-            bg_sync,
-            ctx_early.is_some(),
-        );
-
         let ctx_lookup = || {
             APP_CONTEXT
                 .get()
@@ -641,10 +627,6 @@ async fn main() {
             .collect();
 
         if !file_args.is_empty() && !setup_required {
-            log::info!(
-                "command-line: opening staging view for {} file(s)",
-                file_args.len()
-            );
             // Files were passed -- open the staging view.
             crate::library::staging_view::build_staging_window(
                 app,
@@ -653,14 +635,8 @@ async fn main() {
                 want_upload,
             );
         } else if want_settings || setup_required {
-            log::info!(
-                "command-line: opening settings (want_settings={} setup_required={})",
-                want_settings,
-                setup_required
-            );
             open_settings_window_now(app, ctx_lookup());
         } else if want_library {
-            log::info!("command-line: opening library (explicit --library flag)");
             open_library_window_now(app, ctx_lookup());
         } else if secondary_activation
             || !ctx_early
@@ -668,14 +644,7 @@ async fn main() {
                 .map(|c| c.config.read().data.background_sync_enabled)
                 .unwrap_or(false)
         {
-            log::info!(
-                "command-line: opening default window (secondary={} bg_sync={})",
-                secondary_activation,
-                bg_sync
-            );
             open_default_window(app, ctx_lookup());
-        } else {
-            log::info!("command-line: background mode, no window opened");
         }
 
         app.activate();

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -60,6 +60,23 @@ If you see multiple individual notifications instead of a single updating bar:
 - Some lightweight notification daemons do not support the `x-canonical-private-synchronous` hint, replacement, or progress hints well.
 - **Solution:** Install a full-featured notification daemon like `dunst` (configured appropriately) or use a desktop environment like GNOME or KDE Plasma.
 
+## Startup & Autostart Issues
+
+### App Opens a Window on Login Despite Background Sync (KDE)
+
+If you are using KDE Plasma and the app opens a window every time you log in, even when background sync is enabled, this is likely caused by KDE's session restore feature.
+
+KDE's "Restore previous session" feature re-launches the app independently of the standard autostart mechanism. When it does this, it bypasses the background sync setting and unconditionally opens a window.
+
+**Fix**: Set KDE to start with an empty session instead of restoring the previous one.
+1. Open KDE System Settings
+2. Go to **Session** → **Desktop Session**
+3. Under "On Login", select **Start with an empty session**
+
+### Two Tray Icons Appear (Flatpak on KDE)
+
+If you are running the Flatpak version on KDE and see two tray icons, this is a known interaction between the XDG Background portal, KDE's session restore, and the Flatpak sandbox. Following the fix above (starting with an empty session) will usually resolve the duplicate tray icon as well.
+
 ## Syncing & Upload Issues
 
 ### Files Are Not Syncing


### PR DESCRIPTION
Fixes #201

**Change:**

**Fix autostart disable in Flatpak** -- disabling autostart in settings now calls the Background portal with `auto_start(false)` instead of trying to remove a `.desktop` file that was never created by the portal path.

**Root cause of the original window issue (#196):** KDE's "Restore previous session" feature re-launches the app independently of the autostart mechanism, causing a window to open. Users on KDE should set Desktop Session to "Start with an empty session" to avoid this.